### PR TITLE
Fix size of first frame when using analyze function

### DIFF
--- a/src/flac/decode.c
+++ b/src/flac/decode.c
@@ -348,6 +348,9 @@ FLAC__bool DecoderSession_process(DecoderSession *d)
 			return false;
 	}
 
+	if(d->analysis_mode)
+		FLAC__stream_decoder_get_decode_position(d->decoder, &d->decode_position);
+
 	if(d->abort_flag)
 		return false;
 
@@ -1301,8 +1304,7 @@ void metadata_callback(const FLAC__StreamDecoder *decoder, const FLAC__StreamMet
 {
 	DecoderSession *decoder_session = (DecoderSession*)client_data;
 
-	if(decoder_session->analysis_mode)
-		FLAC__stream_decoder_get_decode_position(decoder, &decoder_session->decode_position);
+	(void)decoder;
 
 	if(metadata->type == FLAC__METADATA_TYPE_STREAMINFO) {
 		FLAC__byte emptyMD5[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};


### PR DESCRIPTION
The size of the first frame was displaying including a PADDING
block, as the decoder position wasn't updated after processing
one such block. The location in the code where the decoder
position is updated has been moved, so a PADDING block does not
get included into the size of the first frame anymore