### PR TITLE
replaygain_synthesis.c: Fix compile issue in MSVS

### DIFF
--- a/src/share/replaygain_synthesis/replaygain_synthesis.c
+++ b/src/share/replaygain_synthesis/replaygain_synthesis.c
@@ -41,6 +41,7 @@
 
 #include <string.h> /* for memset() */
 #include <math.h>
+#include "share/compat.h"
 #include "share/replaygain_synthesis.h"
 #include "FLAC/assert.h"
 


### PR DESCRIPTION
The `inline` keyword is only available in C++ so include `share/compat.h`.

See relevant changes from previous commit: 20a2100d7d7e304f2f332e1a8adafe1b43988d61