### PR TITLE
Fix description of --rice-partition-order in flac -H

### DIFF
--- a/src/flac/main.c
+++ b/src/flac/main.c
@@ -1613,9 +1613,9 @@ void show_explain(void)
 	printf("                                     encoder decide (the minimun is %u, the\n", FLAC__MIN_QLP_COEFF_PRECISION);
 	printf("                                     default is -q 0)\n");
 	printf("  -r, --rice-partition-order=[#,]#   Set [min,]max residual partition order\n");
-	printf("                                     (# is 0..16; min defaults to 0; the\n");
-	printf("                                     default is -r 0; above 4 doesn't usually\n");
-	printf("                                     help much)\n");
+	printf("                                     (# is 0 to 15 inclusive; min defaults to 0;\n");
+	printf("                                     the default is -r 0; above 4 does not\n");
+	printf("                                     usually help much)\n");
 	printf("format options:\n");
 	printf("      --force-raw-format       Force input (when encoding) or output (when\n");
 	printf("                               decoding) to be treated as raw samples\n");


### PR DESCRIPTION
Closing http://sourceforge.net/p/flac/bugs/352/:
This is more of a "human language versus programmer parlor" issue.
src/flac/main.c will return usage error for an argument greater
than FLAC__MAX_RICE_PARTITION_ORDER (15u).
While in programming "0..16" usually means "from zero to 15", in
natural human-to-human talk, it would rather mean "from zero to 16".
This changes the wording a bit to avoid this misunderstanding.