### PR TITLE
Correct flattop window coefficients, normalising window amplitude to 1

### DIFF
--- a/src/libFLAC/window.c
+++ b/src/libFLAC/window.c
@@ -109,7 +109,7 @@ void FLAC__window_flattop(FLAC__real *window, const FLAC__int32 L)
 	FLAC__int32 n;
 
 	for (n = 0; n < L; n++)
-		window[n] = (FLAC__real)(1.0f - 1.93f * cos(2.0f * M_PI * n / N) + 1.29f * cos(4.0f * M_PI * n / N) - 0.388f * cos(6.0f * M_PI * n / N) + 0.0322f * cos(8.0f * M_PI * n / N));
+		window[n] = (FLAC__real)(0.21557895f - 0.41663158f * cos(2.0f * M_PI * n / N) + 0.277263158f * cos(4.0f * M_PI * n / N) - 0.083578947f * cos(6.0f * M_PI * n / N) + 0.006947368f * cos(8.0f * M_PI * n / N));
 }
 
 void FLAC__window_gauss(FLAC__real *window, const FLAC__int32 L, const FLAC__real stddev)


### PR DESCRIPTION
The flattop window is generated based on the coefficients as described in https://octave.sourceforge.io/signal/function/flattopwin.html, but normalisation is not performed. This results in an amplitude of more than 4.6 at the center of the window. Using the normalised coefficients as given in https://au.mathworks.com/help/signal/ref/flattopwin.html?s_tid=gn_loc_drop, the window is properly normalised with and amplitude of 1.0 at the center.

(All the other windows are already correctly normalised to a maximum amplitude of 1.0 at the highest point(s).)