### PR TITLE
Replace xhtml validation links with travis xmllint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,13 @@ env:
   - BUILD_SYSTEM="cmake"     CONFIGURE_OPTS=
   - BUILD_SYSTEM="cmake"     CONFIGURE_OPTS=-DENABLE_64_BIT_WORDS=ON
 install:
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get -y install libtool-bin libogg-dev; fi
+  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get -y install libtool-bin libogg-dev doxygen libxml2-utils w3c-sgml-lib; fi
   - if [ $TRAVIS_OS_NAME = osx ]; then brew install libogg; fi
 
 script:
   - if [[ "${BUILD_SYSTEM}" == "autotools" ]]; then ./autogen.sh && ./configure $CONFIGURE_OPTS && make && make check; fi
   - if [[ "${BUILD_SYSTEM}" == "cmake" ]]; then mkdir cmake-build && cd cmake-build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON $CONFIGURE_OPTS && cmake --build . && ctest -V; fi
+  - if [ $TRAVIS_OS_NAME = linux ] && [ ${BUILD_SYSTEM} = "autotools" ]; then
+      xmllint --valid --noout doc/html/*.html;
+      xmllint --valid --noout doc/html/api/*.html;
+    fi

--- a/doc/doxygen.footer.html
+++ b/doc/doxygen.footer.html
@@ -1,5 +1,5 @@
 
-<hr size="1">
+<hr size="1"/>
 <div class="copyright">
 	<!-- @@@ oh so hacky -->
 	<table>

--- a/doc/html/changelog.html
+++ b/doc/html/changelog.html
@@ -1462,9 +1462,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/developers.html
+++ b/doc/html/developers.html
@@ -118,9 +118,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/documentation.html
+++ b/doc/html/documentation.html
@@ -83,9 +83,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/documentation_bugs.html
+++ b/doc/html/documentation_bugs.html
@@ -77,9 +77,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/documentation_example_code.html
+++ b/doc/html/documentation_example_code.html
@@ -59,9 +59,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/documentation_format_overview.html
+++ b/doc/html/documentation_format_overview.html
@@ -108,9 +108,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/documentation_tools.html
+++ b/doc/html/documentation_tools.html
@@ -69,9 +69,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/documentation_tools_flac.html
+++ b/doc/html/documentation_tools_flac.html
@@ -1181,9 +1181,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/documentation_tools_metaflac.html
+++ b/doc/html/documentation_tools_metaflac.html
@@ -558,9 +558,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/faq.html
+++ b/doc/html/faq.html
@@ -382,9 +382,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/features.html
+++ b/doc/html/features.html
@@ -105,9 +105,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/format.html
+++ b/doc/html/format.html
@@ -1841,9 +1841,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/id.html
+++ b/doc/html/id.html
@@ -281,9 +281,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -88,9 +88,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/license.html
+++ b/doc/html/license.html
@@ -71,9 +71,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>

--- a/doc/html/ogg_mapping.html
+++ b/doc/html/ogg_mapping.html
@@ -116,9 +116,6 @@
 				<br/>
 				Copyright (c) 2011-2016  Xiph.Org Foundation
 			</td>
-			<td width="1%" align="right">
-				<a href="http://validator.w3.org/check?uri=referer"><img src="http://www.w3.org/Icons/valid-xhtml10" alt="Valid XHTML 1.0!" height="31" width="88" border="0" hspace="0" /></a>
-			</td>
 		</tr>
 	</table>
 </div>


### PR DESCRIPTION
Apply Fabian Greffrath's [patch](https://sources.debian.org/src/flac/1.3.2-3/debian/patches/privacy-breach-w3c-valid-html.patch/) from the Debian packages to remove the W3C validator links. They were broken and allow tracking of user activity.

Instead, generate and run the documentation through xmllint as part of the travis-ci.org continuous-integration tests. This gives us more active verification than someone clicking the badge and checking manually.

Addresses discussion in #111.