### PR TITLE
Run libFLAC++ through clang-tidy.

### DIFF
--- a/src/libFLAC++/metadata.cpp
+++ b/src/libFLAC++/metadata.cpp
@@ -38,8 +38,8 @@
 #include "share/alloc.h"
 #include "FLAC++/metadata.h"
 #include "FLAC/assert.h"
-#include <stdlib.h> // for malloc(), free()
-#include <string.h> // for memcpy() etc.
+#include <cstdlib> // for malloc(), free()
+#include <cstring> // for memcpy() etc.
 
 #ifdef _MSC_VER
 // warning C4800: 'int' : forcing to bool 'true' or 'false' (performance warning)
@@ -85,7 +85,7 @@ namespace FLAC {
 				return ret;
 			}
 
-		}
+		} // namespace local
 
 		FLACPP_API Prototype *clone(const Prototype *object)
 		{
@@ -102,24 +102,23 @@ namespace FLAC {
 
 			if(0 != streaminfo)
 				return new StreamInfo(*streaminfo);
-			else if(0 != padding)
+			if(0 != padding)
 				return new Padding(*padding);
-			else if(0 != application)
+			if(0 != application)
 				return new Application(*application);
-			else if(0 != seektable)
+			if(0 != seektable)
 				return new SeekTable(*seektable);
-			else if(0 != vorbiscomment)
+			if(0 != vorbiscomment)
 				return new VorbisComment(*vorbiscomment);
-			else if(0 != cuesheet)
+			if(0 != cuesheet)
 				return new CueSheet(*cuesheet);
-			else if(0 != picture)
+			if(0 != picture)
 				return new Picture(*picture);
-			else if(0 != unknown)
+			if(0 != unknown)
 				return new Unknown(*unknown);
-			else {
-				FLAC__ASSERT(0);
-				return 0;
-			}
+
+			FLAC__ASSERT(0);
+			return 0;
 		}
 
 		//
@@ -203,7 +202,7 @@ namespace FLAC {
 		bool Prototype::get_is_last() const
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)object_->is_last;
+			return static_cast<bool>(object_->is_last);
 		}
 
 		FLAC__MetadataType Prototype::get_type() const
@@ -354,7 +353,7 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(0 != value);
-			memcpy(object_->data.stream_info.md5sum, value, 16);
+			std::memcpy(object_->data.stream_info.md5sum, value, 16);
 		}
 
 
@@ -409,19 +408,19 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(0 != value);
-			memcpy(object_->data.application.id, value, 4);
+			std::memcpy(object_->data.application.id, value, 4);
 		}
 
 		bool Application::set_data(const FLAC__byte *data, uint32_t length)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_application_set_data(object_, (FLAC__byte*)data, length, true);
+			return static_cast<bool>(::FLAC__metadata_object_application_set_data(object_, const_cast<FLAC__byte*>(data), length, true));
 		}
 
 		bool Application::set_data(FLAC__byte *data, uint32_t length, bool copy)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_application_set_data(object_, data, length, copy);
+			return static_cast<bool>(::FLAC__metadata_object_application_set_data(object_, data, length, copy));
 		}
 
 
@@ -452,7 +451,7 @@ namespace FLAC {
 		bool SeekTable::resize_points(uint32_t new_num_points)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_seektable_resize_points(object_, new_num_points);
+			return static_cast<bool>(::FLAC__metadata_object_seektable_resize_points(object_, new_num_points));
 		}
 
 		void SeekTable::set_point(uint32_t indx, const ::FLAC__StreamMetadata_SeekPoint &point)
@@ -466,56 +465,56 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(indx <= object_->data.seek_table.num_points);
-			return (bool)::FLAC__metadata_object_seektable_insert_point(object_, indx, point);
+			return static_cast<bool>(::FLAC__metadata_object_seektable_insert_point(object_, indx, point));
 		}
 
 		bool SeekTable::delete_point(uint32_t indx)
 		{
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(indx < object_->data.seek_table.num_points);
-			return (bool)::FLAC__metadata_object_seektable_delete_point(object_, indx);
+			return static_cast<bool>(::FLAC__metadata_object_seektable_delete_point(object_, indx));
 		}
 
 		bool SeekTable::is_legal() const
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_seektable_is_legal(object_);
+			return static_cast<bool>(::FLAC__metadata_object_seektable_is_legal(object_));
 		}
 
 		bool SeekTable::template_append_placeholders(uint32_t num)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_seektable_template_append_placeholders(object_, num);
+			return static_cast<bool>(::FLAC__metadata_object_seektable_template_append_placeholders(object_, num));
 		}
 
 		bool SeekTable::template_append_point(FLAC__uint64 sample_number)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_seektable_template_append_point(object_, sample_number);
+			return static_cast<bool>(::FLAC__metadata_object_seektable_template_append_point(object_, sample_number));
 		}
 
 		bool SeekTable::template_append_points(FLAC__uint64 sample_numbers[], uint32_t num)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_seektable_template_append_points(object_, sample_numbers, num);
+			return static_cast<bool>(::FLAC__metadata_object_seektable_template_append_points(object_, sample_numbers, num));
 		}
 
 		bool SeekTable::template_append_spaced_points(uint32_t num, FLAC__uint64 total_samples)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_seektable_template_append_spaced_points(object_, num, total_samples);
+			return static_cast<bool>(::FLAC__metadata_object_seektable_template_append_spaced_points(object_, num, total_samples));
 		}
 
 		bool SeekTable::template_append_spaced_points_by_samples(uint32_t samples, FLAC__uint64 total_samples)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_seektable_template_append_spaced_points_by_samples(object_, samples, total_samples);
