### PR TITLE
Fix encoding of contributor name.

### DIFF
--- a/src/plugin_common/charset.c
+++ b/src/plugin_common/charset.c
@@ -4,7 +4,7 @@
  *
  * Only slightly modified charset.c from:
  *  EasyTAG - Tag editor for MP3 and OGG files
- *  Copyright (C) 1999-2001  Håvard Kvålen <havardk@xmms.org>
+ *  Copyright (C) 1999-2001  HÃ¥vard KvÃ¥len <havardk@xmms.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/plugin_common/charset.h
+++ b/src/plugin_common/charset.h
@@ -5,7 +5,7 @@
  * Only slightly modified charset.h from:
  * charset.h - 2001/12/04
  *  EasyTAG - Tag editor for MP3 and OGG files
- *  Copyright (C) 1999-2001  H蛆ard Kv虱en <havardk@xmms.org>
+ *  Copyright (C) 1999-2001  Håvard Kvålen <havardk@xmms.org>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/plugin_xmms/charset.c
+++ b/src/plugin_xmms/charset.c
@@ -3,7 +3,7 @@
  *
  * Almost from charset.c
  *  EasyTAG - Tag editor for MP3 and OGG files
- *  Copyright (C) 1999-2001  Håvard Kvålen <havardk@xmms.org>
+ *  Copyright (C) 1999-2001  HÃ¥vard KvÃ¥len <havardk@xmms.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/src/plugin_xmms/charset.h
+++ b/src/plugin_xmms/charset.h
@@ -3,7 +3,7 @@
  *
  * Almost from charset.h - 2001/12/04
  *  EasyTAG - Tag editor for MP3 and OGG files
- *  Copyright (C) 1999-2001  H蛆ard Kv虱en <havardk@xmms.org>
+ *  Copyright (C) 1999-2001  Håvard Kvålen <havardk@xmms.org>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/plugin_xmms/locale_hack.h
+++ b/src/plugin_xmms/locale_hack.h
@@ -5,7 +5,7 @@
  * Based on:
  * locale.h - 2000/05/05 13:10 Jerome Couderc
  *  EasyTAG - Tag editor for MP3 and OGG files
- *  Copyright (C) 1999-2001  H蛆ard Kv虱en <havardk@xmms.org>
+ *  Copyright (C) 1999-2001  Håvard Kvålen <havardk@xmms.org>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License


### PR DESCRIPTION
The name of Håvard Kvålen was wrongly encoded.

I came across this while checking which environment variables `flac` evaluates and decided to fix it.
