### PR TITLE
Unify floating point types in libFLAC

### DIFF
--- a/src/libFLAC/lpc.c
+++ b/src/libFLAC/lpc.c
@@ -53,11 +53,11 @@
 
 #if defined(_MSC_VER) && (_MSC_VER < 1800)
 #include <float.h>
-static inline long int lround(double x) {
+static inline long int lround(FLAC__double x) {
 	return (long)(x + _copysign(0.5, x));
 }
 #elif !defined(HAVE_LROUND) && defined(__GNUC__)
-static inline long int lround(double x) {
+static inline long int lround(FLAC__double x) {
 	return (long)(x + __builtin_copysign(0.5, x));
 }
 /* If this fails, we are in the presence of a mid 90's compiler, move along... */

--- a/src/libFLAC/window.c
+++ b/src/libFLAC/window.c
@@ -1,6 +1,6 @@
 /* libFLAC - Free Lossless Audio Codec library
  * Copyright (C) 2006-2009  Josh Coalson
- * Copyright (C) 2011-2014  Xiph.Org Foundation
+ * Copyright (C) 2011-2016  Xiph.Org Foundation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -93,11 +93,11 @@ void FLAC__window_blackman_harris_4term_92db_sidelobe(FLAC__real *window, const 
 void FLAC__window_connes(FLAC__real *window, const FLAC__int32 L)
 {
 	const FLAC__int32 N = L - 1;
-	const double N2 = (double)N / 2.;
+	const FLAC__double N2 = (FLAC__double)N / 2.;
 	FLAC__int32 n;
 
 	for (n = 0; n <= N; n++) {
-		double k = ((double)n - N2) / N2;
+		FLAC__double k = ((FLAC__double)n - N2) / N2;
 		k = 1.0f - k * k;
 		window[n] = (FLAC__real)(k * k);
 	}
@@ -115,11 +115,11 @@ void FLAC__window_flattop(FLAC__real *window, const FLAC__int32 L)
 void FLAC__window_gauss(FLAC__real *window, const FLAC__int32 L, const FLAC__real stddev)
 {
 	const FLAC__int32 N = L - 1;
-	const double N2 = (double)N / 2.;
+	const FLAC__double N2 = (FLAC__double)N / 2.;
 	FLAC__int32 n;
 
 	for (n = 0; n <= N; n++) {
-		const double k = ((double)n - N2) / (stddev * N2);
+		const FLAC__double k = ((FLAC__double)n - N2) / (stddev * N2);
 		window[n] = (FLAC__real)exp(-0.5f * k * k);
 	}
 }
@@ -270,11 +270,11 @@ void FLAC__window_punchout_tukey(FLAC__real *window, const FLAC__int32 L, const 
 void FLAC__window_welch(FLAC__real *window, const FLAC__int32 L)
 {
 	const FLAC__int32 N = L - 1;
-	const double N2 = (double)N / 2.;
+	const FLAC__double N2 = (FLAC__double)N / 2.;
 	FLAC__int32 n;
 
 	for (n = 0; n <= N; n++) {
-		const double k = ((double)n - N2) / N2;
+		const FLAC__double k = ((FLAC__double)n - N2) / N2;
 		window[n] = (FLAC__real)(1.0f - k * k);
 	}
 }

--- a/src/libFLAC/window.c
+++ b/src/libFLAC/window.c
@@ -50,15 +50,15 @@ void FLAC__window_bartlett(FLAC__real *window, const FLAC__int32 L)
 
 	if (L & 1) {
 		for (n = 0; n <= N/2; n++)
-			window[n] = 2.0f * n / (float)N;
+			window[n] = 2.0f * n / (FLAC__float)N;
 		for (; n <= N; n++)
-			window[n] = 2.0f - 2.0f * n / (float)N;
+			window[n] = 2.0f - 2.0f * n / (FLAC__float)N;
 	}
 	else {
 		for (n = 0; n <= L/2-1; n++)
-			window[n] = 2.0f * n / (float)N;
+			window[n] = 2.0f * n / (FLAC__float)N;
 		for (; n <= N; n++)
-			window[n] = 2.0f - 2.0f * n / (float)N;
+			window[n] = 2.0f - 2.0f * n / (FLAC__float)N;
 	}
 }
 
@@ -68,7 +68,7 @@ void FLAC__window_bartlett_hann(FLAC__real *window, const FLAC__int32 L)
 	FLAC__int32 n;
 
 	for (n = 0; n < L; n++)
-		window[n] = (FLAC__real)(0.62f - 0.48f * fabs((float)n/(float)N-0.5f) - 0.38f * cos(2.0f * M_PI * ((float)n/(float)N)));
+		window[n] = (FLAC__real)(0.62f - 0.48f * fabs((FLAC__float)n/(FLAC__float)N-0.5f) - 0.38f * cos(2.0f * M_PI * ((FLAC__float)n/(FLAC__float)N)));
 }
 
 void FLAC__window_blackman(FLAC__real *window, const FLAC__int32 L)
@@ -174,15 +174,15 @@ void FLAC__window_triangle(FLAC__real *window, const FLAC__int32 L)
 
 	if (L & 1) {
 		for (n = 1; n <= (L+1)/2; n++)
-			window[n-1] = 2.0f * n / ((float)L + 1.0f);
+			window[n-1] = 2.0f * n / ((FLAC__float)L + 1.0f);
 		for (; n <= L; n++)
-			window[n-1] = (float)(2 * (L - n + 1)) / ((float)L + 1.0f);
+			window[n-1] = (FLAC__float)(2 * (L - n + 1)) / ((FLAC__float)L + 1.0f);
 	}
 	else {
 		for (n = 1; n <= L/2; n++)
-			window[n-1] = 2.0f * n / ((float)L + 1.0f);
+			window[n-1] = 2.0f * n / ((FLAC__float)L + 1.0f);
 		for (; n <= L; n++)
-			window[n-1] = (float)(2 * (L - n + 1)) / ((float)L + 1.0f);
+			window[n-1] = (FLAC__float)(2 * (L - n + 1)) / ((FLAC__float)L + 1.0f);
 	}
 }
 


### PR DESCRIPTION
By convention given in src/libFLAC/include/private/float.h, within libFLAC FLAC__{float|double} instead of just {float|double} shall be used. This applies the changes to the few remaining instances that do not respect this convention so far.