+			return static_cast<bool>(::FLAC__metadata_object_seektable_template_append_spaced_points_by_samples(object_, samples, total_samples));
 		}
 
 		bool SeekTable::template_sort(bool compact)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_seektable_template_sort(object_, compact);
+			return static_cast<bool>(::FLAC__metadata_object_seektable_template_sort(object_, compact));
 		}
 
 
@@ -592,14 +591,14 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(entry.is_valid());
 			zero();
-			construct((const char *)entry.entry_.entry, entry.entry_.length);
+			construct(reinterpret_cast<const char *>(entry.entry_.entry), entry.entry_.length);
 		}
 
 		VorbisComment::Entry &VorbisComment::Entry::operator=(const Entry &entry)
 		{
 			FLAC__ASSERT(entry.is_valid());
 			clear();
-			construct((const char *)entry.entry_.entry, entry.entry_.length);
+			construct(reinterpret_cast<const char *>(entry.entry_.entry), entry.entry_.length);
 			return *this;
 		}
 
@@ -640,7 +639,7 @@ namespace FLAC {
 		const char *VorbisComment::Entry::get_field() const
 		{
 			FLAC__ASSERT(is_valid());
-			return (const char *)entry_.entry;
+			return reinterpret_cast<const char *>(entry_.entry);
 		}
 
 		const char *VorbisComment::Entry::get_field_name() const
@@ -660,17 +659,17 @@ namespace FLAC {
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(0 != field);
 
-			if(!::FLAC__format_vorbiscomment_entry_is_legal((const ::FLAC__byte*)field, field_length))
+			if(!::FLAC__format_vorbiscomment_entry_is_legal(reinterpret_cast<const ::FLAC__byte*>(field), field_length))
 				return is_valid_ = false;
 
 			clear_entry();
 
-			if(0 == (entry_.entry = (FLAC__byte*)safe_malloc_add_2op_(field_length, /*+*/1))) {
+			if(0 == (entry_.entry = static_cast<FLAC__byte*>(safe_malloc_add_2op_(field_length, /*+*/1)))) {
 				is_valid_ = false;
 			}
 			else {
 				entry_.length = field_length;
-				memcpy(entry_.entry, field, field_length);
+				std::memcpy(entry_.entry, field, field_length);
 				entry_.entry[field_length] = '\0';
 				(void) parse_field();
 			}
@@ -680,7 +679,7 @@ namespace FLAC {
 
 		bool VorbisComment::Entry::set_field(const char *field)
 		{
-			return set_field(field, strlen(field));
+			return set_field(field, std::strlen(field));
 		}
 
 		bool VorbisComment::Entry::set_field_name(const char *field_name)
@@ -697,7 +696,7 @@ namespace FLAC {
 				is_valid_ = false;
 			}
 			else {
-				field_name_length_ = strlen(field_name_);
+				field_name_length_ = std::strlen(field_name_);
 				compose_field();
 			}
 
@@ -709,17 +708,17 @@ namespace FLAC {
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(0 != field_value);
 
-			if(!::FLAC__format_vorbiscomment_entry_value_is_legal((const FLAC__byte*)field_value, field_value_length))
+			if(!::FLAC__format_vorbiscomment_entry_value_is_legal(reinterpret_cast<const FLAC__byte*>(field_value), field_value_length))
 				return is_valid_ = false;
 
 			clear_field_value();
 
-			if(0 == (field_value_ = (char *)safe_malloc_add_2op_(field_value_length, /*+*/1))) {
+			if(0 == (field_value_ = static_cast<char *>(safe_malloc_add_2op_(field_value_length, /*+*/1)))) {
 				is_valid_ = false;
 			}
 			else {
 				field_value_length_ = field_value_length;
-				memcpy(field_value_, field_value, field_value_length);
+				std::memcpy(field_value_, field_value, field_value_length);
 				field_value_[field_value_length] = '\0';
 				compose_field();
 			}
@@ -729,7 +728,7 @@ namespace FLAC {
 
 		bool VorbisComment::Entry::set_field_value(const char *field_value)
 		{
-			return set_field_value(field_value, strlen(field_value));
+			return set_field_value(field_value, std::strlen(field_value));
 		}
 
 		void VorbisComment::Entry::zero()
@@ -754,7 +753,7 @@ namespace FLAC {
 		void VorbisComment::Entry::clear_entry()
 		{
 			if(0 != entry_.entry) {
-				free(entry_.entry);
+				std::free(entry_.entry);
 				entry_.entry = 0;
 				entry_.length = 0;
 			}
@@ -763,7 +762,7 @@ namespace FLAC {
 		void VorbisComment::Entry::clear_field_name()
 		{
 			if(0 != field_name_) {
-				free(field_name_);
+				std::free(field_name_);
 				field_name_ = 0;
 				field_name_length_ = 0;
 			}
@@ -772,7 +771,7 @@ namespace FLAC {
 		void VorbisComment::Entry::clear_field_value()
 		{
 			if(0 != field_value_) {
-				free(field_value_);
+				std::free(field_value_);
 				field_value_ = 0;
 				field_value_length_ = 0;
 			}
@@ -786,7 +785,7 @@ namespace FLAC {
 
 		void VorbisComment::Entry::construct(const char *field)
 		{
-			construct(field, strlen(field));
+			construct(field, std::strlen(field));
 		}
 
 		void VorbisComment::Entry::construct(const char *field_name, const char *field_value, uint32_t field_value_length)
@@ -797,23 +796,23 @@ namespace FLAC {
 
 		void VorbisComment::Entry::construct(const char *field_name, const char *field_value)
 		{
-			construct(field_name, field_value, strlen(field_value));
+			construct(field_name, field_value, std::strlen(field_value));
 		}
 
 		void VorbisComment::Entry::compose_field()
 		{
 			clear_entry();
 
-			if(0 == (entry_.entry = (FLAC__byte*)safe_malloc_add_4op_(field_name_length_, /*+*/1, /*+*/field_value_length_, /*+*/1))) {
+			if(0 == (entry_.entry = static_cast<FLAC__byte*>(safe_malloc_add_4op_(field_name_length_, /*+*/1, /*+*/field_value_length_, /*+*/1)))) {
 				is_valid_ = false;
 			}
 			else {
-				memcpy(entry_.entry, field_name_, field_name_length_);
+				std::memcpy(entry_.entry, field_name_, field_name_length_);
 				entry_.length += field_name_length_;
-				memcpy(entry_.entry + entry_.length, "=", 1);
+				std::memcpy(entry_.entry + entry_.length, "=", 1);
 				entry_.length += 1;
 				if (field_value_length_ > 0)
-					memcpy(entry_.entry + entry_.length, field_value_, field_value_length_);
+					std::memcpy(entry_.entry + entry_.length, field_value_, field_value_length_);
 				entry_.length += field_value_length_;
 				entry_.entry[entry_.length] = '\0';
 				is_valid_ = true;
@@ -825,33 +824,33 @@ namespace FLAC {
 			clear_field_name();
 			clear_field_value();
 
-			const char *p = (const char *)memchr(entry_.entry, '=', entry_.length);
+			const char *p = static_cast<const char *>(std::memchr(entry_.entry, '=', entry_.length));
 
 			if(0 == p)
-				p = (const char *)entry_.entry + entry_.length;
+				p = reinterpret_cast<const char *>(entry_.entry) + entry_.length;
 
-			field_name_length_ = (uint32_t)(p - (const char *)entry_.entry);
-			if(0 == (field_name_ = (char *)safe_malloc_add_2op_(field_name_length_, /*+*/1))) { // +1 for the trailing \0
+			field_name_length_ = static_cast<uint32_t>(p - reinterpret_cast<const char *>(entry_.entry));
+			if(0 == (field_name_ = static_cast<char *>(safe_malloc_add_2op_(field_name_length_, /*+*/1)))) { // +1 for the trailing \0
 				is_valid_ = false;
 				return;
 			}
-			memcpy(field_name_, entry_.entry, field_name_length_);
+			std::memcpy(field_name_, entry_.entry, field_name_length_);
 			field_name_[field_name_length_] = '\0';
 
 			if(entry_.length - field_name_length_ == 0) {
 				field_value_length_ = 0;
-				if(0 == (field_value_ = (char *)safe_malloc_(0))) {
+				if(0 == (field_value_ = static_cast<char *>(safe_malloc_(0)))) {
 					is_valid_ = false;
 					return;
 				}
 			}
 			else {
 				field_value_length_ = entry_.length - field_name_length_ - 1;
-				if(0 == (field_value_ = (char *)safe_malloc_add_2op_(field_value_length_, /*+*/1))) { // +1 for the trailing \0
+				if(0 == (field_value_ = static_cast<char *>(safe_malloc_add_2op_(field_value_length_, /*+*/1)))) { // +1 for the trailing \0
 					is_valid_ = false;
 					return;
 				}
-				memcpy(field_value_, ++p, field_value_length_);
+				std::memcpy(field_value_, ++p, field_value_length_);
 				field_value_[field_value_length_] = '\0';
 			}
 
@@ -886,54 +885,54 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(indx < object_->data.vorbis_comment.num_comments);
-			return Entry((const char *)object_->data.vorbis_comment.comments[indx].entry, object_->data.vorbis_comment.comments[indx].length);
+			return Entry(reinterpret_cast<const char *>(object_->data.vorbis_comment.comments[indx].entry), object_->data.vorbis_comment.comments[indx].length);
 		}
 
 		bool VorbisComment::set_vendor_string(const FLAC__byte *string)
 		{
 			FLAC__ASSERT(is_valid());
 			// vendor_string is a special kind of entry
-			const ::FLAC__StreamMetadata_VorbisComment_Entry vendor_string = { static_cast<FLAC__uint32>(strlen((const char *)string)), (FLAC__byte*)string }; // we can cheat on const-ness because we make a copy below:
-			return (bool)::FLAC__metadata_object_vorbiscomment_set_vendor_string(object_, vendor_string, /*copy=*/true);
+			const ::FLAC__StreamMetadata_VorbisComment_Entry vendor_string = { static_cast<FLAC__uint32>(std::strlen(reinterpret_cast<const char *>(string))), const_cast<FLAC__byte*>(string) }; // we can cheat on const-ness because we make a copy below:
+			return static_cast<bool>(::FLAC__metadata_object_vorbiscomment_set_vendor_string(object_, vendor_string, /*copy=*/true));
 		}
 
 		bool VorbisComment::resize_comments(uint32_t new_num_comments)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_vorbiscomment_resize_comments(object_, new_num_comments);
+			return static_cast<bool>(::FLAC__metadata_object_vorbiscomment_resize_comments(object_, new_num_comments));
 		}
 
 		bool VorbisComment::set_comment(uint32_t indx, const VorbisComment::Entry &entry)
 		{
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(indx < object_->data.vorbis_comment.num_comments);
-			return (bool)::FLAC__metadata_object_vorbiscomment_set_comment(object_, indx, entry.get_entry(), /*copy=*/true);
+			return static_cast<bool>(::FLAC__metadata_object_vorbiscomment_set_comment(object_, indx, entry.get_entry(), /*copy=*/true));
 		}
 
 		bool VorbisComment::insert_comment(uint32_t indx, const VorbisComment::Entry &entry)
 		{
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(indx <= object_->data.vorbis_comment.num_comments);
-			return (bool)::FLAC__metadata_object_vorbiscomment_insert_comment(object_, indx, entry.get_entry(), /*copy=*/true);
+			return static_cast<bool>(::FLAC__metadata_object_vorbiscomment_insert_comment(object_, indx, entry.get_entry(), /*copy=*/true));
 		}
 
 		bool VorbisComment::append_comment(const VorbisComment::Entry &entry)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_vorbiscomment_append_comment(object_, entry.get_entry(), /*copy=*/true);
+			return static_cast<bool>(::FLAC__metadata_object_vorbiscomment_append_comment(object_, entry.get_entry(), /*copy=*/true));
 		}
 
 		bool VorbisComment::replace_comment(const VorbisComment::Entry &entry, bool all)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_vorbiscomment_replace_comment(object_, entry.get_entry(), all, /*copy=*/true);
+			return static_cast<bool>(::FLAC__metadata_object_vorbiscomment_replace_comment(object_, entry.get_entry(), static_cast<FLAC__bool>(all), /*copy=*/true));
 		}
 
 		bool VorbisComment::delete_comment(uint32_t indx)
 		{
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(indx < object_->data.vorbis_comment.num_comments);
-			return (bool)::FLAC__metadata_object_vorbiscomment_delete_comment(object_, indx);
+			return static_cast<bool>(::FLAC__metadata_object_vorbiscomment_delete_comment(object_, indx));
 		}
 
 		int VorbisComment::find_entry_from(uint32_t offset, const char *field_name)
@@ -1001,7 +1000,7 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(0 != value);
-			memcpy(object_->isrc, value, 12);
+			std::memcpy(object_->isrc, value, 12);
 			object_->isrc[12] = '\0';
 		}
 
@@ -1066,7 +1065,7 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(0 != value);
-			memcpy(object_->data.cue_sheet.media_catalog_number, value, 128);
+			std::memcpy(object_->data.cue_sheet.media_catalog_number, value, 128);
 			object_->data.cue_sheet.media_catalog_number[128] = '\0';
 		}
 
@@ -1094,7 +1093,7 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(track_num < object_->data.cue_sheet.num_tracks);
-			return (bool)::FLAC__metadata_object_cuesheet_track_resize_indices(object_, track_num, new_num_indices);
+			return static_cast<bool>(::FLAC__metadata_object_cuesheet_track_resize_indices(object_, track_num, new_num_indices));
 		}
 
 		bool CueSheet::insert_index(uint32_t track_num, uint32_t index_num, const ::FLAC__StreamMetadata_CueSheet_Index &indx)
@@ -1102,7 +1101,7 @@ namespace FLAC {
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(track_num < object_->data.cue_sheet.num_tracks);
 			FLAC__ASSERT(index_num <= object_->data.cue_sheet.tracks[track_num].num_indices);
-			return (bool)::FLAC__metadata_object_cuesheet_track_insert_index(object_, track_num, index_num, indx);
+			return static_cast<bool>(::FLAC__metadata_object_cuesheet_track_insert_index(object_, track_num, index_num, indx));
 		}
 
 		bool CueSheet::insert_blank_index(uint32_t track_num, uint32_t index_num)
@@ -1110,7 +1109,7 @@ namespace FLAC {
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(track_num < object_->data.cue_sheet.num_tracks);
 			FLAC__ASSERT(index_num <= object_->data.cue_sheet.tracks[track_num].num_indices);
-			return (bool)::FLAC__metadata_object_cuesheet_track_insert_blank_index(object_, track_num, index_num);
+			return static_cast<bool>(::FLAC__metadata_object_cuesheet_track_insert_blank_index(object_, track_num, index_num));
 		}
 
 		bool CueSheet::delete_index(uint32_t track_num, uint32_t index_num)
@@ -1118,13 +1117,13 @@ namespace FLAC {
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(track_num < object_->data.cue_sheet.num_tracks);
 			FLAC__ASSERT(index_num < object_->data.cue_sheet.tracks[track_num].num_indices);
-			return (bool)::FLAC__metadata_object_cuesheet_track_delete_index(object_, track_num, index_num);
+			return static_cast<bool>(::FLAC__metadata_object_cuesheet_track_delete_index(object_, track_num, index_num));
 		}
 
 		bool CueSheet::resize_tracks(uint32_t new_num_tracks)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_cuesheet_resize_tracks(object_, new_num_tracks);
+			return static_cast<bool>(::FLAC__metadata_object_cuesheet_resize_tracks(object_, new_num_tracks));
 		}
 
 		bool CueSheet::set_track(uint32_t i, const CueSheet::Track &track)
@@ -1132,7 +1131,7 @@ namespace FLAC {
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(i < object_->data.cue_sheet.num_tracks);
 			// We can safely const_cast since copy=true
-			return (bool)::FLAC__metadata_object_cuesheet_set_track(object_, i, const_cast< ::FLAC__StreamMetadata_CueSheet_Track*>(track.get_track()), /*copy=*/true);
+			return static_cast<bool>(::FLAC__metadata_object_cuesheet_set_track(object_, i, const_cast< ::FLAC__StreamMetadata_CueSheet_Track*>(track.get_track()), /*copy=*/true));
 		}
 
 		bool CueSheet::insert_track(uint32_t i, const CueSheet::Track &track)
@@ -1140,27 +1139,27 @@ namespace FLAC {
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(i <= object_->data.cue_sheet.num_tracks);
 			// We can safely const_cast since copy=true
-			return (bool)::FLAC__metadata_object_cuesheet_insert_track(object_, i, const_cast< ::FLAC__StreamMetadata_CueSheet_Track*>(track.get_track()), /*copy=*/true);
+			return static_cast<bool>(::FLAC__metadata_object_cuesheet_insert_track(object_, i, const_cast< ::FLAC__StreamMetadata_CueSheet_Track*>(track.get_track()), /*copy=*/true));
 		}
 
 		bool CueSheet::insert_blank_track(uint32_t i)
 		{
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(i <= object_->data.cue_sheet.num_tracks);
-			return (bool)::FLAC__metadata_object_cuesheet_insert_blank_track(object_, i);
+			return static_cast<bool>(::FLAC__metadata_object_cuesheet_insert_blank_track(object_, i));
 		}
 
 		bool CueSheet::delete_track(uint32_t i)
 		{
 			FLAC__ASSERT(is_valid());
 			FLAC__ASSERT(i < object_->data.cue_sheet.num_tracks);
-			return (bool)::FLAC__metadata_object_cuesheet_delete_track(object_, i);
+			return static_cast<bool>(::FLAC__metadata_object_cuesheet_delete_track(object_, i));
 		}
 
 		bool CueSheet::is_legal(bool check_cd_da_subset, const char **violation) const
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_cuesheet_is_legal(object_, check_cd_da_subset, violation);
+			return static_cast<bool>(::FLAC__metadata_object_cuesheet_is_legal(object_, check_cd_da_subset, violation));
 		}
 
 		FLAC__uint32 CueSheet::calculate_cddb_id() const
@@ -1245,14 +1244,14 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(is_valid());
 			// We can safely const_cast since copy=true
-			return (bool)::FLAC__metadata_object_picture_set_mime_type(object_, const_cast<char*>(string), /*copy=*/true);
+			return static_cast<bool>(::FLAC__metadata_object_picture_set_mime_type(object_, const_cast<char*>(string), /*copy=*/true));
 		}
 
 		bool Picture::set_description(const FLAC__byte *string)
 		{
 			FLAC__ASSERT(is_valid());
 			// We can safely const_cast since copy=true
-			return (bool)::FLAC__metadata_object_picture_set_description(object_, const_cast<FLAC__byte*>(string), /*copy=*/true);
+			return static_cast<bool>(::FLAC__metadata_object_picture_set_description(object_, const_cast<FLAC__byte*>(string), /*copy=*/true));
 		}
 
 		void Picture::set_width(FLAC__uint32 value) const
@@ -1283,13 +1282,13 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(is_valid());
 			// We can safely const_cast since copy=true
-			return (bool)::FLAC__metadata_object_picture_set_data(object_, const_cast<FLAC__byte*>(data), data_length, /*copy=*/true);
+			return static_cast<bool>(::FLAC__metadata_object_picture_set_data(object_, const_cast<FLAC__byte*>(data), data_length, /*copy=*/true));
 		}
 
 		bool Picture::is_legal(const char **violation)
 		{
-  			FLAC__ASSERT(is_valid());
-  			return (bool)::FLAC__metadata_object_picture_is_legal(object_, violation);
+			FLAC__ASSERT(is_valid());
+			return static_cast<bool>(::FLAC__metadata_object_picture_is_legal(object_, violation));
 		}
 
 
@@ -1313,13 +1312,13 @@ namespace FLAC {
 		bool Unknown::set_data(const FLAC__byte *data, uint32_t length)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_application_set_data(object_, (FLAC__byte*)data, length, true);
+			return static_cast<bool>(::FLAC__metadata_object_application_set_data(object_, const_cast<FLAC__byte*>(data), length, true));
 		}
 
 		bool Unknown::set_data(FLAC__byte *data, uint32_t length, bool copy)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_object_application_set_data(object_, data, length, copy);
+			return static_cast<bool>(::FLAC__metadata_object_application_set_data(object_, data, length, copy));
 		}
 
 
@@ -1460,7 +1459,7 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(0 != filename);
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_simple_iterator_init(iterator_, filename, read_only, preserve_file_stats);
+			return static_cast<bool>(::FLAC__metadata_simple_iterator_init(iterator_, filename, read_only, preserve_file_stats));
 		}
 
 		bool SimpleIterator::is_valid() const
@@ -1477,26 +1476,26 @@ namespace FLAC {
 		bool SimpleIterator::is_writable() const
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_simple_iterator_is_writable(iterator_);
+			return static_cast<bool>(::FLAC__metadata_simple_iterator_is_writable(iterator_));
 		}
 
 		bool SimpleIterator::next()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_simple_iterator_next(iterator_);
+			return static_cast<bool>(::FLAC__metadata_simple_iterator_next(iterator_));
 		}
 
 		bool SimpleIterator::prev()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_simple_iterator_prev(iterator_);
+			return static_cast<bool>(::FLAC__metadata_simple_iterator_prev(iterator_));
 		}
 
 		//@@@@ add to tests
 		bool SimpleIterator::is_last() const
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_simple_iterator_is_last(iterator_);
+			return static_cast<bool>(::FLAC__metadata_simple_iterator_is_last(iterator_));
 		}
 
 		//@@@@ add to tests
@@ -1523,7 +1522,7 @@ namespace FLAC {
 		bool SimpleIterator::get_application_id(FLAC__byte *id)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_simple_iterator_get_application_id(iterator_, id);
+			return static_cast<bool>(::FLAC__metadata_simple_iterator_get_application_id(iterator_, id));
 		}
 
 		Prototype *SimpleIterator::get_block()
@@ -1536,20 +1535,20 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(0 != block);
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_simple_iterator_set_block(iterator_, block->object_, use_padding);
+			return static_cast<bool>(::FLAC__metadata_simple_iterator_set_block(iterator_, block->object_, use_padding));
 		}
 
 		bool SimpleIterator::insert_block_after(Prototype *block, bool use_padding)
 		{
 			FLAC__ASSERT(0 != block);
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_simple_iterator_insert_block_after(iterator_, block->object_, use_padding);
+			return static_cast<bool>(::FLAC__metadata_simple_iterator_insert_block_after(iterator_, block->object_, use_padding));
 		}
 
 		bool SimpleIterator::delete_block(bool use_padding)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_simple_iterator_delete_block(iterator_, use_padding);
+			return static_cast<bool>(::FLAC__metadata_simple_iterator_delete_block(iterator_, use_padding));
 		}
 
 
@@ -1591,8 +1590,8 @@ namespace FLAC {
 			FLAC__ASSERT(0 != filename);
 			FLAC__ASSERT(is_valid());
 			return is_ogg?
-				(bool)::FLAC__metadata_chain_read_ogg(chain_, filename) :
-				(bool)::FLAC__metadata_chain_read(chain_, filename)
+				static_cast<bool>(::FLAC__metadata_chain_read_ogg(chain_, filename)) :
+				static_cast<bool>(::FLAC__metadata_chain_read(chain_, filename))
 			;
 		}
 
@@ -1600,33 +1599,33 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(is_valid());
 			return is_ogg?
-				(bool)::FLAC__metadata_chain_read_ogg_with_callbacks(chain_, handle, callbacks) :
-				(bool)::FLAC__metadata_chain_read_with_callbacks(chain_, handle, callbacks)
+				static_cast<bool>(::FLAC__metadata_chain_read_ogg_with_callbacks(chain_, handle, callbacks)) :
+				static_cast<bool>(::FLAC__metadata_chain_read_with_callbacks(chain_, handle, callbacks))
 			;
 		}
 
 		bool Chain::check_if_tempfile_needed(bool use_padding)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_chain_check_if_tempfile_needed(chain_, use_padding);
+			return static_cast<bool>(::FLAC__metadata_chain_check_if_tempfile_needed(chain_, use_padding));
 		}
 
 		bool Chain::write(bool use_padding, bool preserve_file_stats)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_chain_write(chain_, use_padding, preserve_file_stats);
+			return static_cast<bool>(::FLAC__metadata_chain_write(chain_, use_padding, preserve_file_stats));
 		}
 
 		bool Chain::write(bool use_padding, ::FLAC__IOHandle handle, ::FLAC__IOCallbacks callbacks)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_chain_write_with_callbacks(chain_, use_padding, handle, callbacks);
+			return static_cast<bool>(::FLAC__metadata_chain_write_with_callbacks(chain_, use_padding, handle, callbacks));
 		}
 
 		bool Chain::write(bool use_padding, ::FLAC__IOHandle handle, ::FLAC__IOCallbacks callbacks, ::FLAC__IOHandle temp_handle, ::FLAC__IOCallbacks temp_callbacks)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_chain_write_with_callbacks_and_tempfile(chain_, use_padding, handle, callbacks, temp_handle, temp_callbacks);
