### PR TITLE
Speed up FLAC__bitwriter_write_byte_block (metadata writing)

### DIFF
--- a/src/libFLAC/bitwriter.c
+++ b/src/libFLAC/bitwriter.c
@@ -410,6 +410,10 @@ inline FLAC__bool FLAC__bitwriter_write_byte_block(FLAC__BitWriter *bw, const FL
 {
 	uint32_t i;
 
+	/* grow capacity upfront to prevent constant reallocation during writes */
+	if(bw->capacity <= bw->words + nvals / (FLAC__BITS_PER_WORD / 8) + 1 && !bitwriter_grow_(bw, nvals * 8))
+		return false;
+
 	/* this could be faster but currently we don't need it to be since it's only used for writing metadata */
 	for(i = 0; i < nvals; i++) {
 		if(!FLAC__bitwriter_write_raw_uint32_nocheck(bw, (FLAC__uint32)(vals[i]), 8))


### PR DESCRIPTION
This grows the bitwriter capacity before starting to write a byte block. Fixes issue #86.

Writing a 7MB picture block took 2.8s on a test system before this change, approximately 20ms after it.

I left the "this could be faster" comment in there as there's probably room for further improvement - though not really needed now.