### PR TITLE
Fix building/installing docs with CMake

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -25,7 +25,7 @@ else()
         "${PROJECT_SOURCE_DIR}/include/FLAC"
         "${PROJECT_SOURCE_DIR}/include/FLAC++")
 
-    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html/"
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/html/"
         DESTINATION "${CMAKE_INSTALL_DOCDIR}/html/api")
 
 endif()


### PR DESCRIPTION
Details:
 - During the installation of the package with CMake, it stops
   (via fail) when doc files should be copied. It was caused by
   changing current binary to current source CMake directory.


Note that it could also be solved by copying files from the source to the binary dir in the first place, but I didn't have time to inspect that.