+			return static_cast<bool>(::FLAC__metadata_chain_write_with_callbacks_and_tempfile(chain_, use_padding, handle, callbacks, temp_handle, temp_callbacks));
 		}
 
 		void Chain::merge_padding()
@@ -1673,13 +1672,13 @@ namespace FLAC {
 		bool Iterator::next()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_iterator_next(iterator_);
+			return static_cast<bool>(::FLAC__metadata_iterator_next(iterator_));
 		}
 
 		bool Iterator::prev()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_iterator_prev(iterator_);
+			return static_cast<bool>(::FLAC__metadata_iterator_prev(iterator_));
 		}
 
 		::FLAC__MetadataType Iterator::get_block_type() const
@@ -1701,7 +1700,7 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(0 != block);
 			FLAC__ASSERT(is_valid());
-			bool ret = (bool)::FLAC__metadata_iterator_set_block(iterator_, block->object_);
+			bool ret = static_cast<bool>(::FLAC__metadata_iterator_set_block(iterator_, block->object_));
 			if(ret) {
 				block->set_reference(true);
 				delete block;
@@ -1712,14 +1711,14 @@ namespace FLAC {
 		bool Iterator::delete_block(bool replace_with_padding)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__metadata_iterator_delete_block(iterator_, replace_with_padding);
+			return static_cast<bool>(::FLAC__metadata_iterator_delete_block(iterator_, replace_with_padding));
 		}
 
 		bool Iterator::insert_block_before(Prototype *block)
 		{
 			FLAC__ASSERT(0 != block);
 			FLAC__ASSERT(is_valid());
-			bool ret = (bool)::FLAC__metadata_iterator_insert_block_before(iterator_, block->object_);
+			bool ret = static_cast<bool>(::FLAC__metadata_iterator_insert_block_before(iterator_, block->object_));
 			if(ret) {
 				block->set_reference(true);
 				delete block;
@@ -1731,7 +1730,7 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(0 != block);
 			FLAC__ASSERT(is_valid());
-			bool ret = (bool)::FLAC__metadata_iterator_insert_block_after(iterator_, block->object_);
+			bool ret = static_cast<bool>(::FLAC__metadata_iterator_insert_block_after(iterator_, block->object_));
 			if(ret) {
 				block->set_reference(true);
 				delete block;
@@ -1739,5 +1738,5 @@ namespace FLAC {
 			return ret;
 		}
 
-	}
-}
+	} // namespace Metadata
+} // namespace FLAC

