### PR TITLE
Fix compression ratio display for very small files

### DIFF
--- a/src/flac/encode.c
+++ b/src/flac/encode.c
@@ -2463,13 +2463,13 @@ void encoder_progress_callback(const FLAC__StreamEncoder *encoder, FLAC__uint64 
 
 	const FLAC__uint64 uesize = e->unencoded_size;
 
-	e->progress = e->total_samples_to_encode ? (double)samples_written / (double)e->total_samples_to_encode : 0;
-	e->compression_ratio = (e->progress && uesize) ? (double)e->bytes_written / ((double)uesize * min(1.0, e->progress)) : 0;
-
 	(void)encoder, (void)total_frames_estimate;
 
 	e->bytes_written = bytes_written;
 	e->samples_written = samples_written;
+
+	e->progress = e->total_samples_to_encode ? (double)samples_written / (double)e->total_samples_to_encode : 0;
+	e->compression_ratio = (e->progress && uesize) ? (double)e->bytes_written / ((double)uesize * min(1.0, e->progress)) : 0;
 
 	if(e->total_samples_to_encode > 0 && frames_written - e->old_frames_written > e->stats_frames_interval) {
 		print_stats(e);


### PR DESCRIPTION
Because the compression ratio was calculated before processing
the input of the last frame, it did not include the size of this
last frame. This patch moves the calculation of the compression
ratio after the new input has been processed. Now the compression
ratio on very small files is correctly displayed.