### PR TITLE
Solved libtool issue (debian-based)

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -24,7 +24,7 @@ test_program () {
 		fi
 }
 
-for prog in autoconf automake libtool pkg-config ; do
+for prog in autoconf automake libtoolize pkg-config ; do
 	test_program $prog
 	done
 


### PR DESCRIPTION
The 'libtool' is not a program name, it is package name in Debian-based distros. The fronted program is named 'libtoolize'. To avoid strange behaviour, the name in utility tester function was fixed.