### PR TITLE
cmake_minimum_required() cleanup:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required(VERSION 3.9)
+# 3.1 is OK for most parts. However:
+# 3.3 is needed in src/libFLAC
+# 3.5 is needed in src/libFLAC/ia32
+# 3.9 is needed in 'doc' because of doxygen_add_docs()
+cmake_minimum_required(VERSION 3.5)
 
 if(NOT (CMAKE_BUILD_TYPE OR CMAKE_CONFIGURATION_TYPES OR DEFINED ENV{CFLAGS} OR DEFINED ENV{CXXFLAGS}))
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo")
@@ -10,6 +14,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 option(BUILD_CXXLIBS "Build libFLAC++" ON)
 option(BUILD_EXAMPLES "Build and install examples" ON)
+option(BUILD_DOCS "Build and install doxygen documents" ON)
 option(WITH_OGG "ogg support (default: test for libogg)" ON)
 
 if(WITH_OGG)
@@ -93,9 +98,11 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug OR CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)
     add_definitions(-DFLAC__OVERFLOW_DETECT)
 endif()
 
-add_subdirectory("doc")
 add_subdirectory("src")
 add_subdirectory("microbench")
+if(BUILD_DOCS)
+    add_subdirectory("doc")
+endif()
 if(BUILD_EXAMPLES)
     add_subdirectory("examples")
 endif()

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.9)
+
 find_package(Doxygen)
 
 if (NOT DOXYGEN_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.0)
-
 option(ENABLE_64_BIT_WORDS "Set FLAC__BYTES_PER_WORD to 8 (4 is the default)" OFF)
 option(WITH_XMMS "Build XMMS plugin" OFF)
 
@@ -18,7 +16,6 @@ if(WITH_XMMS)
     add_subdirectory("plugin_common")
     add_subdirectory("plugin_xmms")
 endif()
-
 if(BUILD_TESTING)
     add_subdirectory("test_libs_common")
     add_subdirectory("test_libFLAC")

--- a/src/libFLAC/CMakeLists.txt
+++ b/src/libFLAC/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.0)
-
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "[xX]86(_64)?|(AMD|amd)64|i[346]86")
     option(WITH_AVX "Enable AVX, AVX2 optimizations" ON)
 endif()

--- a/src/libFLAC/ia32/CMakeLists.txt
+++ b/src/libFLAC/ia32/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.9)
-
 #include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 add_compile_options(-I${CMAKE_CURRENT_SOURCE_DIR}/)
 


### PR DESCRIPTION
- document version requirements in the top-level file.
- remove incorrect version requirements from sub-dirs.
- set min. required version to 3.5 in top-level file.
- set minimun required version to 3.9 under docs/ .
- make documents building an option (on by default.)
  so, the tree can be built using cmake-3.5 using
 -DBUILD_DOCS=0 on the command line.