### PR TITLE
Fix --output-prefix with input-files in sub-directories.

### DIFF
--- a/src/flac/main.c
+++ b/src/flac/main.c
@@ -2173,12 +2173,30 @@ int decode_file(const char *infilename)
 const char *get_encoded_outfilename(const char *infilename)
 {
 	const char *suffix = (option_values.use_ogg? ".oga" : ".flac");
-	return get_outfilename(infilename, suffix);
+	char *p;
+
+	if(option_values.output_prefix) {
+		p = grabbag__file_get_basename(infilename);
+	}
+	else {
+		p = infilename;
+	}
+
+	return get_outfilename(p, suffix);
 }
 
 const char *get_decoded_outfilename(const char *infilename)
 {
 	const char *suffix;
+	char *p;
+
+	if(option_values.output_prefix) {
+		p = grabbag__file_get_basename(infilename);
+	}
+	else {
+		p = infilename;
+	}
+
 	if(option_values.analyze) {
 		suffix = ".ana";
 	}
@@ -2197,7 +2215,7 @@ const char *get_decoded_outfilename(const char *infilename)
 	else {
 		suffix = ".wav";
 	}
-	return get_outfilename(infilename, suffix);
+	return get_outfilename(p, suffix);
 }
 
 const char *get_outfilename(const char *infilename, const char *suffix)

--- a/test/test_flac.sh
+++ b/test/test_flac.sh
@@ -726,6 +726,43 @@ if [ $is_win = no ] ; then
 	echo OK
 fi
 
+############################################################################
+# test --output-prefix
+############################################################################
+
+in_dir=./tmp_in
+out_dir=./tmp_out
+mkdir $in_dir $out_dir || die "ERROR failed to create temp directories"
+
+cp 50c.raw 50c.flac $in_dir
+
+#
+# test --output-prefix when encoding
+#
+
+echo $ECHO_N "testing --output-prefix=$out_dir/ (encode)... " $ECHO_C
+run_flac $raw_eopt --output-prefix=$out_dir/ $in_dir/50c.raw || die "ERROR generating FLAC file in $out_dir (encode)"
+[ -f $out_dir/50c.flac ] || die "ERROR FLAC file not in $out_dir (encode)"
+run_flac $raw_dopt $out_dir/50c.flac || die "ERROR decoding FLAC file (encode)"
+[ -f $out_dir/50c.raw ] || die "ERROR RAW file not in $out_dir (encode)"
+cmp 50c.raw $out_dir/50c.raw || die "ERROR: file mismatch for --output-prefix=$out_dir (encode)"
+rm -f $out_dir/50c.flac $out_dir/50c.raw
+echo OK
+
+#
+# test --ouput-prefix when decoding
+#
+
+echo $ECHO_N "testing --output-prefix=$out_dir/ (decode)... " $ECHO_C
+run_flac $raw_dopt --output-prefix=$out_dir/ $in_dir/50c.flac || die "ERROR deocding FLAC file in $out_dir (decode)"
+[ -f $out_dir/50c.raw ] || die "ERROR RAW file not in $out_dir (decode)"
+run_flac $raw_eopt $out_dir/50c.raw || die "ERROR generating FLAC file (decode)"
+[ -f $out_dir/50c.flac ] || die "ERROR FLAC file not in $out_dir (decode)"
+cmp 50c.flac $out_dir/50c.flac || die "ERROR: file mismatch for --output-prefix=$out_dir (decode)"
+rm -f $out_dir/50c.flac $out_dir/50c.raw
+echo OK
+
+rm -rf $in_dir $out_dir
 
 ############################################################################
 # test --cue


### PR DESCRIPTION
When `--output-prefix=/foo/bar/` is used with `some/path/to/foo.flac` flac will fail to create the sub-directories instead of just creating the new file in the `/foo/bar/`. So this will strip the unwanted path from `foo.flac` and just successfully create new files to the output directory.

Please review this to make sure I am doing it correctly.


Also please view this issue report which also describes the issue which this patch fixes. I don't have a sourceforge account so someone else will have to respond to that issue report if necessary. :)

https://sourceforge.net/p/flac/bugs/463/.