### PR TITLE
cmake/configure.ac: Enable -fstack-protector-strong by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 option(BUILD_CXXLIBS "Build libFLAC++" ON)
 option(BUILD_EXAMPLES "Build and install examples" ON)
 option(BUILD_DOCS "Build and install doxygen documents" ON)
+option(WITH_STACK_PROTECTOR "Enable GNU GCC stack smash protection" ON)
 option(WITH_OGG "ogg support (default: test for libogg)" ON)
 
 if(WITH_OGG)
@@ -24,8 +25,6 @@ endif()
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wstrict-prototypes -Wmissing-prototypes -Waggregate-return -Wcast-align -Wnested-externs -Wshadow -Wundef -Wmissing-declarations -Winline")
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -funroll-loops")
-
-    option(ENABLE_SSP "Enable GNU GCC stack smash protection" OFF)
 endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wcast-align -Wshadow -Wwrite-strings -Wctor-dtor-privacy -Wnon-virtual-dtor -Wreorder -Wsign-promo -Wundef")
@@ -62,9 +61,14 @@ test_big_endian(CPU_IS_BIG_ENDIAN)
 
 check_c_compiler_flag(-Werror HAVE_WERROR_FLAG)
 check_c_compiler_flag(-Wdeclaration-after-statement HAVE_DECL_AFTER_STMT_FLAG)
-check_c_compiler_flag("-fstack-protector --param ssp-buffer-size=4" HAVE_SSP_FLAG)
 check_c_compiler_flag(-mstackrealign HAVE_STACKREALIGN_FLAG)
 check_cxx_compiler_flag(-Weffc++ HAVE_WEFFCXX_FLAG)
+
+if(WITH_STACK_PROTECTOR)
+  if(NOT MSVC)
+    check_c_compiler_flag("-fstack-protector-strong" HAVE_STACK_PROTECTOR_FLAG)
+  endif()
+endif()
 
 if(HAVE_WERROR_FLAG)
     option(ENABLE_WERROR "Enable -Werror in all Makefiles" OFF)
@@ -74,11 +78,12 @@ add_compile_options(
     $<$<BOOL:${MSVC}>:/wd4267>
     $<$<BOOL:${MSVC}>:/wd4996>
     $<$<BOOL:${ENABLE_WERROR}>:-Werror>
-    $<$<AND:$<BOOL:${HAVE_SSP_FLAG}>,$<BOOL:${ENABLE_SSP}>>:-fstack-protector>
-    $<$<AND:$<BOOL:${HAVE_SSP_FLAG}>,$<BOOL:${ENABLE_SSP}>>:--param>
-    $<$<AND:$<BOOL:${HAVE_SSP_FLAG}>,$<BOOL:${ENABLE_SSP}>>:ssp-buffer-size=4>
     $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<BOOL:${HAVE_WEFFCXX_FLAG}>>:-Weffc++>
     $<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:${HAVE_DECL_AFTER_STMT_FLAG}>>:-Wdeclaration-after-statement>)
+
+if(HAVE_STACK_PROTECTOR_FLAG)
+    add_compile_options(-fstack-protector-strong)
+endif()
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "i686" AND HAVE_STACKREALIGN_FLAG)
     add_compile_options(-mstackrealign)

--- a/configure.ac
+++ b/configure.ac
@@ -310,8 +310,10 @@ AC_SUBST(FLAC__TEST_LEVEL)
 AC_ARG_ENABLE(werror,
 	AC_HELP_STRING([--enable-werror], [Enable -Werror in all Makefiles]))
 
-AC_ARG_ENABLE(stack-smash-protection,
-	AC_HELP_STRING([--enable-stack-smash-protection], [Enable GNU GCC stack smash protection]))
+AC_ARG_ENABLE([stack-smash-protection],
+    [AS_HELP_STRING([--disable-stack-smash-protection],[Disable GNU GCC stack smash protection])],,
+    [AS_IF([test "$ac_cv_c_compiler_gnu" = "yes" && test "$os_is_windows" = "no"],
+        [enable_stack_smash_protection=yes],[enable_stack_smash_protection=no])])
 
 AC_ARG_ENABLE(64-bit-words,
 	AC_HELP_STRING([--enable-64-bit-words], [Set FLAC__BYTES_PER_WORD to 8 (4 is the default)]))
@@ -627,5 +629,6 @@ fi
 	echo "    SSE optimizations : ....................... ${sse_os}"
 	echo "    Asm optimizations : ....................... ${asm_optimisation}"
 	echo "    Ogg/FLAC support : ........................ ${have_ogg}"
+	echo "    Stack protector  : ........................ ${enable_stack_smash_protection}"
 	echo "    Fuzzing support (Clang only) : ............ ${have_oss_fuzzers}"
 echo

--- a/m4/stack_protect.m4
+++ b/m4/stack_protect.m4
@@ -27,7 +27,7 @@ dnl LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 dnl NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 dnl SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-dnl Want to know of GCC stack protector works, botfor the C and for the C++
+dnl We want to know if GCC stack protector works, for the C and for the C++
 dnl compiler.
 dnl
 dnl Just checking if the compiler accepts the required CFLAGSs is not enough
@@ -41,7 +41,7 @@ AC_DEFUN([XIPH_GCC_STACK_PROTECTOR],
 [AC_LANG_ASSERT(C)
 	AC_MSG_CHECKING([if $CC supports stack smash protection])
 	xiph_stack_check_old_cflags="$CFLAGS"
-	SSP_FLAGS="-fstack-protector --param ssp-buffer-size=4"
+	SSP_FLAGS="-fstack-protector-strong"
 	CFLAGS=$SSP_FLAGS
 	AC_TRY_LINK([
 			#include <stdio.h>
@@ -58,7 +58,7 @@ AC_DEFUN([XIPH_GXX_STACK_PROTECTOR],
 [AC_LANG_PUSH([C++])
 	AC_MSG_CHECKING([if $CXX supports stack smash protection])
 	xiph_stack_check_old_cflags="$CFLAGS"
-	SSP_FLAGS="-fstack-protector --param ssp-buffer-size=4"
+	SSP_FLAGS="-fstack-protector-strong"
 	CFLAGS=$SSP_FLAGS
 	AC_TRY_LINK([
 			#include <cstdio>


### PR DESCRIPTION
Windows is excluded from this (MSVC in CMake).

If the general idea is accepted, I'll test across systems and clean up any fuzz.