### PR TITLE
Add unit tests for CRC and BitReader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,32 @@
 language: c
-compiler:
-  - gcc
-  - clang
-os:
-  - linux
-  - osx
+matrix:
+    include:
+        - os: linux
+          compiler: gcc
+
+        - os: linux
+          compiler: clang
+
+        - os: osx
+          compiler: gcc
+
+        - os: osx
+          compiler: clang
+
+        - os: linux
+          compiler: gcc
+          env: CONFIGURE_OPTS=--enable-64-bit-words
+
+        - os: linux
+          compiler: clang
+          env: CONFIGURE_OPTS=--enable-64-bit-words
+
+        - os: osx
+          compiler: gcc
+          env: CONFIGURE_OPTS=--enable-64-bit-words
+
+        - os: osx
+          compiler: clang
+          env: CONFIGURE_OPTS=--enable-64-bit-words
 script:
-  - ./autogen.sh && ./configure && make && make check
-  - make clean && ./configure --enable-64-bit-words && make && make check
+  - ./autogen.sh && ./configure $CONFIGURE_OPTS && make && make check

--- a/src/libFLAC/crc.c
+++ b/src/libFLAC/crc.c
@@ -1,6 +1,6 @@
 /* libFLAC - Free Lossless Audio Codec library
  * Copyright (C) 2000-2009  Josh Coalson
- * Copyright (C) 2011-2016  Xiph.Org Foundation
+ * Copyright (C) 2011-2018  Xiph.Org Foundation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,7 +38,7 @@
 
 /* CRC-8, poly = x^8 + x^2 + x^1 + x^0, init = 0 */
 
