### PR TITLE
Fix format_mistake printf

### DIFF
--- a/src/flac/main.c
+++ b/src/flac/main.c
@@ -1678,7 +1678,7 @@ void show_explain(void)
 void format_mistake(const char *infilename, FileFormat wrong, FileFormat right)
 {
 	/* WATCHOUT: indexed by FileFormat */
-	static const char * const ff[] = { " raw", " WAVE", "n RF64", "n AIFF", "n AIFF-C", " FLAC", "n Ogg FLAC" };
+	static const char * const ff[] = { " raw", " WAVE", " Wave64", "n RF64", "n AIFF", "n AIFF-C", " FLAC", "n Ogg FLAC" };
 	flac__utils_printf(stderr, 1, "WARNING: %s is not a%s file; treating as a%s file\n", infilename, ff[wrong], ff[right]);
 }
 


### PR DESCRIPTION
If on encoding a different format header is detected than is guessed from file extension, format_mistake in invoked. On merging  wave64 support (commit d7f5344), updating the printable names in format_mistake was missed. Compare to this enum: https://github.com/xiph/flac/blob/b358381a102a2c1c153ee4cf95dfc04af62faa1a/src/flac/utils.h#L31