### PR TITLE
Fixed error condition processing

### DIFF
--- a/examples/c/encode/file/main.c
+++ b/examples/c/encode/file/main.c
@@ -110,10 +110,11 @@ int main(int argc, char *argv[])
 			fprintf(stderr, "ERROR: out of memory or tag error\n");
 			ok = false;
 		}
+		else {
+			metadata[1]->length = 1234; /* set the padding length */
 
-		metadata[1]->length = 1234; /* set the padding length */
-
-		ok = FLAC__stream_encoder_set_metadata(encoder, metadata, 2);
+			ok = FLAC__stream_encoder_set_metadata(encoder, metadata, 2);
+		}
 	}
 
 	/* initialize encoder */

--- a/examples/cpp/encode/file/main.cpp
+++ b/examples/cpp/encode/file/main.cpp
@@ -118,10 +118,11 @@ int main(int argc, char *argv[])
 			fprintf(stderr, "ERROR: out of memory or tag error\n");
 			ok = false;
 		}
+		else {
+			metadata[1]->length = 1234; /* set the padding length */
 
-		metadata[1]->length = 1234; /* set the padding length */
-
-		ok = encoder.set_metadata(metadata, 2);
+			ok = encoder.set_metadata(metadata, 2);
+		}
 	}
 
 	/* initialize encoder */


### PR DESCRIPTION
Value of variable `ok` was always overwritten with result of `encoder.set_metadata(metadata, 2)` so it may never set to `false` here.