### PR TITLE
Let Makefile.lite build succeed on FreeBSD amd64

### DIFF
--- a/build/config.mk
+++ b/build/config.mk
@@ -53,7 +53,11 @@ ifndef PROC
             F_PIC :=
         endif
     else
-        PROC := $(shell uname -p)
+        ifeq ($(shell uname -p),amd64)
+            PROC := x86_64
+        else
+            PROC := $(shell uname -p)
+        endif
     endif
 endif
 ifeq ($(PROC),powerpc)
@@ -104,6 +108,9 @@ ifeq ($(OS),Linux)
 	ifeq ($(PROC),x86_64)
         CONFIG_CFLAGS += -fPIC
 	endif
+endif
+ifeq ($(OS),FreeBSD)
+    CONFIG_CFLAGS += -DHAVE_SYS_PARAM_H
 endif
 
 ifneq (0,$(USE_ICONV))

--- a/build/exe.mk
+++ b/build/exe.mk
@@ -26,8 +26,13 @@ ifeq ($(OS),Darwin)
     CC          = cc
     CCC         = c++
 else
+ifeq ($(OS),FreeBSD)
+    CC          = cc
+    CCC         = c++
+else
     CC          = gcc
     CCC         = g++
+endif
 endif
 NASM        = nasm
 LINK        = $(CC) $(LINKAGE)

--- a/build/lib.mk
+++ b/build/lib.mk
@@ -26,8 +26,13 @@ ifeq ($(OS),Darwin)
     CC          = cc
     CCC         = c++
 else
+ifeq ($(OS),FreeBSD)
+    CC          = cc
+    CCC         = c++
+else
     CC          = gcc
     CCC         = g++
+endif
 endif
 NASM        = nasm
 LINK        = ar cru

--- a/src/libFLAC++/Makefile.lite
+++ b/src/libFLAC++/Makefile.lite
@@ -36,13 +36,21 @@
 topdir = ../..
 libdir = $(topdir)/objs/$(BUILD)/lib
 
+ifndef OS
+    OS := $(shell uname -s)
+endif
+
 ifeq ($(OS),Darwin)
     EXPLICIT_LIBS = $(libdir)/libFLAC.a $(OGG_EXPLICIT_LIBS) -lm -lstdc++
 else
 ifeq ($(findstring Windows,$(OS)),Windows)
     LIBS = -lFLAC -lwin_utf8_io $(OGG_LIBS) -lm -lsupc++
 else
+ifeq ($(OS),FreeBSD)
+    LIBS = -lFLAC $(OGG_LIBS) -lm -lstdc++
+else
     LIBS = -lFLAC $(OGG_LIBS) -lm -lsupc++
+endif
 endif
 endif
 


### PR DESCRIPTION
- build/config.mk: some OS call x86_64 amd64
- build/config.mk: FreeBSD needs -DHAVE_SYS_PARAM_H in CFLAGS
- build/exe.mk and lib.mk: default compilers on FreeBSD are cc/c++
- src/libFLAC++/Makefile.lite: $(OS) is not defined
- src/libFLAC++/Makefile.lite: Link -lstdc++ on FreeBSD