### PR TITLE
flacdiff: Add format specifier to prints

### DIFF
--- a/src/utils/flacdiff/main.cpp
+++ b/src/utils/flacdiff/main.cpp
@@ -218,11 +218,11 @@ int main(int argc, char *argv[])
 #endif
 
 	if(argc > 1 && 0 == strcmp(argv[1], "-h")) {
-		printf(usage);
+		printf("%s", usage);
 		return 0;
 	}
 	else if(argc != 3) {
-		fprintf(stderr, usage);
+		fprintf(stderr, "%s", usage);
 		return 255;
 	}
 


### PR DESCRIPTION
printf/fprintf prefer format specifiers rather than variable strings. This isn't crucial to us as no input is processed, so this is just conforming to the compiler. No functional change.

Suppresses the following compiler reported warning:
warning: format not a string literal and no format arguments [-Wformat-security]