### PR TITLE
libFLAC/stream_decoder.c: Fix divide by zero error in FLAC__stream_de…

### DIFF
--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -3119,8 +3119,10 @@ FLAC__bool seek_to_absolute_sample_(FLAC__StreamDecoder *decoder, FLAC__uint64 s
 		/* a little less accurate: */
 		if(upper_bound - lower_bound < 0xffffffff)
 			pos = (FLAC__int64)lower_bound + (FLAC__int64)(((target_sample - lower_bound_sample) * (upper_bound - lower_bound)) / (upper_bound_sample - lower_bound_sample)) - approx_bytes_per_frame;
-		else /* @@@ WATCHOUT, ~2TB limit */
-			pos = (FLAC__int64)lower_bound + (FLAC__int64)((((target_sample - lower_bound_sample)>>8) * ((upper_bound - lower_bound)>>8)) / ((upper_bound_sample - lower_bound_sample)>>16)) - approx_bytes_per_frame;
+		else { /* @@@ WATCHOUT, ~2TB limit */
+		        FLAC__uint64 ratio = (1<<16) / (upper_bound_sample - lower_bound_sample);
+			pos = (FLAC__int64)lower_bound + (FLAC__int64)((((target_sample - lower_bound_sample)>>8) * ((upper_bound - lower_bound)>>8) * ratio)) - approx_bytes_per_frame;
+		}
 #endif
 		if(pos >= (FLAC__int64)upper_bound)
 			pos = (FLAC__int64)upper_bound - 1;


### PR DESCRIPTION
…coder_seek_absolute

In stream_decoder.c, there are three equations of finding the position in seek_to_absolute_sample_ function. The third equation i.e. when FLAC__INTEGER_ONLY_LIBRARY is defined and (upper_bound - lower_bound < 0xffffffff), can cause a divide by zero error if (upper_bound_sample - lower_bound_sample) is less than 2^16. This condition can arise due to an invalid seek table.

The fix mitigates the issue and ensures that the 1st equation and the 3rd equation give the same position under this condition.