### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/src/libFLAC/metadata_iterators.c
+++ b/src/libFLAC/metadata_iterators.c
@@ -3243,8 +3243,10 @@ local_snprintf(char *str, size_t size, const char *fmt, ...)
 	va_start (va, fmt);
 
 #if defined _MSC_VER
-	if (size == 0)
+	if (size == 0) {
+	        va_end (va);
 		return 1024;
+        }
 	rc = vsnprintf_s (str, size, _TRUNCATE, fmt, va);
 	if (rc < 0)
 		rc = size - 1;

--- a/src/share/grabbag/snprintf.c
+++ b/src/share/grabbag/snprintf.c
@@ -62,8 +62,10 @@ flac_snprintf(char *str, size_t size, const char *fmt, ...)
 	va_start (va, fmt);
 
 #if defined _MSC_VER
-	if (size == 0)
+	if (size == 0) {
+	        va_end (va);
 		return 1024;
+        }
 	rc = vsnprintf_s (str, size, _TRUNCATE, fmt, va);
 	if (rc < 0)
 		rc = size - 1;

--- a/src/utils/flactimer/main.cpp
+++ b/src/utils/flactimer/main.cpp
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
 		}
 		fout = fopen(argv[1], "w");
 		if(!fout) {
-			fprintf(fout, "ERROR opening file %s for writing\n", argv[1]);
+			fprintf(stderr, "ERROR opening file %s for writing\n", argv[1]);
 			return 1;
 		}
 		argv += 2;


### PR DESCRIPTION
[src/libFLAC/metadata_iterators.c:3247]: (error) va_list 'va' was opened but not closed by va_end().
[src/share/grabbag/snprintf.c:66]: (error) va_list 'va' was opened but not closed by va_end().
[src/utils/flactimer/main.cpp:84] -> [src/utils/flactimer/main.cpp:83]: (warning) Either the condition '!fout' is redundant or there is possible null pointer dereference