### PR TITLE
cmake: Fix building tests on Windows

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,15 +6,19 @@ if(NOT UNIX)
     add_test(NAME libFLAC
       COMMAND $<TARGET_FILE:test_libFLAC>
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-    add_test(NAME libFLAC++
-      COMMAND $<TARGET_FILE:test_libFLAC++>
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-    add_test(NAME flac_help
-      COMMAND $<TARGET_FILE:flacapp> --help
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-    add_test(NAME metaflac_help
-      COMMAND $<TARGET_FILE:metaflac> --help
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    if(BUILD_CXXLIBS)
+        add_test(NAME libFLAC++
+          COMMAND $<TARGET_FILE:test_libFLAC++>
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    endif()
+    if(BUILD_PROGRAMS)
+        add_test(NAME flac_help
+          COMMAND $<TARGET_FILE:flacapp> --help
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+        add_test(NAME metaflac_help
+          COMMAND $<TARGET_FILE:metaflac> --help
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    endif()
     return()
 endif()
 


### PR DESCRIPTION
This PR fixes a regression introduced in 10797d58962dc13df5d4772322790754165a3c93. When building tests with either `BUILD_CXXLIBS` and/or `BUILD_PROGRAMS` disabled, a Windows-only branch in CMake script attempted to add tests for these components regardless, and failed.