--- a/src/libFLAC++/stream_decoder.cpp
+++ b/src/libFLAC++/stream_decoder.cpp
@@ -71,49 +71,49 @@ namespace FLAC {
 		bool Stream::set_ogg_serial_number(long value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_set_ogg_serial_number(decoder_, value);
+			return static_cast<bool>(::FLAC__stream_decoder_set_ogg_serial_number(decoder_, value));
 		}
 
 		bool Stream::set_md5_checking(bool value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_set_md5_checking(decoder_, value);
+			return static_cast<bool>(::FLAC__stream_decoder_set_md5_checking(decoder_, value));
 		}
 
 		bool Stream::set_metadata_respond(::FLAC__MetadataType type)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_set_metadata_respond(decoder_, type);
+			return static_cast<bool>(::FLAC__stream_decoder_set_metadata_respond(decoder_, type));
 		}
 
 		bool Stream::set_metadata_respond_application(const FLAC__byte id[4])
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_set_metadata_respond_application(decoder_, id);
+			return static_cast<bool>(::FLAC__stream_decoder_set_metadata_respond_application(decoder_, id));
 		}
 
 		bool Stream::set_metadata_respond_all()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_set_metadata_respond_all(decoder_);
+			return static_cast<bool>(::FLAC__stream_decoder_set_metadata_respond_all(decoder_));
 		}
 
 		bool Stream::set_metadata_ignore(::FLAC__MetadataType type)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_set_metadata_ignore(decoder_, type);
