### PR TITLE
move CreateFile function outside of libFLAC

### DIFF
--- a/include/share/compat.h
+++ b/include/share/compat.h
@@ -175,10 +175,6 @@
 #define flac_fstat fstat
 #endif
 
-#ifndef WINAPI_FAMILY_PARTITION
-#define WINAPI_FAMILY_PARTITION(x) 0
-#endif
-
 #ifdef ANDROID
 #include <limits.h>
 #endif

--- a/include/share/grabbag/file.h
+++ b/include/share/grabbag/file.h
@@ -58,6 +58,11 @@ FLAC__bool grabbag__file_remove_file(const char *filename);
 FILE *grabbag__file_get_binary_stdin(void);
 FILE *grabbag__file_get_binary_stdout(void);
 
+#if defined _WIN32 && !defined __CYGWIN__
+#include <windows.h>
+HANDLE WINAPI grabbag__CreateFile_utf8(const char *lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/share/windows_unicode_filenames.h
+++ b/include/share/windows_unicode_filenames.h
@@ -55,10 +55,6 @@ int flac_internal_utime_utf8(const char *filename, struct utimbuf *times);
 int flac_internal_unlink_utf8(const char *filename);
 int flac_internal_rename_utf8(const char *oldname, const char *newname);
 
-#include <windows.h>
-HANDLE WINAPI flac_internal_CreateFile_utf8(const char *lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile);
-#define CreateFile_utf8 flac_internal_CreateFile_utf8
-
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/flac/decode.c
+++ b/src/flac/decode.c
@@ -263,11 +263,11 @@ FLAC__bool DecoderSession_construct(DecoderSession *d, FLAC__bool is_ogg, FLAC__
 void DecoderSession_destroy(DecoderSession *d, FLAC__bool error_occurred)
 {
 	if(0 != d->fout && d->fout != stdout) {
-#ifdef _WIN32
+#if defined _WIN32 && !defined __CYGWIN__
 		if(!error_occurred) {
 			FLAC__off_t written_size = ftello(d->fout);
 			if(written_size > 0) {
-				HANDLE fh = CreateFile_utf8(d->outfilename, GENERIC_READ|GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+				HANDLE fh = grabbag__CreateFile_utf8(d->outfilename, GENERIC_READ|GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 				if(fh != INVALID_HANDLE_VALUE) {
 					if(GetFileType(fh) == FILE_TYPE_DISK) {
 						LARGE_INTEGER size;
@@ -381,9 +381,9 @@ FLAC__bool DecoderSession_process(DecoderSession *d)
 		}
 	}
 
-#ifdef _WIN32
+#if defined _WIN32 && !defined __CYGWIN__
 	if(!d->analysis_mode && !d->test_only && d->total_samples > 0 && d->fout != stdout) {
-		HANDLE fh = CreateFile_utf8(d->outfilename, GENERIC_READ|GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+		HANDLE fh = grabbag__CreateFile_utf8(d->outfilename, GENERIC_READ|GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 		if(fh != INVALID_HANDLE_VALUE) {
 			if (GetFileType(fh) == FILE_TYPE_DISK) {
 				LARGE_INTEGER size;

--- a/src/libFLAC/windows_unicode_filenames.c
+++ b/src/libFLAC/windows_unicode_filenames.c
@@ -34,7 +34,7 @@
 #endif
 
 #include <io.h>
-#include "share/compat.h"
+#include <windows.h>
 #include "share/windows_unicode_filenames.h"
 
 /* convert UTF-8 back to WCHAR. Caller is responsible for freeing memory */
@@ -182,34 +182,4 @@ int flac_internal_rename_utf8(const char *oldname, const char *newname)
 
 		return ret;
 	}
-}
-
-HANDLE WINAPI flac_internal_CreateFile_utf8(const char *lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile)
-{
-#if _MSC_VER > 1900 && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP)
-	wchar_t *wname;
-	HANDLE handle = INVALID_HANDLE_VALUE;
-
-	if ((wname = wchar_from_utf8(lpFileName)) != NULL) {
-
-		handle = CreateFile2(wname, dwDesiredAccess, dwShareMode, CREATE_ALWAYS, NULL);
-		free(wname);
-
-		return handle;
-	}
-#else
-	if (!utf8_filenames) {
-		return CreateFileA(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
-	} else {
-		wchar_t *wname;
-		HANDLE handle = INVALID_HANDLE_VALUE;
-
-		if ((wname = wchar_from_utf8(lpFileName)) != NULL) {
-			handle = CreateFileW(wname, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
-			free(wname);
-		}
-
-		return handle;
-	}
-#endif
 }

--- a/src/share/grabbag/file.c
+++ b/src/share/grabbag/file.c
@@ -41,11 +41,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h> /* for strrchr() */
-#if defined _WIN32 && !defined __CYGWIN__
-// for GetFileInformationByHandle() etc
-#include <windows.h>
-#include <winbase.h>
-#endif
 #include "share/grabbag.h"
 
 
@@ -116,9 +111,9 @@ FLAC__bool grabbag__file_change_stats(const char *filename, FLAC__bool read_only
 
 FLAC__bool grabbag__file_are_same(const char *f1, const char *f2)
 {
-#if defined _MSC_VER || defined __MINGW32__
+#if defined _WIN32 && !defined __CYGWIN__
 	/* see
-	 * http://www.hydrogenaudio.org/forums/index.php?showtopic=49439&pid=444300&st=0
+	 *  http://www.hydrogenaudio.org/forums/index.php?showtopic=49439&pid=444300&st=0
 	 *  http://msdn.microsoft.com/library/default.asp?url=/library/en-us/fileio/fs/getfileinformationbyhandle.asp
 	 *  http://msdn.microsoft.com/library/default.asp?url=/library/en-us/fileio/fs/by_handle_file_information_str.asp
 	 *  http://msdn.microsoft.com/library/default.asp?url=/library/en-us/fileio/fs/createfile.asp
@@ -128,8 +123,8 @@ FLAC__bool grabbag__file_are_same(const char *f1, const char *f2)
 	BY_HANDLE_FILE_INFORMATION info1, info2;
 	HANDLE h1, h2;
 	BOOL ok = 1;
-	h1 = CreateFile_utf8(f1, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-	h2 = CreateFile_utf8(f2, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	h1 = grabbag__CreateFile_utf8(f1, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	h2 = grabbag__CreateFile_utf8(f2, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 	if(h1 == INVALID_HANDLE_VALUE || h2 == INVALID_HANDLE_VALUE)
 		ok = 0;
 	ok &= GetFileInformationByHandle(h1, &info1);
@@ -185,3 +180,44 @@ FILE *grabbag__file_get_binary_stdout(void)
 
 	return stdout;
 }
+
+#if defined _WIN32 && !defined __CYGWIN__
+
+/* convert UTF-8 back to WCHAR. Caller is responsible for freeing memory */
+static wchar_t *wchar_from_utf8(const char *str)
+{
+	wchar_t *widestr;
+	int len;
+
+	if (!str)
+		return NULL;
+	if ((len = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0)) == 0)
+		return NULL;
+	if ((widestr = (wchar_t *)malloc(len*sizeof(wchar_t))) == NULL)
+		return NULL;
+	if (MultiByteToWideChar(CP_UTF8, 0, str, -1, widestr, len) == 0) {
+		free(widestr);
+		widestr = NULL;
+	}
+
+	return widestr;
+}
+
+HANDLE WINAPI grabbag__CreateFile_utf8(const char *lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile)
+{
+	if (!flac_internal_get_utf8_filenames()) {
+		return CreateFileA(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+	} else {
+		wchar_t *wname;
+		HANDLE handle = INVALID_HANDLE_VALUE;
+
+		if ((wname = wchar_from_utf8(lpFileName)) != NULL) {
+			handle = CreateFileW(wname, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+			free(wname);
+		}
+
+		return handle;
+	}
+}
+
+#endif


### PR DESCRIPTION
This patch renames flac_internal_CreateFile_utf8() function to grabbag__CreateFile_utf8() and moves it from /src/libFLAC/windows_unicode_filenames.c into src/share/grabbag/file.c.
This function is not used by libFLAC anyway.

After this, it should be possible to compile libFLAC as UWP.

In the old code there were 3 different #if  conditionals around the code that uses CreateFile_utf8():
1)  #ifdef _WIN32 ... #endif
2)  #if defined _WIN32 && !defined __CYGWIN__ ... #endif
3)  #if defined _MSC_VER || defined __MINGW32__ ... #endif
It seems for me that the 2nd version makes more sense, so I replaced them all with it.

Also this patch removes questionable WINAPI_FAMILY_PARTITION, CreateFile2, etc stuff from the code.
The file src/share/grabbag/file.c contains non-UWP function GetFileInformationByHandle, and nobody complained, so it's OK to use non-UWP CreateFileA/CreateFileW as well.
