### PR TITLE
link lm publicly to FLAC

### DIFF
--- a/src/libFLAC/CMakeLists.txt
+++ b/src/libFLAC/CMakeLists.txt
@@ -102,7 +102,7 @@ endif()
 target_include_directories(FLAC INTERFACE
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
-target_link_libraries(FLAC PRIVATE $<$<BOOL:${HAVE_LROUND}>:m>)
+target_link_libraries(FLAC PUBLIC $<$<BOOL:${HAVE_LROUND}>:m>)
 if(TARGET Ogg::ogg)
     target_link_libraries(FLAC PUBLIC Ogg::ogg)
 endif()


### PR DESCRIPTION
without this, cmake compilation of shared library fails with these error:
```
[ 92%] Linking C executable ../../../bin/metaflac
/usr/bin/ld: ../../../lib/libreplaygain_analysis.a(replaygain_analysis.c.o): undefined reference to symbol 'log10@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
```
and
```
[100%] Linking C executable ../../../bin/flac
/usr/bin/ld: ../../../lib/libreplaygain_analysis.a(replaygain_analysis.c.o): undefined reference to symbol 'log10@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
```