+			return static_cast<bool>(::FLAC__stream_decoder_set_metadata_ignore(decoder_, type));
 		}
 
 		bool Stream::set_metadata_ignore_application(const FLAC__byte id[4])
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_set_metadata_ignore_application(decoder_, id);
+			return static_cast<bool>(::FLAC__stream_decoder_set_metadata_ignore_application(decoder_, id));
 		}
 
 		bool Stream::set_metadata_ignore_all()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_set_metadata_ignore_all(decoder_);
+			return static_cast<bool>(::FLAC__stream_decoder_set_metadata_ignore_all(decoder_));
 		}
 
 		Stream::State Stream::get_state() const
@@ -125,7 +125,7 @@ namespace FLAC {
 		bool Stream::get_md5_checking() const
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_get_md5_checking(decoder_);
+			return static_cast<bool>(::FLAC__stream_decoder_get_md5_checking(decoder_));
 		}
 
 		FLAC__uint64 Stream::get_total_samples() const
@@ -185,49 +185,49 @@ namespace FLAC {
 		bool Stream::finish()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_finish(decoder_);
+			return static_cast<bool>(::FLAC__stream_decoder_finish(decoder_));
 		}
 
 		bool Stream::flush()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_flush(decoder_);
+			return static_cast<bool>(::FLAC__stream_decoder_flush(decoder_));
 		}
 
 		bool Stream::reset()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_reset(decoder_);
