### PR TITLE
Variable removed from expression because it's always equals to false

### DIFF
--- a/src/flac/encode.c
+++ b/src/flac/encode.c
@@ -223,7 +223,7 @@ static FLAC__bool get_sample_info_wave(EncoderSession *e, encode_options_t optio
 				flac__utils_printf(stderr, 1, "%s: ERROR: file has multiple 'ds64' chunks\n", e->inbasefilename);
 				return false;
 			}
-			if(got_fmt_chunk || got_data_chunk) {
+			if(got_fmt_chunk) {
 				flac__utils_printf(stderr, 1, "%s: ERROR: 'ds64' chunk appears after 'fmt ' or 'data' chunk\n", e->inbasefilename);
 				return false;
 			}


### PR DESCRIPTION
Variable `got_data_chunk` was already checked at line https://github.com/xiph/flac/blob/6455e477218360899c55f8dbd06c6628260d4123/src/flac/encode.c#L207
then it must be always false at this line https://github.com/xiph/flac/blob/6455e477218360899c55f8dbd06c6628260d4123/src/flac/encode.c#L226 so it can be safely removed.