### PR TITLE
Fix Makefile.lite: add mkdir for missing dirs and fPIC for aarch64

### DIFF
--- a/Makefile.lite
+++ b/Makefile.lite
@@ -50,9 +50,11 @@ doc:
 	(cd $@ && $(MAKE) -f Makefile.lite)
 
 src examples:
+	(mkdir -p objs/release/bin objs/release/lib objs/debug/bin objs/debug/lib)
 	(cd $@ && $(MAKE) -f Makefile.lite $(CONFIG))
 
 libFLAC libFLAC++ share flac metaflac plugin_common plugin_xmms test_libs_common test_seeking test_streams test_grabbag test_libFLAC test_libFLAC++:
+	(mkdir -p objs/release/bin objs/release/lib objs/debug/bin objs/debug/lib)
 	(cd src/$@ && $(MAKE) -f Makefile.lite $(CONFIG))
 
 flacdiff flactimer:

--- a/build/config.mk
+++ b/build/config.mk
@@ -114,7 +114,7 @@ else
 endif
 
 ifeq ($(OS),Linux)
-	ifeq ($(PROC),x86_64)
+	ifeq ($(PROC),$(filter $(PROC), x86_64 aarch64))
         CONFIG_CFLAGS += -fPIC
 	endif
 endif

--- a/build/exe.mk
+++ b/build/exe.mk
@@ -68,10 +68,9 @@ CXXFLAGS := -O3 -fomit-frame-pointer -funroll-loops $(GCC_INLINE) -DFLaC__INLINE
 endif
 
 LFLAGS   = -L$(LIBPATH)
-
 DEBUG_OBJS = $(SRCS_C:%.c=%.debug.o) $(SRCS_CC:%.cc=%.debug.o) $(SRCS_CPP:%.cpp=%.debug.o) $(SRCS_NASM:%.nasm=%.debug.o)
 RELEASE_OBJS = $(SRCS_C:%.c=%.release.o) $(SRCS_CC:%.cc=%.release.o) $(SRCS_CPP:%.cpp=%.release.o) $(SRCS_NASM:%.nasm=%.release.o)
-ifeq ($(PROC),x86_64)
+ifeq ($(PROC),$(filter $(PROC), x86_64 aarch64))
 DEBUG_PIC_OBJS = $(SRCS_C:%.c=%.debug.pic.o) $(SRCS_CC:%.cc=%.debug.pic.o) $(SRCS_CPP:%.cpp=%.debug.pic.o) $(SRCS_NASM:%.nasm=%.debug.pic.o)
 RELEASE_PIC_OBJS = $(SRCS_C:%.c=%.release.pic.o) $(SRCS_CC:%.cc=%.release.pic.o) $(SRCS_CPP:%.cpp=%.release.pic.o) $(SRCS_NASM:%.nasm=%.release.pic.o)
 endif

--- a/build/lib.mk
+++ b/build/lib.mk
@@ -109,7 +109,7 @@ $(DEBUG_DYNAMIC_LIB) : $(DEBUG_OBJS) $(DEBUG_PIC_OBJS)
 ifeq ($(OS),Darwin)
 	echo Not building dynamic lib, command is: $(LINKD) -o $@ $(DEBUG_OBJS) $(LFLAGS) $(LIBS) -lc
 else
-ifeq ($(PROC),x86_64)
+ifeq ($(PROC),$(filter $(PROC), x86_64 aarch64))
 	$(LINKD) -o $@ $(DEBUG_PIC_OBJS) $(LFLAGS) $(LIBS)
 else
 	$(LINKD) -o $@ $(DEBUG_OBJS) $(LFLAGS) $(LIBS)


### PR DESCRIPTION
Commit f771c64 broke Makefile.lite by removing the only files in the objs directory trees, so git 'forgot' about them. This commit adds a mkdir command to regenerate them on using Makefile.lite, and adds -fPIC to aarch64 so it builds.