### PR TITLE
Do not assume that sys/param.h defines MIN and MAX

### DIFF
--- a/src/libFLAC/include/private/macros.h
+++ b/src/libFLAC/include/private/macros.h
@@ -51,8 +51,10 @@
 /* Whatever other unix that has sys/param.h */
 #elif defined(HAVE_SYS_PARAM_H)
 #include <sys/param.h>
+#if defined(MIN) && defined(MAX)
 #define flac_max(a,b) MAX(a,b)
 #define flac_min(a,b) MIN(a,b)
+#endif
 
 /* Windows VS has them in stdlib.h.. XXX:Untested */
 #elif defined(_MSC_VER)


### PR DESCRIPTION
One such example is sys/param.h from MinGW.