+			return static_cast<bool>(::FLAC__stream_decoder_reset(decoder_));
 		}
 
 		bool Stream::process_single()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_process_single(decoder_);
+			return static_cast<bool>(::FLAC__stream_decoder_process_single(decoder_));
 		}
 
 		bool Stream::process_until_end_of_metadata()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_process_until_end_of_metadata(decoder_);
+			return static_cast<bool>(::FLAC__stream_decoder_process_until_end_of_metadata(decoder_));
 		}
 
 		bool Stream::process_until_end_of_stream()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_process_until_end_of_stream(decoder_);
+			return static_cast<bool>(::FLAC__stream_decoder_process_until_end_of_stream(decoder_));
 		}
 
 		bool Stream::skip_single_frame()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_skip_single_frame(decoder_);
+			return static_cast<bool>(::FLAC__stream_decoder_skip_single_frame(decoder_));
 		}
 
 		bool Stream::seek_absolute(FLAC__uint64 sample)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_decoder_seek_absolute(decoder_, sample);
+			return static_cast<bool>(::FLAC__stream_decoder_seek_absolute(decoder_, sample));
 		}
 
 		::FLAC__StreamDecoderSeekStatus Stream::seek_callback(FLAC__uint64 absolute_byte_offset)
@@ -390,5 +390,5 @@ namespace FLAC {
 			return ::FLAC__STREAM_DECODER_READ_STATUS_ABORT; // double protection
 		}
 
