### PR TITLE
libFLAC: infer the cpu type from common predefined macros

### DIFF
--- a/src/libFLAC/fixed_intrin_sse2.c
+++ b/src/libFLAC/fixed_intrin_sse2.c
@@ -34,6 +34,8 @@
 #  include <config.h>
 #endif
 
+#include "private/cpu.h"
+
 #ifndef FLAC__INTEGER_ONLY_LIBRARY
 #ifndef FLAC__NO_ASM
 #if (defined FLAC__CPU_IA32 || defined FLAC__CPU_X86_64) && defined FLAC__HAS_X86INTRIN

--- a/src/libFLAC/fixed_intrin_ssse3.c
+++ b/src/libFLAC/fixed_intrin_ssse3.c
@@ -34,6 +34,8 @@
 #  include <config.h>
 #endif
 
+#include "private/cpu.h"
+
 #ifndef FLAC__INTEGER_ONLY_LIBRARY
 #ifndef FLAC__NO_ASM
 #if (defined FLAC__CPU_IA32 || defined FLAC__CPU_X86_64) && defined FLAC__HAS_X86INTRIN

--- a/src/libFLAC/include/private/cpu.h
+++ b/src/libFLAC/include/private/cpu.h
@@ -39,6 +39,23 @@
 #include <config.h>
 #endif
 
+#ifndef FLAC__CPU_X86_64
+
+#if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64)
+#define FLAC__CPU_X86_64
+#endif
+
+#endif
+
+#ifndef FLAC__CPU_IA32
+
+#if defined(__i386__) || defined(__i486__) || defined(__i586__) || defined(__i686__) ||defined( __i386) || defined(_M_IX86)
+#define FLAC__CPU_IA32
+#endif
+
+#endif
+
+
 #if defined FLAC__HAS_X86INTRIN
 /* SSE intrinsics support by ICC/MSVC/GCC */
 #if defined __INTEL_COMPILER

--- a/src/libFLAC/lpc_intrin_avx2.c
+++ b/src/libFLAC/lpc_intrin_avx2.c
@@ -34,6 +34,8 @@
 #  include <config.h>
 #endif
 
+#include "private/cpu.h"
+
 #ifndef FLAC__INTEGER_ONLY_LIBRARY
 #ifndef FLAC__NO_ASM
 #if (defined FLAC__CPU_IA32 || defined FLAC__CPU_X86_64) && defined FLAC__HAS_X86INTRIN

--- a/src/libFLAC/lpc_intrin_sse.c
+++ b/src/libFLAC/lpc_intrin_sse.c
@@ -34,12 +34,13 @@
 #  include <config.h>
 #endif
 
+#include "private/cpu.h"
+
 #ifndef FLAC__INTEGER_ONLY_LIBRARY
 #ifndef FLAC__NO_ASM
 #if (defined FLAC__CPU_IA32 || defined FLAC__CPU_X86_64) && defined FLAC__HAS_X86INTRIN
 #include "private/lpc.h"
 #ifdef FLAC__SSE_SUPPORTED
-
 #include "FLAC/assert.h"
 #include "FLAC/format.h"
 

--- a/src/libFLAC/lpc_intrin_sse2.c
+++ b/src/libFLAC/lpc_intrin_sse2.c
@@ -34,6 +34,8 @@
 #  include <config.h>
 #endif
 
+#include "private/cpu.h"
+
 #ifndef FLAC__INTEGER_ONLY_LIBRARY
 #ifndef FLAC__NO_ASM
 #if (defined FLAC__CPU_IA32 || defined FLAC__CPU_X86_64) && defined FLAC__HAS_X86INTRIN

--- a/src/libFLAC/lpc_intrin_sse41.c
+++ b/src/libFLAC/lpc_intrin_sse41.c
@@ -34,6 +34,8 @@
 #  include <config.h>
 #endif
 
+#include "private/cpu.h"
+
 #ifndef FLAC__INTEGER_ONLY_LIBRARY
 #ifndef FLAC__NO_ASM
 #if (defined FLAC__CPU_IA32 || defined FLAC__CPU_X86_64) && defined FLAC__HAS_X86INTRIN

--- a/src/libFLAC/stream_encoder_intrin_avx2.c
+++ b/src/libFLAC/stream_encoder_intrin_avx2.c
@@ -34,6 +34,8 @@
 #  include <config.h>
 #endif
 
+#include "private/cpu.h"
+
 #ifndef FLAC__NO_ASM
 #if (defined FLAC__CPU_IA32 || defined FLAC__CPU_X86_64) && defined FLAC__HAS_X86INTRIN
 #include "private/stream_encoder.h"

--- a/src/libFLAC/stream_encoder_intrin_sse2.c
+++ b/src/libFLAC/stream_encoder_intrin_sse2.c
@@ -34,6 +34,8 @@
 #  include <config.h>
 #endif
 
+#include "private/cpu.h"
+
 #ifndef FLAC__NO_ASM
 #if (defined FLAC__CPU_IA32 || defined FLAC__CPU_X86_64) && defined FLAC__HAS_X86INTRIN
 #include "private/stream_encoder.h"

--- a/src/libFLAC/stream_encoder_intrin_ssse3.c
+++ b/src/libFLAC/stream_encoder_intrin_ssse3.c
@@ -34,6 +34,8 @@
 #  include <config.h>
 #endif
 
+#include "private/cpu.h"
+
 #ifndef FLAC__NO_ASM
 #if (defined FLAC__CPU_IA32 || defined FLAC__CPU_X86_64) && defined FLAC__HAS_X86INTRIN
 #include "private/stream_encoder.h"


### PR DESCRIPTION
adapted from https://sourceforge.net/p/predef/wiki/Architectures/

--

this simplifies building universal binaries on osx