### PR TITLE
Add support in the encoder for up to 20 bit sample rates

### DIFF
--- a/doc/html/faq.html
+++ b/doc/html/faq.html
@@ -278,7 +278,7 @@
 		<br />
 		FLAC supports linear PCM samples with a resolution between 4 and 32 bits per sample.  FLAC does not support floating point samples.  In some cases it is possible to losslessly transform samples from an incompatible range to a FLAC-compatible range before encoding.<br />
 		<br />
-		FLAC supports linear sample rates from 1Hz - 655350Hz in 1Hz increments.<br />
+		FLAC supports linear sample rates from 1Hz - 1048575Hz in 1Hz increments.<br />
 		<br />
 		<a name="general__samples_fp"><b>Will FLAC ever support floating-point samples?</b></a><br />
 		<br />

--- a/doc/html/format.html
+++ b/doc/html/format.html
@@ -523,7 +523,7 @@
 				&lt;20&gt;
 			</td>
 			<td>
-				Sample rate in Hz.  Though 20 bits are available, the maximum sample rate is limited by the structure of frame headers to 655350Hz.  Also, a value of 0 is invalid.
+				Sample rate in Hz.  20 bits are available, the maximum sample rate being 1048575Hz.  Also, a value of 0 is invalid.
 			</td>
 		</tr>
 		<tr>

--- a/include/FLAC/format.h
+++ b/include/FLAC/format.h
@@ -125,7 +125,7 @@ extern "C" {
  *  ((2 ^ 16) - 1) * 10; see <A HREF="../format.html">FLAC format</A>
  *  as to why.
  */
-#define FLAC__MAX_SAMPLE_RATE (655350u)
+#define FLAC__MAX_SAMPLE_RATE (1048575u)
 
 /** The maximum LPC order permitted by the format. */
 #define FLAC__MAX_LPC_ORDER (32u)

--- a/src/libFLAC/format.c
+++ b/src/libFLAC/format.c
@@ -218,12 +218,10 @@ FLAC_API FLAC__bool FLAC__format_blocksize_is_subset(uint32_t blocksize, uint32_
 
 FLAC_API FLAC__bool FLAC__format_sample_rate_is_subset(uint32_t sample_rate)
 {
-	if(
-		!FLAC__format_sample_rate_is_valid(sample_rate) ||
-		(
-			sample_rate >= (1u << 16) &&
-			!(sample_rate % 1000 == 0 || sample_rate % 10 == 0)
-		)
+	if( // sample rate is not subset if
+		!FLAC__format_sample_rate_is_valid(sample_rate) || // sample rate is invalid or
+		sample_rate >= ((1u << 16) * 10) || // sample rate is larger then or equal to 655360 or
+		(sample_rate >= (1u << 16) && sample_rate % 10 != 0) //sample rate is >= 65536 and not divisible by 10
 	) {
 		return false;
 	}

--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -853,10 +853,10 @@ static FLAC__StreamEncoderInitStatus init_stream_internal_(
 	encoder->private_->loose_mid_side_stereo_frames = (uint32_t)((double)encoder->protected_->sample_rate * 0.4 / (double)encoder->protected_->blocksize + 0.5);
 #else
 	/* 26214 is the approximate fixed-point equivalent to 0.4 (0.4 * 2^16) */
-	/* sample rate can be up to 655350 Hz, and thus use 20 bits, so we do the multiply&divide by hand */
-	FLAC__ASSERT(FLAC__MAX_SAMPLE_RATE <= 655350);
+	/* sample rate can be up to 1048575 Hz, and thus use 20 bits, so we do the multiply&divide by hand */
+	FLAC__ASSERT(FLAC__MAX_SAMPLE_RATE <= 1048575);
 	FLAC__ASSERT(FLAC__MAX_BLOCK_SIZE <= 65535);
-	FLAC__ASSERT(encoder->protected_->sample_rate <= 655350);
+	FLAC__ASSERT(encoder->protected_->sample_rate <= 1048575);
 	FLAC__ASSERT(encoder->protected_->blocksize <= 65535);
 	encoder->private_->loose_mid_side_stereo_frames = (uint32_t)FLAC__fixedpoint_trunc((((FLAC__uint64)(encoder->protected_->sample_rate) * (FLAC__uint64)(26214)) << 16) / (encoder->protected_->blocksize<<16) + FLAC__FP_ONE_HALF);
 #endif

--- a/src/libFLAC/stream_encoder_framing.c
+++ b/src/libFLAC/stream_encoder_framing.c
@@ -278,7 +278,7 @@ FLAC__bool FLAC__frame_add_header(const FLAC__FrameHeader *header, FLAC__BitWrit
 		default:
 			if(header->sample_rate <= 255000 && header->sample_rate % 1000 == 0)
 				sample_rate_hint = u = 12;
-			else if(header->sample_rate % 10 == 0)
+			else if(header->sample_rate <= 655350 && header->sample_rate % 10 == 0)
 				sample_rate_hint = u = 14;
 			else if(header->sample_rate <= 0xffff)
 				sample_rate_hint = u = 13;

--- a/src/test_libFLAC/format.c
+++ b/src/test_libFLAC/format.c
@@ -65,11 +65,14 @@ static struct {
 	{ 500010 , true , true  },
 	{ 655349 , true , false },
 	{ 655350 , true , true  },
-	{ 655351 , false, false },
-	{ 655360 , false, false },
-	{ 700000 , false, false },
-	{ 700010 , false, false },
-	{ 1000000, false, false },
+	{ 655351 , true , false },
+	{ 655360 , true , false },
+	{ 700000 , true , false },
+	{ 700010 , true , false },
+	{ 705600 , true , false },
+	{ 768000 , true , false },
+	{ 1000000, true , false },
+	{ 1048575, true , false },
 	{ 1100000, false, false }
 };
 


### PR DESCRIPTION
Add support in the encoder for up to full 20 bit sample rates now that many DACs support up to 768kHz. Files produced with these sample rates are already decodable by the reference decoder. Update documentation and tests accordingly.