### PR TITLE
Prefer old MMX/ASM functions over new SSE4.1 ones.

### DIFF
--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -396,8 +396,10 @@ static FLAC__StreamDecoderInitStatus init_stream_internal_(
 #if FLAC__HAS_X86INTRIN && ! defined FLAC__INTEGER_ONLY_LIBRARY
 # if defined FLAC__SSE4_1_SUPPORTED
 		if (decoder->private_->cpuinfo.x86.sse41) {
+#  if !defined FLAC__HAS_NASM  /* these are not undoubtedly faster than their MMX ASM counterparts */
 			decoder->private_->local_lpc_restore_signal = FLAC__lpc_restore_signal_intrin_sse41;
 			decoder->private_->local_lpc_restore_signal_16bit = FLAC__lpc_restore_signal_16_intrin_sse41;
+#  endif
 			decoder->private_->local_lpc_restore_signal_64bit = FLAC__lpc_restore_signal_wide_intrin_sse41;
 		}
 # endif


### PR DESCRIPTION
My decoding speed tests show that `FLAC__lpc_restore_signal_intrin_sse41()` and `FLAC__lpc_restore_signal_16_intrin_sse41()` are faster than `FLAC__lpc_restore_signal_asm_ia32()` and `FLAC__lpc_restore_signal_asm_ia32_mmx()` on some CPUs, but slower on others. For example, they are faster on older Intel CPUs, but slower on newer Intel CPUs.

Since these new routines aren't always faster, let's use them only if old MMX/ASM ones are unavailable.