-FLAC__byte const FLAC__crc8_table[256] = {
+FLAC__uint8 const FLAC__crc8_table[256] = {
 	0x00, 0x07, 0x0E, 0x09, 0x1C, 0x1B, 0x12, 0x15,
 	0x38, 0x3F, 0x36, 0x31, 0x24, 0x23, 0x2A, 0x2D,
 	0x70, 0x77, 0x7E, 0x79, 0x6C, 0x6B, 0x62, 0x65,
@@ -110,17 +110,6 @@ uint32_t const FLAC__crc16_table[256] = {
 	0x8213,  0x0216,  0x021c,  0x8219,  0x0208,  0x820d,  0x8207,  0x0202
 };
 
-
-void FLAC__crc8_update(const FLAC__byte data, FLAC__uint8 *crc)
-{
-	*crc = FLAC__crc8_table[*crc ^ data];
-}
-
-void FLAC__crc8_update_block(const FLAC__byte *data, uint32_t len, FLAC__uint8 *crc)
-{
-	while(len--)
-		*crc = FLAC__crc8_table[*crc ^ *data++];
-}
 
 FLAC__uint8 FLAC__crc8(const FLAC__byte *data, uint32_t len)
 {

--- a/src/libFLAC/include/private/crc.h
+++ b/src/libFLAC/include/private/crc.h
@@ -1,6 +1,6 @@
 /* libFLAC - Free Lossless Audio Codec library
  * Copyright (C) 2000-2009  Josh Coalson
- * Copyright (C) 2011-2016  Xiph.Org Foundation
+ * Copyright (C) 2011-2018  Xiph.Org Foundation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,10 +39,6 @@
 ** polynomial = x^8 + x^2 + x^1 + x^0
 ** init = 0
 */
-extern FLAC__byte const FLAC__crc8_table[256];
-#define FLAC__CRC8_UPDATE(data, crc) (crc) = FLAC__crc8_table[(crc) ^ (data)];
-void FLAC__crc8_update(const FLAC__byte data, FLAC__uint8 *crc);
-void FLAC__crc8_update_block(const FLAC__byte *data, uint32_t len, FLAC__uint8 *crc);
 FLAC__uint8 FLAC__crc8(const FLAC__byte *data, uint32_t len);
 
 /* 16 bit CRC generator, MSB shifted first

--- a/src/test_libFLAC/Makefile.am
+++ b/src/test_libFLAC/Makefile.am
@@ -1,6 +1,6 @@
 #  test_libFLAC - Unit tester for libFLAC
 #  Copyright (C) 2000-2009  Josh Coalson
-#  Copyright (C) 2011-2016  Xiph.Org Foundation
+#  Copyright (C) 2011-2018  Xiph.Org Foundation
 #
 #  This program is free software; you can redistribute it and/or
 #  modify it under the terms of the GNU General Public License
@@ -36,6 +36,7 @@ test_libFLAC_LDADD = \
 
 test_libFLAC_SOURCES = \
 	bitwriter.c \
+	crc.c \
 	decoders.c \
 	encoders.c \
 	endswap.c \
@@ -46,6 +47,7 @@ test_libFLAC_SOURCES = \
 	metadata_object.c \
 	md5.c \
 	bitwriter.h \
+	crc.h \
 	decoders.h \
 	encoders.h \
 	endswap.h \

--- a/src/test_libFLAC/Makefile.am
+++ b/src/test_libFLAC/Makefile.am
@@ -35,6 +35,7 @@ test_libFLAC_LDADD = \
 	-lm
 
 test_libFLAC_SOURCES = \
+	bitreader.c \
 	bitwriter.c \
 	crc.c \
 	decoders.c \
@@ -46,6 +47,7 @@ test_libFLAC_SOURCES = \
 	metadata_manip.c \
 	metadata_object.c \
 	md5.c \
+	bitreader.h \
 	bitwriter.h \
 	crc.h \
 	decoders.h \

--- a/src/test_libFLAC/Makefile.lite
+++ b/src/test_libFLAC/Makefile.lite
@@ -36,6 +36,7 @@ else
 endif
 
 SRCS_C = \
+	bitreader.c \
 	bitwriter.c \
 	crc.c \
 	decoders.c \

--- a/src/test_libFLAC/Makefile.lite
+++ b/src/test_libFLAC/Makefile.lite
@@ -1,6 +1,6 @@
 #  test_libFLAC - Unit tester for libFLAC
 #  Copyright (C) 2000-2009  Josh Coalson
-#  Copyright (C) 2011-2016  Xiph.Org Foundation
+#  Copyright (C) 2011-2018  Xiph.Org Foundation
 #
 #  This program is free software; you can redistribute it and/or
 #  modify it under the terms of the GNU General Public License
@@ -37,6 +37,7 @@ endif
 
 SRCS_C = \
 	bitwriter.c \
+	crc.c \
 	decoders.c \
 	encoders.c \
 	endswap.c \

--- a/src/test_libFLAC/bitreader.c
+++ b/src/test_libFLAC/bitreader.c
@@ -1,0 +1,321 @@
+/* test_libFLAC - Unit tester for libFLAC
+ * Copyright (C) 2000-2009  Josh Coalson
+ * Copyright (C) 2011-2018  Xiph.Org Foundation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif
+
+#include "FLAC/assert.h"
+#include "share/compat.h"
+#include "private/bitreader.h" /* from the libFLAC private include area */
+#include "bitreader.h"
+#include <stdio.h>
+#include <string.h> /* for memcpy() */
+
+/*
+ * WATCHOUT!  Since FLAC__BitReader is a private structure, we use a copy of
+ * the definition here to get at the internals.  Make sure this is kept up
+ * to date with what is in ../libFLAC/bitreader.c
+ */
+#if (ENABLE_64_BIT_WORDS == 0)
+
+typedef FLAC__uint32 brword;
+#define FLAC__BYTES_PER_WORD 4
+#define FLAC__BITS_PER_WORD 32
+
+#else
+
+typedef FLAC__uint64 brword;
+#define FLAC__BYTES_PER_WORD 8
+#define FLAC__BITS_PER_WORD 64
+
+#endif
+
+struct FLAC__BitReader {
+	/* any partially-consumed word at the head will stay right-justified as bits are consumed from the left */
+	/* any incomplete word at the tail will be left-justified, and bytes from the read callback are added on the right */
+	brword *buffer;
+	uint32_t capacity; /* in words */
+	uint32_t words; /* # of completed words in buffer */
+	uint32_t bytes; /* # of bytes in incomplete word at buffer[words] */
+	uint32_t consumed_words; /* #words ... */
+	uint32_t consumed_bits; /* ... + (#bits of head word) already consumed from the front of buffer */
+	uint32_t read_crc16; /* the running frame CRC */
+	uint32_t crc16_align; /* the number of bits in the current consumed word that should not be CRC'd */
+	FLAC__BitReaderReadCallback read_callback;
+	void *client_data;
+};
+
+static FLAC__bool read_callback(FLAC__byte buffer[], size_t *bytes, void *data);
+
+FLAC__bool test_bitreader(void)
+{
+	FLAC__BitReader *br;
+	FLAC__bool ok;
+	uint32_t i;
+	uint32_t words, bits; /* what we think br->consumed_words and br->consumed_bits should be */
+
+	FLAC__uint16	 crc,expected_crcs[4] = { 0x5e4c, 0x7f6b, 0x2272, 0x42bf };
+	FLAC__byte	 data[32];
+
+	FLAC__uint32	 val_uint32;
+	FLAC__uint64	 val_uint64;
+
+	for (i = 0; i < 32; i++)
+		data[i] = i * 8 + 7;
+
+	printf("\n+++ libFLAC unit test: bitreader\n\n");
+
+	/*
+	 * test new -> delete
+	 */
+	printf("testing new... ");
+	br = FLAC__bitreader_new();
+	if(0 == br) {
+		printf("FAILED, returned NULL\n");
+		return false;
+	}
+	printf("OK\n");
+
+	printf("testing delete... ");
+	FLAC__bitreader_delete(br);
+	printf("OK\n");
+
+	/*
+	 * test new -> init -> delete
+	 */
+	printf("testing new... ");
+	br = FLAC__bitreader_new();
+	if(0 == br) {
+		printf("FAILED, returned NULL\n");
+		return false;
+	}
+	printf("OK\n");
+
+	printf("testing init... ");
+	if(!FLAC__bitreader_init(br, read_callback, data)) {
+		printf("FAILED, returned false\n");
+		return false;
+	}
+	printf("OK\n");
+
+	printf("testing delete... ");
+	FLAC__bitreader_delete(br);
+	printf("OK\n");
+
+	/*
+	 * test new -> init -> clear -> delete
+	 */
+	printf("testing new... ");
+	br = FLAC__bitreader_new();
+	if(0 == br) {
+		printf("FAILED, returned NULL\n");
+		return false;
+	}
+	printf("OK\n");
+
+	printf("testing init... ");
+	if(!FLAC__bitreader_init(br, read_callback, data)) {
+		printf("FAILED, returned false\n");
+		return false;
+	}
+	printf("OK\n");
+
+	printf("testing clear... ");
+	if(!FLAC__bitreader_clear(br)) {
+		printf("FAILED, returned false\n");
+		return false;
+	}
+	printf("OK\n");
+
+	printf("testing delete... ");
+	FLAC__bitreader_delete(br);
+	printf("OK\n");
+
+	/*
+	 * test normal usage
+	 */
+	printf("testing new... ");
+	br = FLAC__bitreader_new();
+	if(0 == br) {
+		printf("FAILED, returned NULL\n");
+		return false;
+	}
+	printf("OK\n");
+
+	printf("testing init... ");
+	if(!FLAC__bitreader_init(br, read_callback, data)) {
+		printf("FAILED, returned false\n");
+		return false;
+	}
+	printf("OK\n");
+
+	printf("testing clear... ");
+	if(!FLAC__bitreader_clear(br)) {
+		printf("FAILED, returned false\n");
+		return false;
+	}
+	printf("OK\n");
+
+	words = bits = 0;
+
+	printf("capacity = %u\n", br->capacity);
+
+	printf("testing raw reads... ");
+	ok =
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 1) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 2) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 5) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 8) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 10) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 4) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 32) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 4) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 2) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 8) &&
+		FLAC__bitreader_read_raw_uint64(br, &val_uint64, 64) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 12)
+	;
+	if(!ok) {
+		printf("FAILED\n");
+		FLAC__bitreader_dump(br, stdout);
+		return false;
+	}
+	/* we read 152 bits (=19 bytes) from the bitreader */
+	words = 152 / FLAC__BITS_PER_WORD;
+	bits = 152 - words*FLAC__BITS_PER_WORD;
+
+	if(br->consumed_words != words) {
+		printf("FAILED word count %u != %u\n", br->consumed_words, words);
+		FLAC__bitreader_dump(br, stdout);
+		return false;
+	}
+	if(br->consumed_bits != bits) {
+		printf("FAILED bit count %u != %u\n", br->consumed_bits, bits);
+		FLAC__bitreader_dump(br, stdout);
+		return false;
+	}
+	crc = FLAC__bitreader_get_read_crc16(br);
+	if(crc != expected_crcs[0]) {
+		printf("FAILED reported CRC 0x%04x does not match expected 0x%04x\n", crc, expected_crcs[0]);
+		FLAC__bitreader_dump(br, stdout);
+		return false;
+	}
+	printf("OK\n");
+	FLAC__bitreader_dump(br, stdout);
+
+	printf("testing CRC reset... ");
+	FLAC__bitreader_clear(br);
+	FLAC__bitreader_reset_read_crc16(br, 0xFFFF);
+	crc = FLAC__bitreader_get_read_crc16(br);
+	if(crc != 0xFFFF) {
+		printf("FAILED reported CRC 0x%04x does not match expected 0xFFFF\n", crc);
+		FLAC__bitreader_dump(br, stdout);
+		return false;
+	}
+	FLAC__bitreader_reset_read_crc16(br, 0);
+	crc = FLAC__bitreader_get_read_crc16(br);
+	if(crc != 0) {
+		printf("FAILED reported CRC 0x%04x does not match expected 0x0000\n", crc);
+		FLAC__bitreader_dump(br, stdout);
+		return false;
+	}
+	FLAC__bitreader_read_raw_uint32(br, &val_uint32, 16);
+	FLAC__bitreader_reset_read_crc16(br, 0);
+	FLAC__bitreader_read_raw_uint32(br, &val_uint32, 32);
+	crc = FLAC__bitreader_get_read_crc16(br);
+	if(crc != expected_crcs[1]) {
+		printf("FAILED reported CRC 0x%04x does not match expected 0x%04x\n", crc, expected_crcs[1]);
+		FLAC__bitreader_dump(br, stdout);
+		return false;
+	}
+	printf("OK\n");
+
+	printf("testing unaligned < 32 bit reads... ");
+	FLAC__bitreader_clear(br);
+	FLAC__bitreader_skip_bits_no_crc(br, 8);
+	FLAC__bitreader_reset_read_crc16(br, 0);
+	ok =
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 1) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 2) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 5) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 8)
+	;
+	if(!ok) {
+		printf("FAILED\n");
+		FLAC__bitreader_dump(br, stdout);
+		return false;
+	}
+	crc = FLAC__bitreader_get_read_crc16(br);
+	if(crc != expected_crcs[2]) {
+		printf("FAILED reported CRC 0x%04x does not match expected 0x%04x\n", crc, expected_crcs[2]);
+		FLAC__bitreader_dump(br, stdout);
+		return false;
+	}
+	printf("OK\n");
+	FLAC__bitreader_dump(br, stdout);
+
+	printf("testing unaligned < 64 bit reads... ");
+	FLAC__bitreader_clear(br);
+	FLAC__bitreader_skip_bits_no_crc(br, 8);
+	FLAC__bitreader_reset_read_crc16(br, 0);
+	ok =
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 1) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 2) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 5) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 8) &&
+		FLAC__bitreader_read_raw_uint32(br, &val_uint32, 32)
+	;
+	if(!ok) {
+		printf("FAILED\n");
+		FLAC__bitreader_dump(br, stdout);
+		return false;
+	}
+	crc = FLAC__bitreader_get_read_crc16(br);
+	if(crc != expected_crcs[3]) {
+		printf("FAILED reported CRC 0x%04x does not match expected 0x%04x\n", crc, expected_crcs[3]);
+		FLAC__bitreader_dump(br, stdout);
+		return false;
+	}
+	printf("OK\n");
+	FLAC__bitreader_dump(br, stdout);
+
+	printf("testing free... ");
+	FLAC__bitreader_free(br);
+	printf("OK\n");
+
+	printf("testing delete... ");
+	FLAC__bitreader_delete(br);
+	printf("OK\n");
+
+	printf("\nPASSED!\n");
+	return true;
+}
+
+/*----------------------------------------------------------------------------*/
+
+static FLAC__bool read_callback(FLAC__byte buffer[], size_t *bytes, void *data)
+{
+	if (*bytes > 32)
+		*bytes = 32;
+
+	memcpy(buffer, data, *bytes);
+
+	return true;
+}

