### PR TITLE
Switch to utimensat for newer POSIX versions

### DIFF
--- a/include/share/compat.h
+++ b/include/share/compat.h
@@ -112,8 +112,12 @@
 #include <sys/utime.h> /* for utime() */
 #endif
 #else
+#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L)
+#include <fcntl.h>
+#else
 #include <sys/types.h> /* some flavors of BSD (like OS X) require this to get time_t */
 #include <utime.h> /* for utime() */
+#endif
 #endif
 
 #if defined _MSC_VER
@@ -160,11 +164,15 @@
 
 #define flac_fopen fopen
 #define flac_chmod chmod
-#define flac_utime utime
 #define flac_unlink unlink
 #define flac_rename rename
 #define flac_stat stat
 
+#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L)
+#define flac_utime(a, b) utimensat (AT_FDCWD, a, *b, 0)
+#else
+#define flac_utime utime
+#endif
 #endif
 
 #ifdef _WIN32

--- a/src/libFLAC/metadata_iterators.c
+++ b/src/libFLAC/metadata_iterators.c
@@ -3422,13 +3422,18 @@ FLAC__bool get_file_stats_(const char *filename, struct flac_stat_s *stats)
 
 void set_file_stats_(const char *filename, struct flac_stat_s *stats)
 {
-	struct utimbuf srctime;
-
 	FLAC__ASSERT(0 != filename);
 	FLAC__ASSERT(0 != stats);
 
+#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L)
+	struct timespec srctime[2] = {};
+	srctime[0].tv_sec = stats->st_atime;
+	srctime[1].tv_sec = stats->st_mtime;
+#else
+	struct utimbuf srctime;
 	srctime.actime = stats->st_atime;
 	srctime.modtime = stats->st_mtime;
+#endif
 	(void)flac_chmod(filename, stats->st_mode);
 	(void)flac_utime(filename, &srctime);
 #if !defined _MSC_VER && !defined __BORLANDC__ && !defined __MINGW32__


### PR DESCRIPTION
Some libcs like uClibc-ng can optionally disable deprecated functions.
utime is one of them. When done so, both the header and the function go
missing.

This fixes flac_utime to work in such a situation.