### PR TITLE
flac: Work around gcc bug to prevent false unset MD5 signature warning

### DIFF
--- a/src/flac/decode.c
+++ b/src/flac/decode.c
@@ -1305,9 +1305,10 @@ void metadata_callback(const FLAC__StreamDecoder *decoder, const FLAC__StreamMet
 		FLAC__stream_decoder_get_decode_position(decoder, &decoder_session->decode_position);
 
 	if(metadata->type == FLAC__METADATA_TYPE_STREAMINFO) {
+		FLAC__byte emptyMD5[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 		FLAC__uint64 skip, until;
 		decoder_session->got_stream_info = true;
-		decoder_session->has_md5sum = memcmp(metadata->data.stream_info.md5sum, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16);
+		decoder_session->has_md5sum = memcmp(metadata->data.stream_info.md5sum, emptyMD5, 16);
 		decoder_session->bps = metadata->data.stream_info.bits_per_sample;
 		decoder_session->channels = metadata->data.stream_info.channels;
 		decoder_session->sample_rate = metadata->data.stream_info.sample_rate;


### PR DESCRIPTION
A bug beginning in gcc version 9.2 causes strings to get incorrectly stripped when passed directly to memcmp with a zero first byte (1). This bug causes flac -t to fail on any .flac file with a md5 checksum beginning in 00. To work around this bug, the FLAC__byte type is used for an empty md5 sum to prevent a string from being stripped, which is backwards compatible and avoids compile-time checks. This was initially reported back in March 2020, but has seen more light since Ubuntu 19.10 and up ship with gcc 9.2 as the default compiler. A patch has been merged into the master gcc branch (2), but has not been included in any versions as of this commit date.

The initial reporter provided a patch in their bug report (3), which is included in this PR with authorship attributed to the reporter.

(1) https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189
(2) https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=d5803b9876b3d11c93d1a10fabb3fbb1c4a14bd6
(3) https://sourceforge.net/p/flac/bugs/478/

Closes #192.