### PR TITLE
libFLAC : new function returns client_data from decoder

### DIFF
--- a/src/libFLAC/include/protected/stream_decoder.h
+++ b/src/libFLAC/include/protected/stream_decoder.h
@@ -57,4 +57,9 @@ typedef struct FLAC__StreamDecoderProtected {
  */
 uint32_t FLAC__stream_decoder_get_input_bytes_unconsumed(const FLAC__StreamDecoder *decoder);
 
+/*
+ * return client_data from decoder
+ */
+FLAC_API void *get_client_data_from_decoder(FLAC__StreamDecoder *decoder);
+
 #endif

--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -3395,3 +3395,7 @@ FLAC__bool file_eof_callback_(const FLAC__StreamDecoder *decoder, void *client_d
 
 	return feof(decoder->private_->file)? true : false;
 }
+
+void *get_client_data_from_decoder(FLAC__StreamDecoder *decoder) {
+	return decoder->private_->client_data;
+}


### PR DESCRIPTION
Hello,

As developer, i'm actually writing java interface to use libFLAC with JNA, to reproduce "flac -t" function, needed to validate/unvalidate flac files before sending them in our preservation system.

The most part of implementation with JNA is working fine. Callback are called, and client_data parameter is a smart way to keep custom datas.
My problem is : when error_callback is called, we update client_data to add error status, but client_data reference (java side) is never updated while native code of libFlac receive an updated client_data from callback call.
Use a class variable is working fine, but it's not a safe way to solve our problem in thread context.

The only thing is missing to us, is a function to return client_data from decoder in libFLAC. With this simple function, we can get our client_data, with error status and cause stored in out client_data structure.

If this modification could be added into libFLAC, it should help other JNA implementers, and avoid a patch-task for new libFLAC releases.

Thanks for you attention and for the great work !
Best regards,

Christophe Dumont

