### PR TITLE
Fix windows_unicode_filenames kludge

### DIFF
--- a/include/share/windows_unicode_filenames.h
+++ b/include/share/windows_unicode_filenames.h
@@ -39,24 +39,21 @@
 #include <sys/utime.h>
 #include "FLAC/ordinals.h"
 
-/***** FIXME: KLUDGE: export these syms for flac.exe, metaflac.exe, etc. *****/
-#include "FLAC/export.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-FLAC_API void flac_internal_set_utf8_filenames(FLAC__bool flag);
-FLAC_API FLAC__bool flac_internal_get_utf8_filenames(void);
+void flac_internal_set_utf8_filenames(FLAC__bool flag);
+FLAC__bool flac_internal_get_utf8_filenames(void);
 #define flac_set_utf8_filenames flac_internal_set_utf8_filenames
 #define flac_get_utf8_filenames flac_internal_get_utf8_filenames
 
-FLAC_API FILE* flac_internal_fopen_utf8(const char *filename, const char *mode);
-FLAC_API int flac_internal_stat64_utf8(const char *path, struct __stat64 *buffer);
-FLAC_API int flac_internal_chmod_utf8(const char *filename, int pmode);
-FLAC_API int flac_internal_utime_utf8(const char *filename, struct utimbuf *times);
-FLAC_API int flac_internal_unlink_utf8(const char *filename);
-FLAC_API int flac_internal_rename_utf8(const char *oldname, const char *newname);
+FILE* flac_internal_fopen_utf8(const char *filename, const char *mode);
+int flac_internal_stat64_utf8(const char *path, struct __stat64 *buffer);
+int flac_internal_chmod_utf8(const char *filename, int pmode);
+int flac_internal_utime_utf8(const char *filename, struct utimbuf *times);
+int flac_internal_unlink_utf8(const char *filename);
+int flac_internal_rename_utf8(const char *oldname, const char *newname);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/flac/CMakeLists.txt
+++ b/src/flac/CMakeLists.txt
@@ -11,7 +11,8 @@ add_executable(flacapp
     utils.c
     vorbiscomment.c
     $<$<BOOL:${WIN32}>:../../include/share/win_utf8_io.h>
-    $<$<BOOL:${WIN32}>:../share/win_utf8_io/win_utf8_io.c>)
+    $<$<BOOL:${WIN32}>:../share/win_utf8_io/win_utf8_io.c>
+    $<$<BOOL:${WIN32}>:../share/windows_unicode_filenames.c>)
 set_property(TARGET flacapp PROPERTY RUNTIME_OUTPUT_NAME flac)
 target_link_libraries(flacapp
     FLAC

--- a/src/flac/Makefile.am
+++ b/src/flac/Makefile.am
@@ -32,6 +32,11 @@ EXTRA_DIST = \
 	iffscan.vcxproj \
 	iffscan.vcxproj.filters
 
+if OS_IS_WINDOWS
+win_utf8_lib = $(top_builddir)/src/share/win_utf8_io/libwin_utf8_io.la
+windows_unicode_compat = $(top_builddir)/src/share/windows_unicode_filenames.c
+endif
+
 flac_SOURCES = \
 	analyze.c \
 	decode.c \
@@ -47,11 +52,8 @@ flac_SOURCES = \
 	foreign_metadata.h \
 	local_string_utils.h \
 	utils.h \
-	vorbiscomment.h
-
-if OS_IS_WINDOWS
-win_utf8_lib = $(top_builddir)/src/share/win_utf8_io/libwin_utf8_io.la
-endif
+	vorbiscomment.h \
+	$(windows_unicode_compat)
 
 flac_LDADD = \
 	$(top_builddir)/src/share/utf8/libutf8.la \

--- a/src/libFLAC/CMakeLists.txt
+++ b/src/libFLAC/CMakeLists.txt
@@ -74,8 +74,7 @@ add_library(FLAC
     stream_encoder_intrin_avx2.c
     stream_encoder_framing.c
     window.c
-    $<$<BOOL:${WIN32}>:../../include/share/windows_unicode_filenames.h>
-    $<$<BOOL:${WIN32}>:windows_unicode_filenames.c>
+    $<$<BOOL:${WIN32}>:../share/windows_unicode_filenames.c>
     $<$<BOOL:${OGG_FOUND}>:ogg_decoder_aspect.c>
     $<$<BOOL:${OGG_FOUND}>:ogg_encoder_aspect.c>
     $<$<BOOL:${OGG_FOUND}>:ogg_helper.c>

--- a/src/libFLAC/Makefile.am
+++ b/src/libFLAC/Makefile.am
@@ -85,7 +85,7 @@ EXTRA_DIST = \
 	windows_unicode_filenames.c
 
 if OS_IS_WINDOWS
-windows_unicode_compat = windows_unicode_filenames.c
+windows_unicode_compat = $(top_builddir)/src/share/windows_unicode_filenames.c
 endif
 
 if FLaC__HAS_OGG

--- a/src/libFLAC/libFLAC_dynamic.vcproj
+++ b/src/libFLAC/libFLAC_dynamic.vcproj
@@ -410,7 +410,7 @@
 				>
 			</File>
 			<File
-				RelativePath=".\windows_unicode_filenames.c"
+				RelativePath="..\share\windows_unicode_filenames.c"
 				>
 			</File>
 		</Filter>

--- a/src/libFLAC/libFLAC_dynamic.vcxproj
+++ b/src/libFLAC/libFLAC_dynamic.vcxproj
@@ -257,7 +257,7 @@
     <ClCompile Include="stream_encoder_intrin_sse2.c" />
     <ClCompile Include="stream_encoder_intrin_ssse3.c" />
     <ClCompile Include="window.c" />
-    <ClCompile Include="windows_unicode_filenames.c" />
+    <ClCompile Include="..\share\windows_unicode_filenames.c" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="ia32\cpu_asm.nasm">

--- a/src/libFLAC/libFLAC_dynamic.vcxproj.filters
+++ b/src/libFLAC/libFLAC_dynamic.vcxproj.filters
@@ -226,7 +226,7 @@
     <ClCompile Include="window.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="windows_unicode_filenames.c">
+    <ClCompile Include="..\share\windows_unicode_filenames.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/libFLAC/libFLAC_static.vcproj
+++ b/src/libFLAC/libFLAC_static.vcproj
@@ -451,7 +451,7 @@
 				>
 			</File>
 			<File
-				RelativePath=".\windows_unicode_filenames.c"
+				RelativePath="..\share\windows_unicode_filenames.c"
 				>
 			</File>
 		</Filter>

--- a/src/libFLAC/libFLAC_static.vcxproj
+++ b/src/libFLAC/libFLAC_static.vcxproj
@@ -217,7 +217,7 @@
     <ClCompile Include="stream_encoder_intrin_sse2.c" />
     <ClCompile Include="stream_encoder_intrin_ssse3.c" />
     <ClCompile Include="window.c" />
-    <ClCompile Include="windows_unicode_filenames.c" />
+    <ClCompile Include="..\share\windows_unicode_filenames.c" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="ia32\cpu_asm.nasm">

--- a/src/libFLAC/libFLAC_static.vcxproj.filters
+++ b/src/libFLAC/libFLAC_static.vcxproj.filters
@@ -226,7 +226,7 @@
     <ClCompile Include="window.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="windows_unicode_filenames.c">
+    <ClCompile Include="..\share\windows_unicode_filenames.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/metaflac/CMakeLists.txt
+++ b/src/metaflac/CMakeLists.txt
@@ -10,7 +10,8 @@ add_executable(metaflac
     usage.c
     utils.c
     $<$<BOOL:${WIN32}>:../../include/share/win_utf8_io.h>
-    $<$<BOOL:${WIN32}>:../share/win_utf8_io/win_utf8_io.c>)
+    $<$<BOOL:${WIN32}>:../share/win_utf8_io/win_utf8_io.c>
+    $<$<BOOL:${WIN32}>:../share/windows_unicode_filenames.c>)
 target_link_libraries(metaflac FLAC getopt utf8)
 
 install(TARGETS metaflac EXPORT targets

--- a/src/metaflac/Makefile.am
+++ b/src/metaflac/Makefile.am
@@ -27,6 +27,11 @@ EXTRA_DIST = \
 	metaflac.vcxproj \
 	metaflac.vcxproj.filters
 
+if OS_IS_WINDOWS
+win_utf8_lib = $(top_builddir)/src/share/win_utf8_io/libwin_utf8_io.la
+windows_unicode_compat = $(top_builddir)/src/share/windows_unicode_filenames.c
+endif
+
 metaflac_SOURCES = \
 	main.c \
 	operations.c \
@@ -42,12 +47,10 @@ metaflac_SOURCES = \
 	operations_shorthand.h \
 	options.h \
 	usage.h \
-	utils.h
-metaflac_LDFLAGS = $(AM_LDFLAGS)
+	utils.h \
+	$(windows_unicode_compat)
 
-if OS_IS_WINDOWS
-win_utf8_lib = $(top_builddir)/src/share/win_utf8_io/libwin_utf8_io.la
-endif
+metaflac_LDFLAGS = $(AM_LDFLAGS)
 
 metaflac_LDADD = \
 	$(top_builddir)/src/share/grabbag/libgrabbag.la \

--- a/src/share/windows_unicode_filenames.c
+++ b/src/share/windows_unicode_filenames.c
@@ -37,8 +37,6 @@
 #include <windows.h>
 #include "share/windows_unicode_filenames.h"
 
-/*** FIXME: KLUDGE: export these syms for flac.exe, metaflac.exe, etc. ***/
-
 /* convert UTF-8 back to WCHAR. Caller is responsible for freeing memory */
 static wchar_t *wchar_from_utf8(const char *str)
 {
@@ -63,19 +61,19 @@ static wchar_t *wchar_from_utf8(const char *str)
 static FLAC__bool utf8_filenames = false;
 
 
-FLAC_API void flac_internal_set_utf8_filenames(FLAC__bool flag)
+void flac_internal_set_utf8_filenames(FLAC__bool flag)
 {
 	utf8_filenames = flag ? true : false;
 }
 
-FLAC_API FLAC__bool flac_internal_get_utf8_filenames(void)
+FLAC__bool flac_internal_get_utf8_filenames(void)
 {
 	return utf8_filenames;
 }
 
 /* file functions */
 
-FLAC_API FILE* flac_internal_fopen_utf8(const char *filename, const char *mode)
+FILE* flac_internal_fopen_utf8(const char *filename, const char *mode)
 {
 	if (!utf8_filenames) {
 		return fopen(filename, mode);
@@ -97,7 +95,7 @@ FLAC_API FILE* flac_internal_fopen_utf8(const char *filename, const char *mode)
 	}
 }
 
-FLAC_API int flac_internal_stat64_utf8(const char *path, struct __stat64 *buffer)
+int flac_internal_stat64_utf8(const char *path, struct __stat64 *buffer)
 {
 	if (!utf8_filenames) {
 		return _stat64(path, buffer);
@@ -113,7 +111,7 @@ FLAC_API int flac_internal_stat64_utf8(const char *path, struct __stat64 *buffer
 	}
 }
 
-FLAC_API int flac_internal_chmod_utf8(const char *filename, int pmode)
+int flac_internal_chmod_utf8(const char *filename, int pmode)
 {
 	if (!utf8_filenames) {
 		return _chmod(filename, pmode);
@@ -129,7 +127,7 @@ FLAC_API int flac_internal_chmod_utf8(const char *filename, int pmode)
 	}
 }
 
-FLAC_API int flac_internal_utime_utf8(const char *filename, struct utimbuf *times)
+int flac_internal_utime_utf8(const char *filename, struct utimbuf *times)
 {
 	if (!utf8_filenames) {
 		return utime(filename, times);
@@ -148,7 +146,7 @@ FLAC_API int flac_internal_utime_utf8(const char *filename, struct utimbuf *time
 	}
 }
 
-FLAC_API int flac_internal_unlink_utf8(const char *filename)
+int flac_internal_unlink_utf8(const char *filename)
 {
 	if (!utf8_filenames) {
 		return _unlink(filename);
@@ -164,7 +162,7 @@ FLAC_API int flac_internal_unlink_utf8(const char *filename)
 	}
 }
 
-FLAC_API int flac_internal_rename_utf8(const char *oldname, const char *newname)
+int flac_internal_rename_utf8(const char *oldname, const char *newname)
 {
 	if (!utf8_filenames) {
 		return rename(oldname, newname);

--- a/src/test_grabbag/cuesheet/CMakeLists.txt
+++ b/src/test_grabbag/cuesheet/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(test_cuesheet
     main.c
     $<$<BOOL:${WIN32}>:../../../include/share/win_utf8_io.h>
-    $<$<BOOL:${WIN32}>:../../share/win_utf8_io/win_utf8_io.c>)
+    $<$<BOOL:${WIN32}>:../../share/win_utf8_io/win_utf8_io.c>
+    $<$<BOOL:${WIN32}>:../../share/windows_unicode_filenames.c>)
 target_link_libraries(test_cuesheet FLAC grabbag)

--- a/src/test_grabbag/cuesheet/Makefile.am
+++ b/src/test_grabbag/cuesheet/Makefile.am
@@ -23,10 +23,15 @@ EXTRA_DIST = \
 	test_cuesheet.vcxproj \
 	test_cuesheet.vcxproj.filters
 
+if OS_IS_WINDOWS
+windows_unicode_compat = $(top_builddir)/src/share/windows_unicode_filenames.c
+endif
+
 AM_CPPFLAGS = -I$(top_builddir) -I$(srcdir)/include -I$(top_srcdir)/include
 check_PROGRAMS = test_cuesheet
 test_cuesheet_SOURCES = \
-	main.c
+	main.c \
+	$(windows_unicode_compat)
 test_cuesheet_LDADD = \
 	$(top_builddir)/src/share/grabbag/libgrabbag.la \
 	$(top_builddir)/src/share/replaygain_analysis/libreplaygain_analysis.la \

--- a/src/test_grabbag/picture/CMakeLists.txt
+++ b/src/test_grabbag/picture/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(test_picture
     main.c
     $<$<BOOL:${WIN32}>:../../../include/share/win_utf8_io.h>
-    $<$<BOOL:${WIN32}>:../../share/win_utf8_io/win_utf8_io.c>)
+    $<$<BOOL:${WIN32}>:../../share/win_utf8_io/win_utf8_io.c>
+    $<$<BOOL:${WIN32}>:../../share/windows_unicode_filenames.c>)
 target_link_libraries(test_picture FLAC grabbag)

--- a/src/test_grabbag/picture/Makefile.am
+++ b/src/test_grabbag/picture/Makefile.am
@@ -23,14 +23,16 @@ EXTRA_DIST = \
 	test_picture.vcxproj \
 	test_picture.vcxproj.filters
 
+if OS_IS_WINDOWS
+windows_unicode_compat = $(top_builddir)/src/share/windows_unicode_filenames.c
+win_utf8_lib = $(top_builddir)/src/share/win_utf8_io/libwin_utf8_io.la
+endif
+
 AM_CPPFLAGS = -I$(top_builddir) -I$(srcdir)/include -I$(top_srcdir)/include
 check_PROGRAMS = test_picture
 test_picture_SOURCES = \
-	main.c
-
-if OS_IS_WINDOWS
-win_utf8_lib = $(top_builddir)/src/share/win_utf8_io/libwin_utf8_io.la
-endif
+	main.c \
+	$(windows_unicode_compat)
 
 test_picture_LDADD = \
 	$(top_builddir)/src/share/grabbag/libgrabbag.la \

--- a/src/test_libFLAC++/CMakeLists.txt
+++ b/src/test_libFLAC++/CMakeLists.txt
@@ -6,5 +6,6 @@ add_executable(test_libFLAC++
     metadata_manip.cpp
     metadata_object.cpp
     $<$<BOOL:${WIN32}>:../../include/share/win_utf8_io.h>
-    $<$<BOOL:${WIN32}>:../share/win_utf8_io/win_utf8_io.c>)
+    $<$<BOOL:${WIN32}>:../share/win_utf8_io/win_utf8_io.c>
+    $<$<BOOL:${WIN32}>:../share/windows_unicode_filenames.c>)
 target_link_libraries(test_libFLAC++ FLAC++ test_libs_common grabbag)

--- a/src/test_libFLAC++/Makefile.am
+++ b/src/test_libFLAC++/Makefile.am
@@ -28,6 +28,7 @@ check_PROGRAMS = test_libFLAC++
 
 if OS_IS_WINDOWS
 win_utf8_lib = $(top_builddir)/src/share/win_utf8_io/libwin_utf8_io.la
+windows_unicode_compat = $(top_builddir)/src/share/windows_unicode_filenames.c
 endif
 
 test_libFLAC___LDADD = \
@@ -49,6 +50,7 @@ test_libFLAC___SOURCES = \
 	metadata_object.cpp \
 	decoders.h \
 	encoders.h \
-	metadata.h
+	metadata.h \
+	$(windows_unicode_compat)
 
 CLEANFILES = test_libFLAC++.exe

--- a/src/test_libFLAC/CMakeLists.txt
+++ b/src/test_libFLAC/CMakeLists.txt
@@ -16,7 +16,8 @@ add_executable(test_libFLAC
     "$<TARGET_PROPERTY:FLAC,SOURCE_DIR>/crc.c"
     "$<TARGET_PROPERTY:FLAC,SOURCE_DIR>/md5.c"
     $<$<BOOL:${WIN32}>:../../include/share/win_utf8_io.h>
-    $<$<BOOL:${WIN32}>:../share/win_utf8_io/win_utf8_io.c>)
+    $<$<BOOL:${WIN32}>:../share/win_utf8_io/win_utf8_io.c>
+    $<$<BOOL:${WIN32}>:../share/windows_unicode_filenames.c>)
 
 target_compile_definitions(test_libFLAC PRIVATE
     $<$<BOOL:${ENABLE_64_BIT_WORDS}>:ENABLE_64_BIT_WORDS>)

--- a/src/test_seeking/CMakeLists.txt
+++ b/src/test_seeking/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(test_seeking
     main.c
     $<$<BOOL:${WIN32}>:../../include/share/win_utf8_io.h>
-    $<$<BOOL:${WIN32}>:../share/win_utf8_io/win_utf8_io.c>)
+    $<$<BOOL:${WIN32}>:../share/win_utf8_io/win_utf8_io.c>
+    $<$<BOOL:${WIN32}>:../share/windows_unicode_filenames.c>)
 target_link_libraries(test_seeking FLAC)

--- a/src/test_seeking/Makefile.am
+++ b/src/test_seeking/Makefile.am
@@ -27,11 +27,16 @@ AM_CFLAGS = @OGG_CFLAGS@
 
 AM_CPPFLAGS = -I$(top_builddir) -I$(srcdir)/include -I$(top_srcdir)/include
 
+if OS_IS_WINDOWS
+windows_unicode_compat = $(top_builddir)/src/share/windows_unicode_filenames.c
+endif
+
 check_PROGRAMS = test_seeking
 test_seeking_LDADD = \
 	$(top_builddir)/src/libFLAC/libFLAC.la
 
 test_seeking_SOURCES = \
-	main.c
+	main.c \
+	$(windows_unicode_compat)
 
 CLEANFILES = test_seeking.exe


### PR DESCRIPTION
Commit b917d456 cleaned up MinGW DLLs, which had lots of exported functions that don't belong there. However, the functions in windows_unicode_filenames where kept, the fix marked as a kludge, because flac, metaflac and lots of testing relied on them.

windows_unicode_filenames.c is moved from src/libFLAC/ to src/share like the .h file with the same name, which was already in
include/share. flac and metaflac binaries now use these files directly instead of through libFLAC. While this might grow binary size (it actually shrinks mine), it provides a much cleaner DLL interface.