### PR TITLE
Make it possible to limit minimum bitrate

### DIFF
--- a/include/FLAC++/encoder.h
+++ b/include/FLAC++/encoder.h
@@ -147,6 +147,7 @@ namespace FLAC {
 			virtual bool set_total_samples_estimate(FLAC__uint64 value);    ///< See FLAC__stream_encoder_set_total_samples_estimate()
 			virtual bool set_metadata(::FLAC__StreamMetadata **metadata, uint32_t num_blocks);    ///< See FLAC__stream_encoder_set_metadata()
 			virtual bool set_metadata(FLAC::Metadata::Prototype **metadata, uint32_t num_blocks); ///< See FLAC__stream_encoder_set_metadata()
+			virtual bool set_limit_min_bitrate(bool value);                 ///< See FLAC__stream_encoder_set_limit_min_bitrate()
 
 			/* get_state() is not virtual since we want subclasses to be able to return their own state */
 			State get_state() const;                                   ///< See FLAC__stream_encoder_get_state()
@@ -169,6 +170,7 @@ namespace FLAC {
 			virtual uint32_t get_max_residual_partition_order() const; ///< See FLAC__stream_encoder_get_max_residual_partition_order()
 			virtual uint32_t get_rice_parameter_search_dist() const;   ///< See FLAC__stream_encoder_get_rice_parameter_search_dist()
 			virtual FLAC__uint64 get_total_samples_estimate() const;   ///< See FLAC__stream_encoder_get_total_samples_estimate()
+			virtual bool     get_limit_min_bitrate() const;            ///< See FLAC__stream_encoder_get_limit_min_bitrate()
 
 			virtual ::FLAC__StreamEncoderInitStatus init();            ///< See FLAC__stream_encoder_init_stream()
 			virtual ::FLAC__StreamEncoderInitStatus init_ogg();        ///< See FLAC__stream_encoder_init_ogg_stream()

--- a/include/FLAC/stream_encoder.h
+++ b/include/FLAC/stream_encoder.h
@@ -1198,6 +1198,24 @@ FLAC_API FLAC__bool FLAC__stream_encoder_set_total_samples_estimate(FLAC__Stream
  */
 FLAC_API FLAC__bool FLAC__stream_encoder_set_metadata(FLAC__StreamEncoder *encoder, FLAC__StreamMetadata **metadata, uint32_t num_blocks);
 
+/** Set to \c true to make the encoder not output frames which contain
+ *  only constant subframes. This is beneficial for streaming
+ *  applications: very small frames can cause problems with buffering
+ *  as bitrates can drop as low 1kbit/s for CDDA audio encoded within
+ *  subset. The minimum bitrate for a FLAC file encoded with this
+ *  function used is raised to 1bit/sample (i.e. 48kbit/s for 48kHz
+ *  material).
+ *
+ * \default \c false
+ * \param  encoder  An encoder instance to set.
+ * \param  value    Flag value (see above).
+ * \assert
+ *    \code encoder != NULL \endcode
+ * \retval FLAC__bool
+ *    \c false if the encoder is already initialized, else \c true.
+ */
+FLAC_API FLAC__bool FLAC__stream_encoder_set_limit_min_bitrate(FLAC__StreamEncoder *encoder, FLAC__bool value);
+
 /** Get the current encoder state.
  *
  * \param  encoder  An encoder instance to query.
@@ -1424,6 +1442,16 @@ FLAC_API uint32_t FLAC__stream_encoder_get_rice_parameter_search_dist(const FLAC
  *    See FLAC__stream_encoder_get_total_samples_estimate().
  */
 FLAC_API FLAC__uint64 FLAC__stream_encoder_get_total_samples_estimate(const FLAC__StreamEncoder *encoder);
+
+/** Get the "limit_min_bitrate" flag.
+ *
+ * \param  encoder  An encoder instance to query.
+ * \assert
+ *    \code encoder != NULL \endcode
+ * \retval FLAC__bool
+ *    See FLAC__stream_encoder_set_limit_min_bitrate().
+ */
+FLAC_API FLAC__bool FLAC__stream_encoder_get_limit_min_bitrate(const FLAC__StreamEncoder *encoder);
 
 /** Initialize the encoder instance to encode native FLAC streams.
  *

--- a/src/flac/encode.c
+++ b/src/flac/encode.c
@@ -2147,6 +2147,7 @@ FLAC__bool EncoderSession_init_encoder(EncoderSession *e, encode_options_t optio
 		FLAC__stream_encoder_set_apodization(e->encoder, apodizations);
 	FLAC__stream_encoder_set_total_samples_estimate(e->encoder, e->total_samples_to_encode);
 	FLAC__stream_encoder_set_metadata(e->encoder, (num_metadata > 0)? metadata : 0, num_metadata);
+	FLAC__stream_encoder_set_limit_min_bitrate(e->encoder, options.limit_min_bitrate);
 
 	FLAC__stream_encoder_disable_constant_subframes(e->encoder, options.debug.disable_constant_subframes);
 	FLAC__stream_encoder_disable_fixed_subframes(e->encoder, options.debug.disable_fixed_subframes);

--- a/src/flac/encode.h
+++ b/src/flac/encode.h
@@ -85,6 +85,7 @@ typedef struct {
 	FLAC__bool ignore_chunk_sizes;
 	FLAC__bool sector_align;
 	FLAC__bool error_on_compression_fail;
+	FLAC__bool limit_min_bitrate;
 
 	FLAC__StreamMetadata *vorbis_comment;
 	FLAC__StreamMetadata *pictures[64];

--- a/src/flac/main.c
+++ b/src/flac/main.c
@@ -168,6 +168,7 @@ static struct share__option long_options_[] = {
 	{ "sign"                      , share__required_argument, 0, 0 },
 	{ "input-size"                , share__required_argument, 0, 0 },
 	{ "error-on-compression-fail" , share__no_argument, 0, 0 },
+	{ "limit-min-bitrate"         , share__no_argument, 0, 0 },
 
 	/*
 	 * analysis options
@@ -268,6 +269,7 @@ static struct {
 	FLAC__bool cued_seekpoints;
 	FLAC__bool channel_map_none; /* --channel-map=none specified, eventually will expand to take actual channel map */
 	FLAC__bool error_on_compression_fail;
+	FLAC__bool limit_min_bitrate;
 
 	uint32_t num_files;
 	char **filenames;
@@ -597,6 +599,7 @@ FLAC__bool init_options(void)
 	option_values.cued_seekpoints = true;
 	option_values.channel_map_none = false;
 	option_values.error_on_compression_fail = false;
+	option_values.limit_min_bitrate = false;
 
 	option_values.num_files = 0;
 	option_values.filenames = 0;
@@ -824,6 +827,9 @@ int parse_option(int short_option, const char *long_option, const char *option_a
 		}
 		else if(0 == strcmp(long_option, "residual-text")) {
 			option_values.aopts.do_residual_text = true;
+		}
+		else if(0 == strcmp(long_option, "limit-min-bitrate")) {
+			option_values.limit_min_bitrate = true;
 		}
 		/*
 		 * negatives
@@ -1289,6 +1295,7 @@ void show_help(void)
 	printf("  -p, --qlp-coeff-precision-search   Exhaustively search LP coeff quantization\n");
 	printf("  -q, --qlp-coeff-precision=#        Specify precision in bits\n");
 	printf("  -r, --rice-partition-order=[#,]#   Set [min,]max residual partition order\n");
+	printf("      --limit-min-bitrate            Limit minimum bitrate (for streaming)\n");
 	printf("format options:\n");
 	printf("      --force-raw-format       Treat input or output as raw samples\n");
 	printf("      --force-aiff-format      Force decoding to AIFF format\n");
@@ -1618,6 +1625,11 @@ void show_explain(void)
 	printf("                                     (# is 0 to 15 inclusive; min defaults to 0;\n");
 	printf("                                     the default is -r 0; above 4 does not\n");
 	printf("                                     usually help much)\n");
+	printf("      --limit-min-bitrate            Limit minimum bitrate by not allowing frames\n");
+	printf("                                     consisting of only constant subframes. This\n");
+	printf("                                     ensures a bitrate of at least 1 bit/sample,\n");
+	printf("                                     for example 48kbit/s for 48kHz input. This is\n");
+	printf("                                     mostly beneficial for internet streaming.\n");
 	printf("format options:\n");
 	printf("      --force-raw-format       Force input (when encoding) or output (when\n");
 	printf("                               decoding) to be treated as raw samples\n");
@@ -1926,6 +1938,7 @@ int encode_file(const char *infilename, FLAC__bool is_first_file, FLAC__bool is_
 	encode_options.debug.disable_verbatim_subframes = option_values.debug.disable_verbatim_subframes;
 	encode_options.debug.do_md5 = option_values.debug.do_md5;
 	encode_options.error_on_compression_fail = option_values.error_on_compression_fail;
+	encode_options.limit_min_bitrate = option_values.limit_min_bitrate;
 
 	/* if infilename and outfilename point to the same file, we need to write to a temporary file */
 	if(encode_infile != stdin && grabbag__file_are_same(infilename, outfilename)) {

--- a/src/libFLAC++/stream_encoder.cpp
+++ b/src/libFLAC++/stream_encoder.cpp
@@ -211,6 +211,12 @@ namespace FLAC {
 			return ok;
 		}
 
+		bool Stream::set_limit_min_bitrate(bool value)
+		{
+			FLAC__ASSERT(is_valid());
+			return static_cast<bool>(::FLAC__stream_encoder_set_limit_min_bitrate(encoder_, value));
+		}
+
 		Stream::State Stream::get_state() const
 		{
 			FLAC__ASSERT(is_valid());
@@ -329,6 +335,12 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(is_valid());
 			return ::FLAC__stream_encoder_get_total_samples_estimate(encoder_);
+		}
+
+		bool Stream::get_limit_min_bitrate() const
+		{
+			FLAC__ASSERT(is_valid());
+			return static_cast<bool>(::FLAC__stream_encoder_get_limit_min_bitrate(encoder_));
 		}
 
 		::FLAC__StreamEncoderInitStatus Stream::init()

--- a/src/libFLAC/fixed.c
+++ b/src/libFLAC/fixed.c
@@ -235,13 +235,14 @@ uint32_t FLAC__fixed_compute_best_predictor(const FLAC__int32 data[], uint32_t d
 		error -= last_error_3; total_error_4 += local_abs(error); last_error_3 = save;
 	}
 
-	if(total_error_0 < flac_min(flac_min(flac_min(total_error_1, total_error_2), total_error_3), total_error_4))
+	/* prefer lower order */
+	if(total_error_0 <= flac_min(flac_min(flac_min(total_error_1, total_error_2), total_error_3), total_error_4))
 		order = 0;
-	else if(total_error_1 < flac_min(flac_min(total_error_2, total_error_3), total_error_4))
+	else if(total_error_1 <= flac_min(flac_min(total_error_2, total_error_3), total_error_4))
 		order = 1;
-	else if(total_error_2 < flac_min(total_error_3, total_error_4))
+	else if(total_error_2 <= flac_min(total_error_3, total_error_4))
 		order = 2;
-	else if(total_error_3 < total_error_4)
+	else if(total_error_3 <= total_error_4)
 		order = 3;
 	else
 		order = 4;
@@ -297,13 +298,14 @@ uint32_t FLAC__fixed_compute_best_predictor_wide(const FLAC__int32 data[], uint3
 		error -= last_error_3; total_error_4 += local_abs(error); last_error_3 = save;
 	}
 
-	if(total_error_0 < flac_min(flac_min(flac_min(total_error_1, total_error_2), total_error_3), total_error_4))
+	/* prefer lower order */
+	if(total_error_0 <= flac_min(flac_min(flac_min(total_error_1, total_error_2), total_error_3), total_error_4))
 		order = 0;
-	else if(total_error_1 < flac_min(flac_min(total_error_2, total_error_3), total_error_4))
+	else if(total_error_1 <= flac_min(flac_min(total_error_2, total_error_3), total_error_4))
 		order = 1;
-	else if(total_error_2 < flac_min(total_error_3, total_error_4))
+	else if(total_error_2 <= flac_min(total_error_3, total_error_4))
 		order = 2;
-	else if(total_error_3 < total_error_4)
+	else if(total_error_3 <= total_error_4)
 		order = 3;
 	else
 		order = 4;

--- a/src/libFLAC/fixed_intrin_sse2.c
+++ b/src/libFLAC/fixed_intrin_sse2.c
@@ -158,14 +158,14 @@ uint32_t FLAC__fixed_compute_best_predictor_intrin_sse2(const FLAC__int32 data[]
 		}
 	}
 
-	/* prefer higher order */
-	if(total_error_0 < flac_min(flac_min(flac_min(total_error_1, total_error_2), total_error_3), total_error_4))
+	/* prefer lower order */
+	if(total_error_0 <= flac_min(flac_min(flac_min(total_error_1, total_error_2), total_error_3), total_error_4))
 		order = 0;
-	else if(total_error_1 < flac_min(flac_min(total_error_2, total_error_3), total_error_4))
+	else if(total_error_1 <= flac_min(flac_min(total_error_2, total_error_3), total_error_4))
 		order = 1;
-	else if(total_error_2 < flac_min(total_error_3, total_error_4))
+	else if(total_error_2 <= flac_min(total_error_3, total_error_4))
 		order = 2;
-	else if(total_error_3 < total_error_4)
+	else if(total_error_3 <= total_error_4)
 		order = 3;
 	else
 		order = 4;
@@ -309,14 +309,14 @@ uint32_t FLAC__fixed_compute_best_predictor_wide_intrin_sse2(const FLAC__int32 d
 		}
 	}
 
-	/* prefer higher order */
-	if(total_error_0 < flac_min(flac_min(flac_min(total_error_1, total_error_2), total_error_3), total_error_4))
+	/* prefer lower order */
+	if(total_error_0 <= flac_min(flac_min(flac_min(total_error_1, total_error_2), total_error_3), total_error_4))
 		order = 0;
-	else if(total_error_1 < flac_min(flac_min(total_error_2, total_error_3), total_error_4))
+	else if(total_error_1 <= flac_min(flac_min(total_error_2, total_error_3), total_error_4))
 		order = 1;
-	else if(total_error_2 < flac_min(total_error_3, total_error_4))
+	else if(total_error_2 <= flac_min(total_error_3, total_error_4))
 		order = 2;
-	else if(total_error_3 < total_error_4)
+	else if(total_error_3 <= total_error_4)
 		order = 3;
 	else
 		order = 4;

--- a/src/libFLAC/fixed_intrin_ssse3.c
+++ b/src/libFLAC/fixed_intrin_ssse3.c
@@ -143,14 +143,14 @@ uint32_t FLAC__fixed_compute_best_predictor_intrin_ssse3(const FLAC__int32 data[
 		}
 	}
 
-	/* prefer higher order */
-	if(total_error_0 < flac_min(flac_min(flac_min(total_error_1, total_error_2), total_error_3), total_error_4))
+	/* prefer lower order */
+	if(total_error_0 <= flac_min(flac_min(flac_min(total_error_1, total_error_2), total_error_3), total_error_4))
 		order = 0;
-	else if(total_error_1 < flac_min(flac_min(total_error_2, total_error_3), total_error_4))
+	else if(total_error_1 <= flac_min(flac_min(total_error_2, total_error_3), total_error_4))
 		order = 1;
-	else if(total_error_2 < flac_min(total_error_3, total_error_4))
+	else if(total_error_2 <= flac_min(total_error_3, total_error_4))
 		order = 2;
-	else if(total_error_3 < total_error_4)
+	else if(total_error_3 <= total_error_4)
 		order = 3;
 	else
 		order = 4;
@@ -282,14 +282,14 @@ uint32_t FLAC__fixed_compute_best_predictor_wide_intrin_ssse3(const FLAC__int32 
 		}
 	}
 
-	/* prefer higher order */
-	if(total_error_0 < flac_min(flac_min(flac_min(total_error_1, total_error_2), total_error_3), total_error_4))
+	/* prefer lower order */
+	if(total_error_0 <= flac_min(flac_min(flac_min(total_error_1, total_error_2), total_error_3), total_error_4))
 		order = 0;
-	else if(total_error_1 < flac_min(flac_min(total_error_2, total_error_3), total_error_4))
+	else if(total_error_1 <= flac_min(flac_min(total_error_2, total_error_3), total_error_4))
 		order = 1;
-	else if(total_error_2 < flac_min(total_error_3, total_error_4))
+	else if(total_error_2 <= flac_min(total_error_3, total_error_4))
 		order = 2;
-	else if(total_error_3 < total_error_4)
+	else if(total_error_3 <= total_error_4)
 		order = 3;
 	else
 		order = 4;

--- a/src/libFLAC/include/protected/stream_encoder.h
+++ b/src/libFLAC/include/protected/stream_encoder.h
@@ -107,6 +107,7 @@ typedef struct FLAC__StreamEncoderProtected {
 	uint32_t max_residual_partition_order;
 	uint32_t rice_parameter_search_dist;
 	FLAC__uint64 total_samples_estimate;
+	FLAC__bool limit_min_bitrate;
 	FLAC__StreamMetadata **metadata;
 	uint32_t num_metadata_blocks;
 	FLAC__uint64 streaminfo_offset, seektable_offset, audio_offset;

--- a/src/test_libFLAC++/encoders.cpp
+++ b/src/test_libFLAC++/encoders.cpp
@@ -322,6 +322,11 @@ static bool test_stream_encoder(Layer layer, bool is_ogg)
 		return die_s_("returned false", encoder);
 	printf("OK\n");
 
+	printf("testing set_limit_min_bitrate()... ");
+	if(!encoder->set_limit_min_bitrate(true))
+		return die_s_("returned false", encoder);
+	printf("OK\n");
+
 	if(layer < LAYER_FILENAME) {
 		printf("opening file for FLAC output... ");
 		file = ::flac_fopen(flacfilename(is_ogg), "w+b");
@@ -494,6 +499,13 @@ static bool test_stream_encoder(Layer layer, bool is_ogg)
 	printf("testing get_total_samples_estimate()... ");
 	if(encoder->get_total_samples_estimate() != streaminfo_.data.stream_info.total_samples) {
 		printf("FAILED, expected %" PRIu64 ", got %" PRIu64 "\n", streaminfo_.data.stream_info.total_samples, encoder->get_total_samples_estimate());
+		return false;
+	}
+	printf("OK\n");
+	
+	printf("testing get_limit_min_bitrate()... ");
+	if(encoder->get_limit_min_bitrate() != true) {
+		printf("FAILED, expected true, got false\n");
 		return false;
 	}
 	printf("OK\n");

--- a/src/test_libFLAC/encoders.c
+++ b/src/test_libFLAC/encoders.c
@@ -275,6 +275,11 @@ static FLAC__bool test_stream_encoder(Layer layer, FLAC__bool is_ogg)
 		return die_s_("returned false", encoder);
 	printf("OK\n");
 
+	printf("testing FLAC__stream_encoder_set_limit_min_bitrate()... ");
+	if(!FLAC__stream_encoder_set_limit_min_bitrate(encoder, true))
+		return die_s_("returned false", encoder);
+	printf("OK\n");
+
 	if(layer < LAYER_FILENAME) {
 		printf("opening file for FLAC output... ");
 		file = flac_fopen(flacfilename(is_ogg), "w+b");
@@ -455,6 +460,12 @@ static FLAC__bool test_stream_encoder(Layer layer, FLAC__bool is_ogg)
 		return false;
 	}
 	printf("OK\n");
+	
+	printf("testing FLAC__stream_encoder_get_limit_min_bitrate()... ");
+	if(FLAC__stream_encoder_get_limit_min_bitrate(encoder) != true) {
+		printf("FAILED, expected true, got false\n");
+		return false;
+	}
 
 	/* init the dummy sample buffer */
 	for(i = 0; i < sizeof(samples) / sizeof(FLAC__int32); i++)

--- a/test/test_flac.sh
+++ b/test/test_flac.sh
@@ -1249,6 +1249,25 @@ flac2flac input-SCVA.flac case04e "--no-padding -S 5x"
 # case 04f: on file with SEEKTABLE block and size-changing option specified, drop existing SEEKTABLE, new SEEKTABLE with default points
 #(already covered by case03c)
 
+############################################################################
+# test limiting minimum bitrate
+############################################################################
+
+echo $ECHO_N "Testing --limit-min-bitrate" $ECHO_C
+
+run_flac -f -o out.flac --no-padding --no-seektable --limit-min-bitrate "$testdatadir/input-VA.flac"
+size=$(wc -c < out.flac)
+
+if [ "$size" -lt "1022" ]; then
+    die "ERROR: filesize of flac file encoded with --limit-min-bitrate is smaller than expected"
+fi
+
+echo OK
+
+############################################################################
+# test overflow of total samples field in STREAMINFO
+############################################################################
+
 test_total_samples_overflow ()
 {
 	total_samples=$1
@@ -1270,7 +1289,6 @@ if [ "$FLAC__TEST_LEVEL" -gt 1 ] ; then
 	test_total_samples_overflow 68719476736 0
 	test_total_samples_overflow 68719476737 0
 fi
-
 
 rm -f out.flac out.meta out1.meta
 


### PR DESCRIPTION
Quite a lot of decoders have trouble streaming or seeking in a file with frames that only consist of constant subframes because of the large difference between the largest and smallest subframe. To remedy this, this commit disables the use of constant subframes for the last subframe in case all others are constant.

This fixes #90 and fixes #262