--- a/src/test_libFLAC/bitreader.h
+++ b/src/test_libFLAC/bitreader.h
@@ -17,48 +17,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
+#ifndef FLAC__TEST_LIBFLAC_BITREADER_H
+#define FLAC__TEST_LIBFLAC_BITREADER_H
+
+#include "FLAC/ordinals.h"
+
+FLAC__bool test_bitreader(void);
+
 #endif
-
-#include "bitreader.h"
-#include "bitwriter.h"
-#include "crc.h"
-#include "decoders.h"
-#include "encoders.h"
-#include "endswap.h"
-#include "format.h"
-#include "metadata.h"
-#include "md5.h"
-
-int main(void)
-{
-	if(!test_endswap())
-		return 1;
-
-	if(!test_crc())
-		return 1;
-
-	if(!test_md5())
-		return 1;
-
-	if(!test_bitreader())
-		return 1;
-
-	if(!test_bitwriter())
-		return 1;
-
-	if(!test_format())
-		return 1;
-
-	if(!test_encoders())
-		return 1;
-
-	if(!test_decoders())
-		return 1;
-
-	if(!test_metadata())
-		return 1;
-
-	return 0;
-}

--- a/src/test_libFLAC/bitwriter.c
+++ b/src/test_libFLAC/bitwriter.c
@@ -1,6 +1,6 @@
 /* test_libFLAC - Unit tester for libFLAC
  * Copyright (C) 2000-2009  Josh Coalson
- * Copyright (C) 2011-2016  Xiph.Org Foundation
+ * Copyright (C) 2011-2018  Xiph.Org Foundation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -112,9 +112,8 @@ FLAC__bool test_bitwriter(void)
 	printf("OK\n");
 
 	printf("testing init... ");
-	FLAC__bitwriter_init(bw);
-	if(0 == bw) {
-		printf("FAILED, returned NULL\n");
+	if(!FLAC__bitwriter_init(bw)) {
+		printf("FAILED, returned false\n");
 		return false;
 	}
 	printf("OK\n");
@@ -135,19 +134,14 @@ FLAC__bool test_bitwriter(void)
 	printf("OK\n");
 
 	printf("testing init... ");
-	FLAC__bitwriter_init(bw);
-	if(0 == bw) {
-		printf("FAILED, returned NULL\n");
+	if(!FLAC__bitwriter_init(bw)) {
+		printf("FAILED, returned false\n");
 		return false;
 	}
 	printf("OK\n");
 
 	printf("testing clear... ");
 	FLAC__bitwriter_clear(bw);
-	if(0 == bw) {
-		printf("FAILED, returned NULL\n");
-		return false;
-	}
 	printf("OK\n");
 
 	printf("testing delete... ");
@@ -166,10 +160,11 @@ FLAC__bool test_bitwriter(void)
 	printf("OK\n");
 
 	printf("testing init... ");
-	ok = FLAC__bitwriter_init(bw);
-	printf("%s\n", ok?"OK":"FAILED");
-	if(!ok)
+	if(!FLAC__bitwriter_init(bw)) {
+		printf("FAILED, returned false\n");
 		return false;
+	}
+	printf("OK\n");
 
 	printf("testing clear... ");
 	FLAC__bitwriter_clear(bw);
@@ -204,7 +199,7 @@ FLAC__bool test_bitwriter(void)
 	bits = 152 - words*FLAC__BITS_PER_WORD;
 
 	if(bw->words != words) {
-		printf("FAILED byte count %u != %u\n", bw->words, words);
+		printf("FAILED word count %u != %u\n", bw->words, words);
 		FLAC__bitwriter_dump(bw, stdout);
 		return false;
 	}
@@ -237,7 +232,7 @@ FLAC__bool test_bitwriter(void)
 	test_pattern1[words] <<= 6;
 	test_pattern1[words] |= 0x3d;
 	if(bw->words != words) {
-		printf("FAILED byte count %u != %u\n", bw->words, words);
+		printf("FAILED word count %u != %u\n", bw->words, words);
 		FLAC__bitwriter_dump(bw, stdout);
 		return false;
 	}

--- a/src/test_libFLAC/crc.c
+++ b/src/test_libFLAC/crc.c
@@ -1,0 +1,182 @@
+/* test_libFLAC - Unit tester for libFLAC
+ * Copyright (C) 2014-2018  Xiph.Org Foundation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif
+
+#include <stdio.h>
+
+#include "FLAC/assert.h"
+#include "share/compat.h"
+#include "private/crc.h"
+#include "crc.h"
+
+static FLAC__uint8 crc8_update_ref(FLAC__byte byte, FLAC__uint8 crc);
+static FLAC__uint16 crc16_update_ref(FLAC__byte byte, FLAC__uint16 crc);
+
+static FLAC__bool test_crc8(const FLAC__byte *data, size_t size);
+static FLAC__bool test_crc16(const FLAC__byte *data, size_t size);
+static FLAC__bool test_crc16_update(const FLAC__byte *data, size_t size);
+
+#define DATA_SIZE 32768
+
+FLAC__bool test_crc(void)
+{
+	uint32_t i;
+	FLAC__byte data[DATA_SIZE] = { 0 };
+
+	/* Initialize data reproducibly with pseudo-random values. */
+	for (i = 1; i < DATA_SIZE; i++)
+		data[i] = crc8_update_ref(i % 256, data[i - 1]);
+
+	printf("\n+++ libFLAC unit test: crc\n\n");
+
+	if (! test_crc8(data, DATA_SIZE))
+		return false;
+
+	if (! test_crc16(data, DATA_SIZE))
+		return false;
+
+	if (! test_crc16_update(data, DATA_SIZE))
+		return false;
+
+	printf("\nPASSED!\n");
+	return true;
+}
+
+/*----------------------------------------------------------------------------*/
+
+/* Reference implementations of CRC-8 and CRC-16 to check against. */
+
+#define CRC8_POLYNOMIAL 0x07
+
+static FLAC__uint8 crc8_update_ref(FLAC__byte byte, FLAC__uint8 crc)
+{
+    uint32_t i;
+
+    crc ^= byte;
+
+    for (i = 0; i < 8; i++) {
+        crc = (crc << 1) ^ ((crc >> 7) ? CRC8_POLYNOMIAL : 0);
+    }
+
+    return crc;
+}
+
+#define CRC16_POLYNOMIAL 0x8005
+
+static FLAC__uint16 crc16_update_ref(FLAC__byte byte, FLAC__uint16 crc)
+{
+    uint32_t i;
+
+    crc ^= byte << 8;
+
+    for (i = 0; i < 8; i++) {
+        crc = (crc << 1) ^ ((crc >> 15) ? CRC16_POLYNOMIAL : 0);
+    }
+
+    return crc;
+}
+
+/*----------------------------------------------------------------------------*/
+
+static FLAC__bool test_crc8(const FLAC__byte *data, size_t size)
+{
+	uint32_t i;
+	FLAC__uint8 crc0,crc1;
+
+	printf("testing FLAC__crc8 ... ");
+
+	crc0 = 0;
+	crc1 = FLAC__crc8(data, 0);
+
+	if (crc1 != crc0) {
+		printf("FAILED, FLAC__crc8 returned non-zero CRC for zero bytes of data\n");
+		return false;
+	}
+
+	for (i = 0; i < size; i++) {
+		crc0 = crc8_update_ref(data[i], crc0);
+		crc1 = FLAC__crc8(data, i + 1);
+
+		if (crc1 != crc0) {
+			printf("FAILED, FLAC__crc8 result did not match reference CRC for %i bytes of test data\n", i + 1);
+			return false;
+		}
+	}
+
+	printf("OK\n");
+
+	return true;
+}
+
+static FLAC__bool test_crc16(const FLAC__byte *data, size_t size)
+{
+	uint32_t i;
+	FLAC__uint16 crc0,crc1;
+
+	printf("testing FLAC__crc16 ... ");
+
+	crc0 = 0;
+	crc1 = FLAC__crc16(data, 0);
+
+	if (crc1 != crc0) {
+		printf("FAILED, FLAC__crc16 returned non-zero CRC for zero bytes of data\n");
+		return false;
+	}
+
+	for (i = 0; i < size; i++) {
+		crc0 = crc16_update_ref(data[i], crc0);
+		crc1 = FLAC__crc16(data, i + 1);
+
+		if (crc1 != crc0) {
+			printf("FAILED, FLAC__crc16 result did not match reference CRC for %i bytes of test data\n", i + 1);
+			return false;
+		}
+	}
+
+	printf("OK\n");
+
+	return true;
+}
+
+static FLAC__bool test_crc16_update(const FLAC__byte *data, size_t size)
+{
+	uint32_t i;
+	FLAC__uint16 crc0,crc1;
+
+	printf("testing FLAC__CRC16_UPDATE macro ... ");
+
+	crc0 = 0;
+	crc1 = 0;
+
+	for (i = 0; i < size; i++) {
+		crc0 = crc16_update_ref(data[i], crc0);
+		crc1 = FLAC__CRC16_UPDATE(data[i], crc1);
+
+		if (crc1 != crc0) {
+			printf("FAILED, FLAC__CRC16_UPDATE result did not match reference CRC after %i bytes of test data\n", i + 1);
+			return false;
+		}
+	}
+
+	printf("OK\n");
+
+	return true;
+}

