### PR TITLE
Fix some minor build issues on Darwin/x86_64

### DIFF
--- a/build/config.mk
+++ b/build/config.mk
@@ -63,6 +63,12 @@ endif
 ifeq ($(PROC),powerpc)
     PROC := ppc
 endif
+# x64_64 Mac OS outputs 'i386' in uname -p; use uname -m instead
+ifeq ($(PROC),i386)
+    ifeq ($(OS),Darwin)
+        PROC := $(shell uname -m)
+    endif
+endif
 
 ifeq ($(OS),Linux)
     PROC := $(shell uname -m)
@@ -93,7 +99,7 @@ VERSION=\"1.3.1\"
 CONFIG_CFLAGS=$(CUSTOM_CFLAGS) -DHAVE_STDINT_H -DHAVE_INTTYPES_H -DHAVE_CXX_VARARRAYS -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
 
 ifeq ($(OS),Darwin)
-    CONFIG_CFLAGS += -DFLAC__SYS_DARWIN -arch $(PROC)
+    CONFIG_CFLAGS += -DFLAC__SYS_DARWIN -DHAVE_SYS_PARAM_H -arch $(PROC)
 else
     CONFIG_CFLAGS += -DHAVE_SOCKLEN_T
 endif

--- a/examples/c/decode/file/Makefile.lite
+++ b/examples/c/decode/file/Makefile.lite
@@ -21,6 +21,8 @@
 #
 
 topdir = ../../../..
+
+include $(topdir)/build/config.mk
 libdir = $(topdir)/objs/$(BUILD)/lib
 
 PROGRAM_NAME = example_c_decode_file

--- a/examples/c/encode/file/Makefile.lite
+++ b/examples/c/encode/file/Makefile.lite
@@ -21,6 +21,8 @@
 #
 
 topdir = ../../../..
+
+include $(topdir)/build/config.mk
 libdir = $(topdir)/objs/$(BUILD)/lib
 
 PROGRAM_NAME = example_c_encode_file

--- a/examples/cpp/decode/file/Makefile.lite
+++ b/examples/cpp/decode/file/Makefile.lite
@@ -21,6 +21,8 @@
 #
 
 topdir = ../../../..
+
+include $(topdir)/build/config.mk
 libdir = $(topdir)/objs/$(BUILD)/lib
 
 PROGRAM_NAME = example_cpp_decode_file

--- a/examples/cpp/encode/file/Makefile.lite
+++ b/examples/cpp/encode/file/Makefile.lite
@@ -21,6 +21,8 @@
 #
 
 topdir = ../../../..
+
+include $(topdir)/build/config.mk
 libdir = $(topdir)/objs/$(BUILD)/lib
 
 PROGRAM_NAME = example_cpp_encode_file

--- a/src/flac/Makefile.lite
+++ b/src/flac/Makefile.lite
@@ -21,6 +21,8 @@
 #
 
 topdir = ../..
+
+include $(topdir)/build/config.mk
 libdir = $(topdir)/objs/$(BUILD)/lib
 
 PROGRAM_NAME = flac

--- a/src/libFLAC/cpu.c
+++ b/src/libFLAC/cpu.c
@@ -77,13 +77,9 @@ static void disable_avx(FLAC__CPUInfo *info)
 #include <machine/cpu.h>
 #endif
 
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__DragonFly__) || defined(__APPLE__)
 #include <sys/types.h>
 #include <sys/sysctl.h>
-#endif
-
-#if defined(__APPLE__)
-/* how to get sysctlbyname()? */
 #endif
 
 #ifdef FLAC__CPU_IA32

--- a/src/metaflac/Makefile.lite
+++ b/src/metaflac/Makefile.lite
@@ -21,6 +21,8 @@
 #
 
 topdir = ../..
+
+include $(topdir)/build/config.mk
 libdir = $(topdir)/objs/$(BUILD)/lib
 
 PROGRAM_NAME = metaflac

--- a/src/test_grabbag/cuesheet/Makefile.lite
+++ b/src/test_grabbag/cuesheet/Makefile.lite
@@ -21,6 +21,8 @@
 #
 
 topdir = ../../..
+
+include $(topdir)/build/config.mk
 libdir = $(topdir)/objs/$(BUILD)/lib
 
 PROGRAM_NAME = test_cuesheet

--- a/src/test_grabbag/picture/Makefile.lite
+++ b/src/test_grabbag/picture/Makefile.lite
@@ -21,6 +21,8 @@
 #
 
 topdir = ../../..
+
+include $(topdir)/build/config.mk
 libdir = $(topdir)/objs/$(BUILD)/lib
 
 PROGRAM_NAME = test_picture

--- a/src/test_libFLAC++/Makefile.lite
+++ b/src/test_libFLAC++/Makefile.lite
@@ -21,6 +21,8 @@
 #
 
 topdir = ../..
+
+include $(topdir)/build/config.mk
 libdir = $(topdir)/objs/$(BUILD)/lib
 
 PROGRAM_NAME = test_libFLAC++

--- a/src/test_libFLAC/Makefile.lite
+++ b/src/test_libFLAC/Makefile.lite
@@ -21,6 +21,8 @@
 #
 
 topdir = ../..
+
+include $(topdir)/build/config.mk
 libdir = $(topdir)/objs/$(BUILD)/lib
 
 PROGRAM_NAME = test_libFLAC

--- a/src/test_seeking/Makefile.lite
+++ b/src/test_seeking/Makefile.lite
@@ -21,6 +21,8 @@
 #
 
 topdir = ../..
+
+include $(topdir)/build/config.mk
 libdir = $(topdir)/objs/$(BUILD)/lib
 
 PROGRAM_NAME = test_seeking

--- a/src/test_streams/Makefile.lite
+++ b/src/test_streams/Makefile.lite
@@ -21,6 +21,8 @@
 #
 
 topdir = ../..
+
+include $(topdir)/build/config.mk
 libdir = $(topdir)/objs/$(BUILD)/lib
 
 PROGRAM_NAME = test_streams


### PR DESCRIPTION
Address several points on Darwin / Mac OS:
- Fix open question in cpu.c: Provide proper headers for sysctlbyname() on Darwin
- Include config.mk in Makefile.lite files for binaries and libs to allow accessing variables OS, PROC, etc.
- Allow Makefile.lite to build 64 bit binaries on Darwin/x86_64
