### PR TITLE
Removed useless comparison

### DIFF
--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -3317,7 +3317,7 @@ FLAC__bool seek_to_absolute_sample_ogg_(FLAC__StreamDecoder *decoder, FLAC__uint
 					}
 					left_pos = pos;
 				}
-				else if(this_frame_sample > target_sample) {
+				else {
 					right_sample = this_frame_sample;
 					/* sanity check to avoid infinite loop */
 					if (right_pos == pos) {


### PR DESCRIPTION
Line https://github.com/xiph/flac/blob/6455e477218360899c55f8dbd06c6628260d4123/src/libFLAC/stream_decoder.c#L3303 have comparison which negative condition equals to https://github.com/xiph/flac/blob/6455e477218360899c55f8dbd06c6628260d4123/src/libFLAC/stream_decoder.c#L3320