### PR TITLE
stream_decoder: fix integer underflow due to malformed wasted_bits

### DIFF
--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -2481,6 +2481,8 @@ FLAC__bool read_subframe_(FLAC__StreamDecoder *decoder, unsigned channel, unsign
 		if(!FLAC__bitreader_read_unary_unsigned(decoder->private_->input, &u))
 			return false; /* read_callback_ sets the state for us */
 		decoder->private_->frame.subframes[channel].wasted_bits = u+1;
+		if (decoder->private_->frame.subframes[channel].wasted_bits >= bps)
+			return false;
 		bps -= decoder->private_->frame.subframes[channel].wasted_bits;
 	}
 	else


### PR DESCRIPTION
It is pretty easy for a malformed FLAC file to underflow the "bps"
variable.  In the debug build, this results in an assertion failure in
FLAC__bitreader_read_raw_uint32():

    FLAC__ASSERT(bits <= 32);

In non-debug builds, this simply makes
FLAC__bitreader_read_raw_uint32() fail because
bitreader_read_from_client_() doesn't find enough buffer space for
2**32-1 bits.  But since the failing FLAC_ASSERT() is reasonable, this
should be caught in the FLAC__bitreader_read_raw_uint32() caller.

Demo file: http://max.kellermann.name/download/mpd/flac/afl/integer_underflow.flac (bug found with AFL)