### PR TITLE
Fix nullptr dereference in FLAC++

### DIFF
--- a/src/libFLAC++/metadata.cpp
+++ b/src/libFLAC++/metadata.cpp
@@ -55,6 +55,9 @@ namespace FLAC {
 
 			Prototype *construct_block(::FLAC__StreamMetadata *object)
 			{
+				if (0 == object)
+					return 0;
+
 				Prototype *ret = 0;
 				switch(object->type) {
 					case FLAC__METADATA_TYPE_STREAMINFO:


### PR DESCRIPTION
I've encountered a crash due to dereferencing a nullptr when calling `SimpleIterator::get_block()`. It turned out that the C API (`FLAC__metadata_simple_iterator_get_block`) can return null which wasn't propagated through the C++ API. This PR fixes the issue by ensuring that we don't dereference the `FLAC__StreamMetadata` pointer if it's null, in which case the C++ API will return null like the C function. 

I've encountered this issue when trying to open a file that got truncated in the middle of a PICTURE block. 