### PR TITLE
Fix possible overflows in stream_encoder.c and analyse.c

### DIFF
--- a/src/flac/analyze.c
+++ b/src/flac/analyze.c
@@ -62,7 +62,7 @@ void flac__analyze_init(analysis_options aopts)
 	}
 }
 
-void flac__analyze_frame(const FLAC__Frame *frame, uint32_t frame_number, FLAC__uint64 frame_offset, uint32_t frame_bytes, analysis_options aopts, FILE *fout)
+void flac__analyze_frame(const FLAC__Frame *frame, uint32_t frame_number, FLAC__uint64 frame_offset, FLAC__uint64 frame_bytes, analysis_options aopts, FILE *fout)
 {
 	const uint32_t channels = frame->header.channels;
 	char outfilename[1024];
@@ -70,7 +70,7 @@ void flac__analyze_frame(const FLAC__Frame *frame, uint32_t frame_number, FLAC__
 	uint32_t i, channel, partitions;
 
 	/* do the human-readable part first */
-	fprintf(fout, "frame=%u\toffset=%" PRIu64 "\tbits=%u\tblocksize=%u\tsample_rate=%u\tchannels=%u\tchannel_assignment=%s\n", frame_number, frame_offset, frame_bytes*8, frame->header.blocksize, frame->header.sample_rate, channels, FLAC__ChannelAssignmentString[frame->header.channel_assignment]);
+	fprintf(fout, "frame=%u\toffset=%" PRIu64 "\tbits=%" PRIu64 "\tblocksize=%u\tsample_rate=%u\tchannels=%u\tchannel_assignment=%s\n", frame_number, frame_offset, frame_bytes*8, frame->header.blocksize, frame->header.sample_rate, channels, FLAC__ChannelAssignmentString[frame->header.channel_assignment]);
 	for(channel = 0; channel < channels; channel++) {
 		const FLAC__Subframe *subframe = frame->subframes+channel;
 		const FLAC__bool is_rice2 = subframe->data.fixed.entropy_coding_method.type == FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE2;

--- a/src/flac/analyze.h
+++ b/src/flac/analyze.h
@@ -26,7 +26,7 @@ typedef struct {
 } analysis_options;
 
 void flac__analyze_init(analysis_options aopts);
-void flac__analyze_frame(const FLAC__Frame *frame, uint32_t frame_number, FLAC__uint64 frame_offset, uint32_t frame_bytes, analysis_options aopts, FILE *fout);
+void flac__analyze_frame(const FLAC__Frame *frame, uint32_t frame_number, FLAC__uint64 frame_offset, FLAC__uint64 frame_bytes, analysis_options aopts, FILE *fout);
 void flac__analyze_finish(analysis_options aopts);
 
 #endif

--- a/src/flac/decode.c
+++ b/src/flac/decode.c
@@ -1007,7 +1007,7 @@ FLAC__StreamDecoderWriteStatus write_callback(const FLAC__StreamDecoder *decoder
 		decoder_session->is_unsigned_samples
 	));
 	uint32_t wide_samples = frame->header.blocksize, wide_sample, sample, channel;
-	uint32_t frame_bytes = 0;
+	FLAC__uint64 frame_bytes = 0;
 
 	static union
 	{	/* The arrays defined within this union are all the same size. */
@@ -1117,7 +1117,7 @@ FLAC__StreamDecoderWriteStatus write_callback(const FLAC__StreamDecoder *decoder
 	if(decoder_session->analysis_mode) {
 		FLAC__uint64 dpos;
 		FLAC__stream_decoder_get_decode_position(decoder_session->decoder, &dpos);
-		frame_bytes = (uint32_t)(dpos-decoder_session->decode_position);
+		frame_bytes = (dpos-decoder_session->decode_position);
 		decoder_session->decode_position = dpos;
 	}
 

--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -4110,13 +4110,14 @@ static inline uint32_t count_rice_bits_in_partition_(
 	const FLAC__int32 *residual
 )
 {
-	uint32_t i, partition_bits =
+	uint32_t i;
+	uint64_t partition_bits =
 		FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE_PARAMETER_LEN + /* actually could end up being FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE2_PARAMETER_LEN but err on side of 16bps */
 		(1+rice_parameter) * partition_samples /* 1 for unary stop bit + rice_parameter for the binary portion */
 	;
 	for(i = 0; i < partition_samples; i++)
 		partition_bits += ( (FLAC__uint32)((residual[i]<<1)^(residual[i]>>31)) >> rice_parameter );
-	return partition_bits;
+	return (uint32_t)(flac_min(partition_bits,(uint32_t)(-1))); // To make sure the return value doesn't overflow
 }
 #else
 static inline uint32_t count_rice_bits_in_partition_(
@@ -4125,15 +4126,15 @@ static inline uint32_t count_rice_bits_in_partition_(
 	const FLAC__uint64 abs_residual_partition_sum
 )
 {
-	return
+	return (uint32_t)(flac_min( // To make sure the return value doesn't overflow
 		FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE_PARAMETER_LEN + /* actually could end up being FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE2_PARAMETER_LEN but err on side of 16bps */
 		(1+rice_parameter) * partition_samples + /* 1 for unary stop bit + rice_parameter for the binary portion */
 		(
 			rice_parameter?
-				(uint32_t)(abs_residual_partition_sum >> (rice_parameter-1)) /* rice_parameter-1 because the real coder sign-folds instead of using a sign bit */
-				: (uint32_t)(abs_residual_partition_sum << 1) /* can't shift by negative number, so reverse */
+				(abs_residual_partition_sum >> (rice_parameter-1)) /* rice_parameter-1 because the real coder sign-folds instead of using a sign bit */
+				: (abs_residual_partition_sum << 1) /* can't shift by negative number, so reverse */
 		)
-		- (partition_samples >> 1)
+		- (partition_samples >> 1),(uint32_t)(-1)));
 		/* -(partition_samples>>1) to subtract out extra contributions to the abs_residual_partition_sum.
 		 * The actual number of bits used is closer to the sum(for all i in the partition) of  abs(residual[i])>>(rice_parameter-1)
 		 * By using the abs_residual_partition sum, we also add in bits in the LSBs that would normally be shifted out.
@@ -4224,7 +4225,10 @@ FLAC__bool set_partitioned_rice_(
 				raw_bits[0] = 0;
 		}
 		parameters[0] = best_rice_parameter;
-		bits_ += best_partition_bits;
+		if(best_partition_bits < UINT_MAX - bits_) // To make sure _bits doesn't overflow
+			bits_ += best_partition_bits;
+		else
+			bits_ = UINT_MAX;
 	}
 	else {
 		uint32_t partition, residual_sample;
@@ -4327,7 +4331,10 @@ FLAC__bool set_partitioned_rice_(
 					raw_bits[partition] = 0;
 			}
 			parameters[partition] = best_rice_parameter;
-			bits_ += best_partition_bits;
+			if(best_partition_bits < UINT_MAX - bits_) // To make sure _bits doesn't overflow
+				bits_ += best_partition_bits;
+			else
+				bits_ = UINT_MAX;
 			residual_sample += partition_samples;
 		}
 	}


### PR DESCRIPTION
Recently I was trying some new approaches to improve FLAC compression, when I stumbled on a possible overflow. The reason this has not come up earlier is because the encoder only hits this point when the estimate of the rice_parameter is very much off.

To trigger this overflow, one has to force rice_parameter to 0 in for example the function evaluate_lpc_subframe in libFLAC/stream_encoder.c. When encoding noisy material, which needs a high rice parameter, it can happen that the return value of that function overflows. When this happens, the wrong order might be picked, and the file blows up to enormous proportions. In my case, about 30 times the size of the original WAV file.

When analysing this problem, I found more or less the same overflow in flac/analyse.c, where in flac__analyse_frame, frame_bytes is multiplied by 8. 

These patches alleviate these problems. Below two links with results

[Graph with sample set 1](http://www.audiograaf.nl/misc_stuff/check-ricebitscalculation-overflow-patch1.pdf)
[Graph with sample set 2](http://www.audiograaf.nl/misc_stuff/check-ricebitscalculation-overflow-patch1.pdf)