-	}
-}
+	} // namespace Decoder
+} // namespace FLAC

--- a/src/libFLAC++/stream_encoder.cpp
+++ b/src/libFLAC++/stream_encoder.cpp
@@ -72,127 +72,127 @@ namespace FLAC {
 		bool Stream::set_ogg_serial_number(long value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_ogg_serial_number(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_ogg_serial_number(encoder_, value));
 		}
 
 		bool Stream::set_verify(bool value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_verify(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_verify(encoder_, value));
 		}
 
 		bool Stream::set_streamable_subset(bool value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_streamable_subset(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_streamable_subset(encoder_, value));
 		}
 
 		bool Stream::set_channels(uint32_t value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_channels(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_channels(encoder_, value));
 		}
 
 		bool Stream::set_bits_per_sample(uint32_t value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_bits_per_sample(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_bits_per_sample(encoder_, value));
 		}
 
 		bool Stream::set_sample_rate(uint32_t value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_sample_rate(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_sample_rate(encoder_, value));
 		}
 
 		bool Stream::set_compression_level(uint32_t value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_compression_level(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_compression_level(encoder_, value));
 		}
 
 		bool Stream::set_blocksize(uint32_t value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_blocksize(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_blocksize(encoder_, value));
 		}
 
 		bool Stream::set_do_mid_side_stereo(bool value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_do_mid_side_stereo(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_do_mid_side_stereo(encoder_, value));
 		}
 
 		bool Stream::set_loose_mid_side_stereo(bool value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_loose_mid_side_stereo(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_loose_mid_side_stereo(encoder_, value));
 		}
 
 		bool Stream::set_apodization(const char *specification)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_apodization(encoder_, specification);
+			return static_cast<bool>(::FLAC__stream_encoder_set_apodization(encoder_, specification));
 		}
 
 		bool Stream::set_max_lpc_order(uint32_t value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_max_lpc_order(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_max_lpc_order(encoder_, value));
 		}
 
 		bool Stream::set_qlp_coeff_precision(uint32_t value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_qlp_coeff_precision(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_qlp_coeff_precision(encoder_, value));
 		}
 
 		bool Stream::set_do_qlp_coeff_prec_search(bool value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_do_qlp_coeff_prec_search(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_do_qlp_coeff_prec_search(encoder_, value));
 		}
 
 		bool Stream::set_do_escape_coding(bool value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_do_escape_coding(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_do_escape_coding(encoder_, value));
 		}
 
 		bool Stream::set_do_exhaustive_model_search(bool value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_do_exhaustive_model_search(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_do_exhaustive_model_search(encoder_, value));
 		}
 
 		bool Stream::set_min_residual_partition_order(uint32_t value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_min_residual_partition_order(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_min_residual_partition_order(encoder_, value));
 		}
 
 		bool Stream::set_max_residual_partition_order(uint32_t value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_max_residual_partition_order(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_max_residual_partition_order(encoder_, value));
 		}
 
 		bool Stream::set_rice_parameter_search_dist(uint32_t value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_rice_parameter_search_dist(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_rice_parameter_search_dist(encoder_, value));
 		}
 
 		bool Stream::set_total_samples_estimate(FLAC__uint64 value)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_total_samples_estimate(encoder_, value);