--- a/src/test_libFLAC/crc.h
+++ b/src/test_libFLAC/crc.h
@@ -1,6 +1,5 @@
 /* test_libFLAC - Unit tester for libFLAC
- * Copyright (C) 2000-2009  Josh Coalson
- * Copyright (C) 2011-2018  Xiph.Org Foundation
+ * Copyright (C) 2014-2018  Xiph.Org Foundation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -17,44 +16,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifdef HAVE_CONFIG_H
-#  include <config.h>
+#ifndef FLAC__TEST_LIBFLAC_CRC_H
+#define FLAC__TEST_LIBFLAC_CRC_H
+
+#include "FLAC/ordinals.h"
+
+FLAC__bool test_crc(void);
+
 #endif
-
-#include "bitwriter.h"
-#include "crc.h"
-#include "decoders.h"
-#include "encoders.h"
-#include "endswap.h"
-#include "format.h"
-#include "metadata.h"
-#include "md5.h"
-
-int main(void)
-{
-	if(!test_endswap())
-		return 1;
-
-	if(!test_crc())
-		return 1;
-
-	if(!test_md5())
-		return 1;
-
-	if(!test_bitwriter())
-		return 1;
-
-	if(!test_format())
-		return 1;
-
-	if(!test_encoders())
-		return 1;
-
-	if(!test_decoders())
-		return 1;
-
-	if(!test_metadata())
-		return 1;
-
-	return 0;
-}

--- a/src/test_libFLAC/test_libFLAC.vcproj
+++ b/src/test_libFLAC/test_libFLAC.vcproj
@@ -185,6 +185,10 @@
 			UniqueIdentifier="{93995380-89BD-4b04-88EB-625FBE52EBFB}"
 			>
 			<File
+				RelativePath=".\bitreader.h"
+				>
+			</File>
+			<File
 				RelativePath=".\bitwriter.h"
 				>
 			</File>
@@ -222,6 +226,10 @@
 			Filter="cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx"
 			UniqueIdentifier="{4FC737F1-C7A5-4376-A066-2A32D752A2FF}"
 			>
+			<File
+				RelativePath=".\bitreader.c"
+				>
+			</File>
 			<File
 				RelativePath=".\bitwriter.c"
 				>

--- a/src/test_libFLAC/test_libFLAC.vcproj
+++ b/src/test_libFLAC/test_libFLAC.vcproj
@@ -189,6 +189,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\crc.h"
+				>
+			</File>
+			<File
 				RelativePath=".\decoders.h"
 				>
 			</File>
@@ -220,6 +224,10 @@
 			>
 			<File
 				RelativePath=".\bitwriter.c"
+				>
+			</File>
+			<File
+				RelativePath=".\crc.c"
 				>
 			</File>
 			<File

--- a/src/test_libFLAC/test_libFLAC.vcxproj
+++ b/src/test_libFLAC/test_libFLAC.vcxproj
@@ -165,6 +165,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="bitreader.h" />
     <ClInclude Include="bitwriter.h" />
     <ClInclude Include="crc.h" />
     <ClInclude Include="decoders.h" />
@@ -175,6 +176,7 @@
     <ClInclude Include="metadata.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="bitreader.c" />
     <ClCompile Include="bitwriter.c" />
     <ClCompile Include="crc.c" />
     <ClCompile Include="decoders.c" />

--- a/src/test_libFLAC/test_libFLAC.vcxproj
+++ b/src/test_libFLAC/test_libFLAC.vcxproj
@@ -166,6 +166,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="bitwriter.h" />
+    <ClInclude Include="crc.h" />
     <ClInclude Include="decoders.h" />
     <ClInclude Include="encoders.h" />
     <ClInclude Include="endswap.h" />
@@ -175,6 +176,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="bitwriter.c" />
+    <ClCompile Include="crc.c" />
     <ClCompile Include="decoders.c" />
     <ClCompile Include="encoders.c" />
     <ClCompile Include="endswap.c" />

--- a/src/test_libFLAC/test_libFLAC.vcxproj.filters
+++ b/src/test_libFLAC/test_libFLAC.vcxproj.filters
@@ -14,6 +14,9 @@
     <ClInclude Include="bitwriter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="crc.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="decoders.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -35,6 +38,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="bitwriter.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="crc.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="decoders.c">

--- a/src/test_libFLAC/test_libFLAC.vcxproj.filters
+++ b/src/test_libFLAC/test_libFLAC.vcxproj.filters
@@ -11,6 +11,9 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="bitreader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="bitwriter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -37,6 +40,9 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="bitreader.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="bitwriter.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
This PR adds unit tests for CRC calculation and for the BitReader. See PR #57 for reference.

The CRC tests verify CRC8 and CRC16 calculation against simple reference CRC implementations.
The BitReader test includes code to test unaligned small reads (less than a word) that would trigger the bug found by @lvqcl, fixed in commit d57fb5c in PR #57.

In addition, obsolete CRC8 functions are removed (commit 8cebcf7) and some checks and messages in the BitWriter test are fixed (commit d93eec3).