### PR TITLE
libFLAC/bitwriter.c: Add sanity check to prevent excessive allocation

### DIFF
--- a/src/libFLAC/bitwriter.c
+++ b/src/libFLAC/bitwriter.c
@@ -107,6 +107,10 @@ FLAC__bool bitwriter_grow_(FLAC__BitWriter *bw, uint32_t bits_to_add)
 	FLAC__ASSERT(0 != bw);
 	FLAC__ASSERT(0 != bw->buffer);
 
+	/* sanity check */
+	if (bits_to_add > 16 * 1024 * 1024)
+		return false;
+
 	/* calculate total words needed to store 'bits_to_add' additional bits */
 	new_capacity = bw->words + ((bw->bits + bits_to_add + FLAC__BITS_PER_WORD - 1) / FLAC__BITS_PER_WORD);
 


### PR DESCRIPTION
When fuzzing the encoder it is possible to cause the encoder to
allocate huge amounts of memory. Sanity check for the number of
bits to grow the bitwrite capacity and returning false (indicating
memory allocation failed) prevents this and seems to have no effect
in the encoding of non-fuzzing inputs.

Credit: Oss-Fuzz
Issue: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=17273
Testcase: fuzzer_encoder-5640245298593792