### PR TITLE
Simplified logic of parsing sizes of rice-partitions

### DIFF
--- a/doc/html/format.html
+++ b/doc/html/format.html
@@ -1737,13 +1737,13 @@
 				Encoded residual.  The number of samples (n) in the partition is determined as follows:<br />
 				<ul>
 				<li>
-					if the partition order is zero, n = frame's blocksize - predictor order
+					partition size = (frame's blocksize / (2^partition order))
 				</li>
 				<li>
-					else if this is not the first partition of the subframe, n = (frame's blocksize / (2^partition order))
+					for first partition of the subframe, n = partition size - predictor
 				</li>
 				<li>
-					else n = (frame's blocksize / (2^partition order)) - predictor order
+					for remaining partitions, n = partition size
 				</li>
 				</ul>
 			</td>
@@ -1816,13 +1816,13 @@
 				Encoded residual.  The number of samples (n) in the partition is determined as follows:<br />
 				<ul>
 				<li>
-					if the partition order is zero, n = frame's blocksize - predictor order
+					partition size = (frame's blocksize / (2^partition order))
 				</li>
 				<li>
-					else if this is not the first partition of the subframe, n = (frame's blocksize / (2^partition order))
+					for first partition of the subframe, n = partition size - predictor
 				</li>
 				<li>
-					else n = (frame's blocksize / (2^partition order)) - predictor order
+					for remaining partitions, n = partition size
 				</li>
 				</ul>
 			</td>

--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -2752,7 +2752,7 @@ FLAC__bool read_residual_partitioned_rice_(FLAC__StreamDecoder *decoder, uint32_
 	int i;
 	uint32_t partition, sample, u;
 	const uint32_t partitions = 1u << partition_order;
-	const uint32_t partition_samples = partition_order > 0? decoder->private_->frame.header.blocksize >> partition_order : decoder->private_->frame.header.blocksize - predictor_order;
+	const uint32_t partition_samples = decoder->private_->frame.header.blocksize >> partition_order;
 	const uint32_t plen = is_extended? FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE2_PARAMETER_LEN : FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE_PARAMETER_LEN;
 	const uint32_t pesc = is_extended? FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE2_ESCAPE_PARAMETER : FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE_ESCAPE_PARAMETER;
 
@@ -2771,7 +2771,7 @@ FLAC__bool read_residual_partitioned_rice_(FLAC__StreamDecoder *decoder, uint32_
 		partitioned_rice_contents->parameters[partition] = rice_parameter;
 		if(rice_parameter < pesc) {
 			partitioned_rice_contents->raw_bits[partition] = 0;
-			u = (partition_order == 0 || partition > 0)? partition_samples : partition_samples - predictor_order;
+			u = (partition == 0) ? partition_samples - predictor_order : partition_samples;
 			if(!FLAC__bitreader_read_rice_signed_block(decoder->private_->input, residual + sample, u, rice_parameter))
 				return false; /* read_callback_ sets the state for us */
 			sample += u;
@@ -2780,7 +2780,7 @@ FLAC__bool read_residual_partitioned_rice_(FLAC__StreamDecoder *decoder, uint32_
 			if(!FLAC__bitreader_read_raw_uint32(decoder->private_->input, &rice_parameter, FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE_RAW_LEN))
 				return false; /* read_callback_ sets the state for us */
 			partitioned_rice_contents->raw_bits[partition] = rice_parameter;
-			for(u = (partition_order == 0 || partition > 0)? 0 : predictor_order; u < partition_samples; u++, sample++) {
+			for(u = (partition == 0)? predictor_order : 0; u < partition_samples; u++, sample++) {
 				if(!FLAC__bitreader_read_raw_int32(decoder->private_->input, &i, rice_parameter))
 					return false; /* read_callback_ sets the state for us */
 				residual[sample] = i;


### PR DESCRIPTION
Tiny change, but simplifies some a definition that I first stumbled on. Also leads to code with less branches.

> if the partition order is zero, n = frame's blocksize - predictor order
> else if this is not the first partition of the subframe,
>   n = (frame's blocksize / (2^partition order))
> else n = (frame's blocksize / (2^partition order)) - predictor order

if the partition order is zero, then partition_number can only be zero
if the partition order is zero, then
  (frame's blocksize / (2^partition order))
  is (frame's blocksize / 1) == frame's blocksize