### PR TITLE
build on GCC/MinGW-w64 using cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ check_c_compiler_flag(-mstackrealign HAVE_STACKREALIGN_FLAG)
 check_cxx_compiler_flag(-Weffc++ HAVE_WEFFCXX_FLAG)
 
 if(WITH_STACK_PROTECTOR)
-  if(NOT MSVC)
+  if(NOT (MSVC OR MINGW))
     check_c_compiler_flag("-fstack-protector-strong" HAVE_STACK_PROTECTOR_FLAG)
   endif()
 endif()

--- a/config.cmake.h.in
+++ b/config.cmake.h.in
@@ -174,7 +174,7 @@
 #define _GNU_SOURCE
 #endif
 
-#ifndef _FORTIFY_SOURCE
+#if !defined(_FORTIFY_SOURCE) && !defined(__MINGW32__)
 #cmakedefine DODEFINE_FORTIFY_SOURCE 2
 #define _FORTIFY_SOURCE DODEFINE_FORTIFY_SOURCE
 #endif


### PR DESCRIPTION
because some MinGW-w64 build may not have stack-protector or FORTIFY enabled.

using `cmake [PATH] -DWITH_OGG=OFF` build successfully after this change.