+			return static_cast<bool>(::FLAC__stream_encoder_set_total_samples_estimate(encoder_, value));
 		}
 
 		bool Stream::set_metadata(::FLAC__StreamMetadata **metadata, uint32_t num_blocks)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_set_metadata(encoder_, metadata, num_blocks);
+			return static_cast<bool>(::FLAC__stream_encoder_set_metadata(encoder_, metadata, num_blocks));
 		}
 
 		bool Stream::set_metadata(FLAC::Metadata::Prototype **metadata, uint32_t num_blocks)
@@ -212,11 +212,11 @@ namespace FLAC {
 			}
 #ifndef HAVE_CXX_VARARRAYS
 			// complete the hack
-			const bool ok = (bool)::FLAC__stream_encoder_set_metadata(encoder_, m, num_blocks);
+			const bool ok = static_cast<bool>(::FLAC__stream_encoder_set_metadata(encoder_, m, num_blocks));
 			delete [] m;
 			return ok;
 #else
-			return (bool)::FLAC__stream_encoder_set_metadata(encoder_, m, num_blocks);
+			return static_cast<bool>(::FLAC__stream_encoder_set_metadata(encoder_, m, num_blocks));
 #endif
 		}
 
@@ -241,25 +241,25 @@ namespace FLAC {
 		bool Stream::get_verify() const
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_get_verify(encoder_);
+			return static_cast<bool>(::FLAC__stream_encoder_get_verify(encoder_));
 		}
 
 		bool Stream::get_streamable_subset() const
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_get_streamable_subset(encoder_);
+			return static_cast<bool>(::FLAC__stream_encoder_get_streamable_subset(encoder_));
 		}
 
 		bool Stream::get_do_mid_side_stereo() const
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_get_do_mid_side_stereo(encoder_);
+			return static_cast<bool>(::FLAC__stream_encoder_get_do_mid_side_stereo(encoder_));
 		}
 
 		bool Stream::get_loose_mid_side_stereo() const
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_get_loose_mid_side_stereo(encoder_);
+			return static_cast<bool>(::FLAC__stream_encoder_get_loose_mid_side_stereo(encoder_));
 		}
 
 		uint32_t Stream::get_channels() const
@@ -301,19 +301,19 @@ namespace FLAC {
 		bool Stream::get_do_qlp_coeff_prec_search() const
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_get_do_qlp_coeff_prec_search(encoder_);
+			return static_cast<bool>(::FLAC__stream_encoder_get_do_qlp_coeff_prec_search(encoder_));
 		}
 
 		bool Stream::get_do_escape_coding() const
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_get_do_escape_coding(encoder_);
+			return static_cast<bool>(::FLAC__stream_encoder_get_do_escape_coding(encoder_));
 		}
 
 		bool Stream::get_do_exhaustive_model_search() const
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_get_do_exhaustive_model_search(encoder_);
+			return static_cast<bool>(::FLAC__stream_encoder_get_do_exhaustive_model_search(encoder_));
 		}
 
 		uint32_t Stream::get_min_residual_partition_order() const
@@ -355,19 +355,19 @@ namespace FLAC {
 		bool Stream::finish()
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_finish(encoder_);
+			return static_cast<bool>(::FLAC__stream_encoder_finish(encoder_));
 		}
 
 		bool Stream::process(const FLAC__int32 * const buffer[], uint32_t samples)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_process(encoder_, buffer, samples);
+			return static_cast<bool>(::FLAC__stream_encoder_process(encoder_, buffer, samples));
 		}
 
 		bool Stream::process_interleaved(const FLAC__int32 buffer[], uint32_t samples)
 		{
 			FLAC__ASSERT(is_valid());
-			return (bool)::FLAC__stream_encoder_process_interleaved(encoder_, buffer, samples);
+			return static_cast<bool>(::FLAC__stream_encoder_process_interleaved(encoder_, buffer, samples));
 		}
 
 		::FLAC__StreamEncoderReadStatus Stream::read_callback(FLAC__byte buffer[], size_t *bytes)
@@ -512,5 +512,5 @@ namespace FLAC {
 			instance->progress_callback(bytes_written, samples_written, frames_written, total_frames_estimate);
 		}
 
-	}
-}
+	} // namespace Encoder
+} // namespace FLAC


### PR DESCRIPTION
Applied the following suggestions:

modernize-use-auto
modernize-use-equals-default
modernize-deprecated-headers
google-readability-casting
google-readability-namespace-comments
readability-else-after-return