### PR TITLE
Proposal: Change apodization parameters for built-in compression levels 7 and 8

### DIFF
--- a/man/flac.1
+++ b/man/flac.1
@@ -264,10 +264,10 @@ Synonymous with -l 8 -b 4096 -m -r 5
 Synonymous with -l 8 -b 4096 -m -r 6 -A tukey(0.5) -A partial_tukey(2)
 .TP
 \fB-7, --compression-level-7\fR
-Synonymous with -l 12 -b 4096 -m -r 6 -A tukey(0.5) -A partial_tukey(2)
+Synonymous with -l 12 -b 4096 -m -r 6 -A tukey(0.5) -A partial_tukey(2) -A punchout_tukey(3)
 .TP
 \fB-8, --compression-level-8\fR
-Synonymous with -l 12 -b 4096 -m -r 6 -A tukey(0.5) -A partial_tukey(2) -A punchout_tukey(3)
+Synonymous with -l 12 -b 4096 -m -r 6 -A tukey(0.25) -A tukey(0.5) -A partial_tukey(6) -A punchout_tukey(6)
 .RE
 .TP
 \fB--fast\fR

--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -1,6 +1,6 @@
 /* libFLAC - Free Lossless Audio Codec library
  * Copyright (C) 2000-2009  Josh Coalson
- * Copyright (C) 2011-2016  Xiph.Org Foundation
+ * Copyright (C) 2011-2017  Xiph.Org Foundation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -119,8 +119,8 @@ static const  struct CompressionLevels {
 	{ true , true ,  8, 0, false, false, false, 0, 4, 0, "tukey(5e-1)" },
 	{ true , false,  8, 0, false, false, false, 0, 5, 0, "tukey(5e-1)" },
 	{ true , false,  8, 0, false, false, false, 0, 6, 0, "tukey(5e-1);partial_tukey(2)" },
-	{ true , false, 12, 0, false, false, false, 0, 6, 0, "tukey(5e-1);partial_tukey(2)" },
-	{ true , false, 12, 0, false, false, false, 0, 6, 0, "tukey(5e-1);partial_tukey(2);punchout_tukey(3)" }
+	{ true , false, 12, 0, false, false, false, 0, 6, 0, "tukey(5e-1);partial_tukey(2);punchout_tukey(3)" },
+	{ true , false, 12, 0, false, false, false, 0, 6, 0, "tukey(25e-2);tukey(5e-1);partial_tukey(6);punchout_tukey(6)" }
 	/* here we use locale-independent 5e-1 instead of 0.5 or 0,5 */
 };
 


### PR DESCRIPTION
I spend some time throwing various content at the encoder with lots of apodization settings and captured how often a particular apodization function resulted in the best encoding.
Long story short: The previous level-8 apodization settings are the best choice in about 75% of all frames.

Due to the fact that even single thread performance of CPUs has improved a bit since the compression levels have been changed last, I propose the new levels given in this patch. 
Rationale:
The proposed apodization settings for level 8 are the best choice in about 80% of all frames in my tests. 80% is a reasonable Pareto based approach. The encoder slowdown for adding those apodizations is very small and likely not an issue for most users, given the current CPUs.

Details:
- Use the apodization parameters previously used for level 8 now in level 7
- Update the level 8 apodization parameters to yield slightly better
  compression
- Update manpage accordingly