### PR TITLE
lib.mk: Remove incorrect u flag from ar

### DIFF
--- a/build/lib.mk
+++ b/build/lib.mk
@@ -38,7 +38,7 @@ ifeq ($(CC),gcc)
     GCC_INLINE  = -finline-functions
 endif
 NASM        = nasm
-LINK        = ar cru
+LINK        = ar cr
 OBJPATH     = $(topdir)/objs
 LIBPATH     = $(OBJPATH)/$(BUILD)/lib
 DEBUG_LIBPATH     = $(OBJPATH)/debug/lib


### PR DESCRIPTION
We work in deterministic mode by default, so timestamps are zeroed, thus it is impossible to check timestamps and insert only newer members. Silences the following autotools warning:

ar: `u' modifier ignored since `D' is the default (see `U')

https://sourceware.org/binutils/docs/binutils/ar-cmdline.html