### PR TITLE
libFLAC/stream_decoder.c: fix integer overflow on corrupt file

### DIFF
--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -1628,6 +1628,8 @@ FLAC__bool read_metadata_streaminfo_(FLAC__StreamDecoder *decoder, FLAC__bool is
 
 	/* skip the rest of the block */
 	FLAC__ASSERT(used_bits % 8 == 0);
+	if (length < (used_bits / 8))
+		return false; /* read_callback_ sets the state for us */
 	length -= (used_bits / 8);
 	if(!FLAC__bitreader_skip_byte_block_aligned_no_crc(decoder->private_->input, length))
 		return false; /* read_callback_ sets the state for us */


### PR DESCRIPTION
Corrupt metadata could make the length calculation overflow.

This issue was found when reading a corrupt flac file when ubsan (undefined behaviour sanitizer) is enabled for the compiler.
