### PR TITLE
flac/main.c: replace an snprintf() call with flac_snprintf()

### DIFF
--- a/src/flac/main.c
+++ b/src/flac/main.c
@@ -1933,7 +1933,7 @@ int encode_file(const char *infilename, FLAC__bool is_first_file, FLAC__bool is_
 			conditional_fclose(encode_infile);
 			return 1;
 		}
-		snprintf(internal_outfilename, dest_len, "%s%s", outfilename, tmp_suffix);
+		flac_snprintf(internal_outfilename, dest_len, "%s%s", outfilename, tmp_suffix);
 	}
 
 	if(input_format == FORMAT_RAW) {


### PR DESCRIPTION
flac_snprintf() is used everywhere else in there. that single instance
of plain snprintf() was added in commit 04974d27. fixes flac.exe build
with older msvc versions.