### PR TITLE
configure.ac: check for sys/auxv.h before defining FLAC__CPU_PPC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -144,7 +144,7 @@ case "$host_cpu" in
 	powerpc64|powerpc64le)
 		cpu_ppc64=true
 		cpu_ppc=true
-		AC_DEFINE(FLAC__CPU_PPC)
+		AC_CHECK_HEADER(sys/auxv.h, AC_DEFINE(FLAC__CPU_PPC))
 		AH_TEMPLATE(FLAC__CPU_PPC, [define if building for PowerPC])
 		AC_DEFINE(FLAC__CPU_PPC64)
 		AH_TEMPLATE(FLAC__CPU_PPC64, [define if building for PowerPC64])
@@ -152,7 +152,7 @@ case "$host_cpu" in
 		;;
 	powerpc|powerpcle)
 		cpu_ppc=true
-		AC_DEFINE(FLAC__CPU_PPC)
+		AC_CHECK_HEADER(sys/auxv.h, AC_DEFINE(FLAC__CPU_PPC))
 		AH_TEMPLATE(FLAC__CPU_PPC, [define if building for PowerPC])
 		asm_optimisation=$asm_opt
 		;;


### PR DESCRIPTION
Signed-off-by: Peter Seiderer <ps.report@gmx.net>
---
Note: One of the buildroot autobuilder provided powerpc toolchains
seem to not provide the sys/auxv.h header file, resulting in a
compile failure (see [1] for details).

[1] http://lists.busybox.net/pipermail/buildroot/2019-September/259732.html