### PR TITLE
Fix nasm.h not found when building in x86

### DIFF
--- a/src/libFLAC/ia32/CMakeLists.txt
+++ b/src/libFLAC/ia32/CMakeLists.txt
@@ -1,4 +1,4 @@
-#include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 add_compile_options(-I${CMAKE_CURRENT_SOURCE_DIR}/)
 
 if(APPLE)


### PR DESCRIPTION
The following is the error from compiler:
```
Assembling cpu_asm.nasm
  cmd.exe /D /C "C:\Users\appveyor\AppData\Local\Temp\1\tmp62cb769c16c04b79a2f73246c8ccf95a.cmd"
  "/NASM/nasm.exe" -o "FLAC-asm.dir\Release\cpu_asm.obj" -fwin32 -I"C:\project\lib\flac\include\\" -I"C:\project\lib\flac\_build\Win32\\" -D"CMAKE_INTDIR="Release"" -dOBJ_FORMAT_win32 "C:\project\lib\flac\src\libFLAC\ia32\cpu_asm.nasm"
  C:\project\lib\flac\src\libFLAC\ia32\cpu_asm.nasm:34: fatal: unable to open include file `nasm.h'
```
Closes #220.