### PR TITLE
action.yml: Use config Debug in all cmake steps

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -157,7 +157,7 @@ jobs:
           CC: ${{ matrix.cc }}
           CXX: ${{ matrix.cxx }}
         working-directory: cmake-build
-        run: cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ${{ matrix.configure-opts }} -DCMAKE_FIND_FRAMEWORK=NEVER
+        run: cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ${{ matrix.configure-opts }} -DCMAKE_FIND_FRAMEWORK=NEVER
 
       - name: CMake build
         if: startsWith(matrix.build-system,'cmake')
@@ -165,7 +165,7 @@ jobs:
           CC: ${{ matrix.cc }}
           CXX: ${{ matrix.cxx }}
         working-directory: cmake-build
-        run: cmake --build .
+        run: cmake --build . --config Debug
 
       - name: CMake test
         if: startsWith(matrix.build-system,'cmake')


### PR DESCRIPTION
Use `-DCMAKE_BUILD_TYPE=Debug` and specify `--config Debug` explicitly for
the build.