### PR TITLE
Integrate Github Actions

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,153 @@
+name: GitHub Actions
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        name:
+          [
+            ubuntu-latest-gcc-autotools,
+            ubuntu-latest-clang-autotools,
+            ubuntu-latest-gcc-cmake,
+            ubuntu-latest-clang-cmake,
+            macos-latest-clang-autotools,
+            macos-latest-clang-cmake,
+            ubuntu-latest-gcc-autotools-64-bit-words,
+            ubuntu-latest-clang-autotools-64-bit-words,
+            ubuntu-latest-gcc-cmake-64-bit-words,
+            ubuntu-latest-clang-cmake-64-bit-words,
+            macos-latest-clang-autotools-64-bit-words,
+            macos-latest-clang-cmake-64-bit-words
+          ]
+        include:
+          - name: ubuntu-latest-gcc-autotools
+            os: ubuntu-latest
+            cc: gcc
+            cxx: g++
+            build-system: autotools
+            configure-opts: ''
+
+          - name: ubuntu-latest-clang-autotools
+            os: ubuntu-latest
+            cc: clang
+            cxx: clang++
+            build-system: autotools
+            configure-opts: ''
+
+          - name: ubuntu-latest-gcc-cmake
+            os: ubuntu-latest
+            cc: gcc
+            cxx: g++
+            build-system: cmake
+            configure-opts: ''
+
+          - name: ubuntu-latest-clang-cmake
+            os: ubuntu-latest
+            cc: clang
+            cxx: clang++
+            build-system: cmake
+            configure-opts: ''
+
+          - name: macos-latest-clang-autotools
+            os: macos-latest
+            cc: clang
+            cxx: clang++
+            build-system: autotools
+            configure-opts: ''
+
+          - name: macos-latest-clang-cmake
+            os: macos-latest
+            cc: clang
+            cxx: clang++
+            build-system: cmake
+            configure-opts: ''
+
+          - name: ubuntu-latest-gcc-autotools-64-bit-words
+            os: ubuntu-latest
+            cc: gcc
+            cxx: g++
+            build-system: autotools
+            configure-opts: --enable-64-bit-words
+
+          - name: ubuntu-latest-clang-autotools-64-bit-words
+            os: ubuntu-latest
+            cc: clang
+            cxx: clang++
+            build-system: autotools
+            configure-opts: --enable-64-bit-words
+
+          - name: ubuntu-latest-gcc-cmake-64-bit-words
+            os: ubuntu-latest
+            cc: gcc
+            cxx: g++
+            build-system: cmake
+            configure-opts: -DENABLE_64_BIT_WORDS=ON
+
+          - name: ubuntu-latest-clang-cmake-64-bit-words
+            os: ubuntu-latest
+            cc: clang
+            cxx: clang++
+            build-system: cmake
+            configure-opts: -DENABLE_64_BIT_WORDS=ON
+
+          - name: macos-latest-clang-autotools-64-bit-words
+            os: macos-latest
+            cc: clang
+            cxx: clang++
+            build-system: autotools
+            configure-opts: --enable-64-bit-words
+
+          - name: macos-latest-clang-cmake-64-bit-words
+            os: macos-latest
+            cc: clang
+            cxx: clang++
+            build-system: cmake
+            configure-opts: -DENABLE_64_BIT_WORDS=ON
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install MacOS dependencies
+        if: startsWith(matrix.os,'macos')
+        run: |
+          brew update
+          brew install automake pkg-config libogg
+
+      - name: Install Lunux dependencies
+        if: startsWith(matrix.os,'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libtool-bin libogg-dev doxygen libxml2-utils w3c-sgml-lib
+
+      - name: Build with Autotools
+        if: startsWith(matrix.build-system,'autotools')
+        env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
+        run: |
+          ./autogen.sh
+          ./configure ${{ matrix.configure-opts }}
+          make
+          make check
+
+      - name: Build with CMake
+        if: startsWith(matrix.build-system,'cmake')
+        env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
+        run: |
+          mkdir cmake-build
+          cd cmake-build
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ${{ matrix.configure-opts }} -DCMAKE_FIND_FRAMEWORK=NEVER
+          cmake --build .
+          ctest -V
+
+      - name: Check documentation
+        if: startsWith(matrix.os,'ubuntu') && startsWith(matrix.build-system,'autotools')
+        run: |
+          xmllint --valid --noout doc/html/*.html;
+          xmllint --valid --noout doc/html/api/*.html;


### PR DESCRIPTION
Travis CI tests are incredible slow. This PR adds [Github Actions](https://help.github.com/en/actions) workflow pipeline to run tests.

Note macOS GCC tests are removed, it seems like [Apple's GCC is actually Clang](https://www.quora.com/Why-does-the-gcc-command-on-MacOS-execute-clang),

Travis CI is not deleted in this PR just to be sure everything works as expected.