### PR TITLE
Update MinGW build files

### DIFF
--- a/src/test_grabbag/picture/Makefile.am
+++ b/src/test_grabbag/picture/Makefile.am
@@ -27,9 +27,14 @@ check_PROGRAMS = test_picture
 test_picture_SOURCES = \
 	main.c
 
+if OS_IS_WINDOWS
+win_utf8_lib = $(top_builddir)/src/share/win_utf8_io/libwin_utf8_io.la
+endif
+
 test_picture_LDADD = \
 	$(top_builddir)/src/share/grabbag/libgrabbag.la \
 	$(top_builddir)/src/share/replaygain_analysis/libreplaygain_analysis.la \
-	$(top_builddir)/src/libFLAC/libFLAC.la
+	$(top_builddir)/src/libFLAC/libFLAC.la \
+	$(win_utf8_lib)
 
 CLEANFILES = test_picture.exe

--- a/src/test_grabbag/picture/Makefile.lite
+++ b/src/test_grabbag/picture/Makefile.lite
@@ -32,7 +32,11 @@ INCLUDES = -I./include -I$(topdir)/include
 ifeq ($(OS),Darwin)
     EXPLICIT_LIBS = $(libdir)/libgrabbag.a $(libdir)/libreplaygain_analysis.a $(libdir)/libFLAC.a $(OGG_EXPLICIT_LIBS) -lm
 else
+ifeq ($(findstring Windows,$(OS)),Windows)
+    LIBS = -lgrabbag -lreplaygain_analysis -lFLAC -lwin_utf8_io $(OGG_LIBS) -lm
+else
     LIBS = -lgrabbag -lreplaygain_analysis -lFLAC $(OGG_LIBS) -lm
+endif
 endif
 
 SRCS_C = \

--- a/src/test_libFLAC++/Makefile.am
+++ b/src/test_libFLAC++/Makefile.am
@@ -24,12 +24,18 @@ EXTRA_DIST = \
 
 AM_CPPFLAGS = -I$(top_builddir) -I$(srcdir)/include -I$(top_srcdir)/include
 check_PROGRAMS = test_libFLAC++
+
+if OS_IS_WINDOWS
+win_utf8_lib = $(top_builddir)/src/share/win_utf8_io/libwin_utf8_io.la
+endif
+
 test_libFLAC___LDADD = \
 	$(top_builddir)/src/share/grabbag/libgrabbag.la \
 	$(top_builddir)/src/share/replaygain_analysis/libreplaygain_analysis.la \
 	$(top_builddir)/src/test_libs_common/libtest_libs_common.la \
 	$(top_builddir)/src/libFLAC++/libFLAC++.la \
 	$(top_builddir)/src/libFLAC/libFLAC.la \
+	$(win_utf8_lib) \
 	@OGG_LIBS@ \
 	-lm
 

--- a/src/test_libFLAC++/Makefile.lite
+++ b/src/test_libFLAC++/Makefile.lite
@@ -32,7 +32,11 @@ INCLUDES = -I$(topdir)/include
 ifeq ($(OS),Darwin)
     EXPLICIT_LIBS = $(libdir)/libgrabbag.a $(libdir)/libreplaygain_analysis.a $(libdir)/libtest_libs_common.a $(libdir)/libFLAC++.a $(libdir)/libFLAC.a $(OGG_EXPLICIT_LIBS) -lm
 else
+ifeq ($(findstring Windows,$(OS)),Windows)
+    LIBS = -lgrabbag -lreplaygain_analysis -ltest_libs_common -lFLAC++ -lFLAC -lwin_utf8_io $(OGG_LIBS) -lm
+else
     LIBS = -lgrabbag -lreplaygain_analysis -ltest_libs_common -lFLAC++ -lFLAC $(OGG_LIBS) -lm
+endif
 endif
 
 SRCS_CPP = \

--- a/src/test_libFLAC/Makefile.am
+++ b/src/test_libFLAC/Makefile.am
@@ -26,11 +26,16 @@ AM_CPPFLAGS = -I$(top_builddir) -I$(srcdir)/include -I$(top_srcdir)/include -I$(
 
 check_PROGRAMS = test_libFLAC
 
+if OS_IS_WINDOWS
+win_utf8_lib = $(top_builddir)/src/share/win_utf8_io/libwin_utf8_io.la
+endif
+
 test_libFLAC_LDADD = \
 	$(top_builddir)/src/share/grabbag/libgrabbag.la \
 	$(top_builddir)/src/share/replaygain_analysis/libreplaygain_analysis.la \
 	$(top_builddir)/src/test_libs_common/libtest_libs_common.la \
 	$(top_builddir)/src/libFLAC/libFLAC-static.la \
+	$(win_utf8_lib) \
 	@OGG_LIBS@ \
 	-lm
 

--- a/src/test_libFLAC/Makefile.lite
+++ b/src/test_libFLAC/Makefile.lite
@@ -32,7 +32,11 @@ INCLUDES = -I../libFLAC/include -I$(topdir)/include
 ifeq ($(OS),Darwin)
     EXPLICIT_LIBS = $(libdir)/libgrabbag.a $(libdir)/libreplaygain_analysis.a $(libdir)/libtest_libs_common.a $(libdir)/libFLAC.a $(OGG_EXPLICIT_LIBS) -lm
 else
+ifeq ($(findstring Windows,$(OS)),Windows)
+    LIBS = -lgrabbag -lreplaygain_analysis -ltest_libs_common -lFLAC -lwin_utf8_io $(OGG_LIBS) -lm
+else
     LIBS = -lgrabbag -lreplaygain_analysis -ltest_libs_common -lFLAC $(OGG_LIBS) -lm
+endif
 endif
 
 SRCS_C = \


### PR DESCRIPTION
Now `test_grabbag`, `test_libFLAC` and `test_libFLAC++` depend on `win_utf8_io` library, so it's necessary to fix their `Makefile.am` and `Makefile.lite` files. Unfortunately these changed were missed in the previous commit.