### PR TITLE
cmake: fix nasm sources build when building in a separate directory

### DIFF
--- a/src/libFLAC/ia32/CMakeLists.txt
+++ b/src/libFLAC/ia32/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.9)
 
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
+#include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
+add_compile_options(-I${CMAKE_CURRENT_SOURCE_DIR}/)
 
 if(APPLE)
     add_compile_options(-dOBJ_FORMAT_macho)


### PR DESCRIPTION
When building in the same directory as the source, it works, but not in
a separate directory.  The trailing slash is important with nasm.  Note
that: include_directories("${CMAKE_CURRENT_SOURCE_DIR}/") does not work
because cmake seems to strip the trailing slash.

Also relax the cmake version requirement from 3.12 to 3.9 as everywhere
else in the tree: it works just fine.