### PR TITLE
Fix version & requires fields in pkg config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,11 @@ option(INSTALL_PKGCONFIG_MODULES "Install PkgConfig modules" ON)
 option(INSTALL_CMAKE_CONFIG_MODULE "Install CMake package-config module" ON)
 option(WITH_OGG "ogg support (default: test for libogg)" ON)
 
+set(VERSION ${PROJECT_VERSION})
+
 if(WITH_OGG)
     find_package(Ogg REQUIRED)
+    set(OGG_PACKAGE "ogg")
 endif()
 
 find_package(Iconv)


### PR DESCRIPTION
Details:
 - When building with CMake, pkg-config files flac.pc and flac++.pc
   are not updated with Version information. This causes a failure
   when running a configure script in opus-tools
   (https://github.com/xiph/opus-tools).

   Note that OGG_PACKAGE is set to "ogg" exactly as in the configure.ac,
   but it is only set when the building explicitly with libogg.

BTW, I have no idea what libogg is, so this might be an "over-patch". :)