### PR TITLE
Series of patches and fixes for autotools building

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -531,7 +531,7 @@ AH_VERBATIM([FLAC_API_EXPORTS],
 #endif
 #endif])
 
-if test x$enable_shared != "xyes" ; then
+if test x$enable_static = "xyes" ; then
 dnl for correct FLAC_API
 	CPPFLAGS="-DFLAC__NO_DLL $CPPFLAGS"
 	fi

--- a/configure.ac
+++ b/configure.ac
@@ -199,6 +199,8 @@ case "$host" in
 	*mingw*)
 		CPPFLAGS="-D__MSVCRT_VERSION__=0x0601 $CPPFLAGS"
 		os_is_windows=yes
+		AC_SEARCH_LIBS(__memset_chk, ssp, , mingw_has_memset_chk=no)
+		AC_SEARCH_LIBS(__stack_chk_fail, ssp, , mingw_has_stack_chk_fail=no)
 		;;
 esac
 
@@ -301,7 +303,7 @@ AC_ARG_ENABLE(werror,
 
 AC_ARG_ENABLE([stack-smash-protection],
     [AS_HELP_STRING([--disable-stack-smash-protection],[Disable GNU GCC stack smash protection])],,
-    [AS_IF([test "$ac_cv_c_compiler_gnu" = "yes" && test "$os_is_windows" = "no"],
+    [AS_IF([test "$ac_cv_c_compiler_gnu" = "yes" && test "x$mingw_has_stack_chk_fail" != "xno"],
         [enable_stack_smash_protection=yes],[enable_stack_smash_protection=no])])
 
 AC_ARG_ENABLE(64-bit-words,
@@ -460,7 +462,11 @@ if test x$ac_cv_c_compiler_gnu = xyes -o x$xiph_cv_c_compiler_clang = xyes ; the
 	dnl some distributions (such as Gentoo) have _FORTIFY_SOURCE always
 	dnl enabled. We test for this situation in order to prevent polluting
 	dnl the console with messages of macro redefinitions.
-	AX_ADD_FORTIFY_SOURCE
+
+	if test "x$mingw_has_memset_chk" != "xno"
+	then
+		AX_ADD_FORTIFY_SOURCE
+	fi
 
 	AC_LANG_PUSH([C++])
 	XIPH_ADD_CXXFLAGS([-Weffc++])

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ AX_CHECK_ENABLE_DEBUG
 user_cflags=$CFLAGS
 
 #Prefer whatever the current ISO standard is.
-AC_PROG_CC_STDC
+AC_PROG_CC
 AC_USE_SYSTEM_EXTENSIONS
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 LT_INIT([win32-dll disable-static pic-only])
@@ -63,7 +63,6 @@ fi
 AC_LANG_POP([C++])
 
 # c flavor
-AC_HEADER_STDC
 AM_PROG_CC_C_O
 AC_C_INLINE
 AC_C_VARARRAYS

--- a/configure.ac
+++ b/configure.ac
@@ -54,18 +54,8 @@ AC_CHECK_SIZEOF(off_t,1)	# Fake default value.
 AC_CHECK_SIZEOF([void*])
 AC_SEARCH_LIBS([lround],[m], [AC_DEFINE(HAVE_LROUND,1,lround support)])
 
-AC_LANG_PUSH([C++])
-# c++ flavor first
-AC_C_VARARRAYS
-if test $ac_cv_c_vararrays = yes; then
-	AC_DEFINE([HAVE_CXX_VARARRAYS], 1, [Define to 1 if C++ supports variable-length arrays.])
-fi
-AC_LANG_POP([C++])
-
-# c flavor
 AM_PROG_CC_C_O
 AC_C_INLINE
-AC_C_VARARRAYS
 AC_C_TYPEOF
 
 AC_CHECK_HEADERS([stdint.h inttypes.h byteswap.h sys/param.h sys/ioctl.h termios.h x86intrin.h cpuid.h])

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@
 # instead of FLAC__ since autoconf triggers off 'AC_' in strings
 
 AC_PREREQ(2.60)
-AC_INIT([flac], [1.3.4], [flac-dev@xiph.org], [flac], [https://www.xiph.org/flac/])
+AC_INIT([flac],[1.3.4],[flac-dev@xiph.org],[flac],[https://www.xiph.org/flac/])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_SRCDIR([src/flac/main.c])
 AC_CONFIG_MACRO_DIR([m4])
@@ -90,7 +90,7 @@ AC_DEFINE_UNQUOTED(CPU_IS_LITTLE_ENDIAN, ${ac_cv_c_little_endian},
 AC_DEFINE_UNQUOTED(WORDS_BIGENDIAN, ${ac_cv_c_big_endian},
 					[Target processor is big endian.])
 
-AC_ARG_ENABLE(asm-optimizations, AC_HELP_STRING([--disable-asm-optimizations], [Don't use any assembly optimization routines]), asm_opt=no, asm_opt=yes)
+AC_ARG_ENABLE(asm-optimizations, AS_HELP_STRING([--disable-asm-optimizations],[Don't use any assembly optimization routines]), asm_opt=no, asm_opt=yes)
 dnl ' Terminate the damn single quote
 AM_CONDITIONAL(FLaC__NO_ASM, test "x$asm_opt" = xno)
 if test "x$asm_opt" = xno ; then
@@ -238,7 +238,7 @@ fi
 AM_CONDITIONAL([DEBUG], [test "x${ax_enable_debug}" = "xyes" || test "x${ax_enable_debug}" = "xinfo"])
 
 AC_ARG_ENABLE(sse,
-AC_HELP_STRING([--disable-sse], [Disable passing of -msse2 to the compiler]),
+AS_HELP_STRING([--disable-sse],[Disable passing of -msse2 to the compiler]),
 [case "${enableval}" in
 	yes) sse_os=yes ;;
 	no)  sse_os=no ;;
@@ -246,7 +246,7 @@ AC_HELP_STRING([--disable-sse], [Disable passing of -msse2 to the compiler]),
 esac],[sse_os=yes])
 
 AC_ARG_ENABLE(altivec,
-AC_HELP_STRING([--disable-altivec], [Disable Altivec optimizations]),
+AS_HELP_STRING([--disable-altivec],[Disable Altivec optimizations]),
 [case "${enableval}" in
 	yes) use_altivec=true ;;
 	no)  use_altivec=false ;;
@@ -259,7 +259,7 @@ AH_TEMPLATE(FLAC__USE_ALTIVEC, [define to enable use of Altivec instructions])
 fi
 
 AC_ARG_ENABLE(vsx,
-AC_HELP_STRING([--disable-vsx], [Disable VSX optimizations]),
+AS_HELP_STRING([--disable-vsx],[Disable VSX optimizations]),
 [case "${enableval}" in
 	yes) use_vsx=true ;;
 	no)  use_vsx=false ;;
@@ -272,7 +272,7 @@ AH_TEMPLATE(FLAC__USE_VSX, [define to enable use of VSX instructions])
 fi
 
 AC_ARG_ENABLE(avx,
-AC_HELP_STRING([--disable-avx], [Disable AVX, AVX2 optimizations]),
+AS_HELP_STRING([--disable-avx],[Disable AVX, AVX2 optimizations]),
 [case "${enableval}" in
 	yes) use_avx=true ;;
 	no)  use_avx=false ;;
@@ -285,14 +285,14 @@ AH_TEMPLATE(FLAC__USE_AVX, [define to enable use of AVX instructions])
 fi
 
 AC_ARG_ENABLE(thorough-tests,
-AC_HELP_STRING([--disable-thorough-tests], [Disable thorough (long) testing, do only basic tests]),
+AS_HELP_STRING([--disable-thorough-tests],[Disable thorough (long) testing, do only basic tests]),
 [case "${enableval}" in
 	yes) thorough_tests=true ;;
 	no)  thorough_tests=false ;;
 	*) AC_MSG_ERROR(bad value ${enableval} for --enable-thorough-tests) ;;
 esac],[thorough_tests=true])
 AC_ARG_ENABLE(exhaustive-tests,
-AC_HELP_STRING([--enable-exhaustive-tests], [Enable exhaustive testing (VERY long)]),
+AS_HELP_STRING([--enable-exhaustive-tests],[Enable exhaustive testing (VERY long)]),
 [case "${enableval}" in
 	yes) exhaustive_tests=true ;;
 	no)  exhaustive_tests=false ;;
@@ -308,7 +308,7 @@ fi
 AC_SUBST(FLAC__TEST_LEVEL)
 
 AC_ARG_ENABLE(werror,
-	AC_HELP_STRING([--enable-werror], [Enable -Werror in all Makefiles]))
+	AS_HELP_STRING([--enable-werror],[Enable -Werror in all Makefiles]))
 
 AC_ARG_ENABLE([stack-smash-protection],
     [AS_HELP_STRING([--disable-stack-smash-protection],[Disable GNU GCC stack smash protection])],,
@@ -316,7 +316,7 @@ AC_ARG_ENABLE([stack-smash-protection],
         [enable_stack_smash_protection=yes],[enable_stack_smash_protection=no])])
 
 AC_ARG_ENABLE(64-bit-words,
-	AC_HELP_STRING([--enable-64-bit-words], [Set FLAC__BYTES_PER_WORD to 8 (4 is the default)]))
+	AS_HELP_STRING([--enable-64-bit-words],[Set FLAC__BYTES_PER_WORD to 8 (4 is the default)]))
 if test "x$enable_64_bit_words" = xyes ; then
 	AC_DEFINE_UNQUOTED([ENABLE_64_BIT_WORDS],1,[Set FLAC__BYTES_PER_WORD to 8 (4 is the default)])
 else
@@ -325,7 +325,7 @@ else
 AC_SUBST(ENABLE_64_BIT_WORDS)
 
 AC_ARG_ENABLE(valgrind-testing,
-AC_HELP_STRING([--enable-valgrind-testing], [Run all tests inside Valgrind]),
+AS_HELP_STRING([--enable-valgrind-testing],[Run all tests inside Valgrind]),
 [case "${enableval}" in
 	yes) FLAC__TEST_WITH_VALGRIND=yes ;;
 	no)  FLAC__TEST_WITH_VALGRIND=no ;;
@@ -334,7 +334,7 @@ esac],[FLAC__TEST_WITH_VALGRIND=no])
 AC_SUBST(FLAC__TEST_WITH_VALGRIND)
 
 AC_ARG_ENABLE(doxygen-docs,
-AC_HELP_STRING([--disable-doxygen-docs], [Disable API documentation building via Doxygen]),
+AS_HELP_STRING([--disable-doxygen-docs],[Disable API documentation building via Doxygen]),
 [case "${enableval}" in
 	yes) enable_doxygen_docs=true ;;
 	no)  enable_doxygen_docs=false ;;
@@ -346,7 +346,7 @@ fi
 AM_CONDITIONAL(FLaC__HAS_DOXYGEN, test -n "$DOXYGEN")
 
 AC_ARG_ENABLE(local-xmms-plugin,
-AC_HELP_STRING([--enable-local-xmms-plugin], [Install XMMS plugin to ~/.xmms/Plugins instead of system location]),
+AS_HELP_STRING([--enable-local-xmms-plugin],[Install XMMS plugin to ~/.xmms/Plugins instead of system location]),
 [case "${enableval}" in
 	yes) install_xmms_plugin_locally=true ;;
 	no)  install_xmms_plugin_locally=false ;;
@@ -355,7 +355,7 @@ esac],[install_xmms_plugin_locally=false])
 AM_CONDITIONAL(FLaC__INSTALL_XMMS_PLUGIN_LOCALLY, test "x$install_xmms_plugin_locally" = xtrue)
 
 AC_ARG_ENABLE(xmms-plugin,
-AC_HELP_STRING([--disable-xmms-plugin], [Do not build XMMS plugin]),
+AS_HELP_STRING([--disable-xmms-plugin],[Do not build XMMS plugin]),
 [case "${enableval}" in
 	yes) enable_xmms_plugin=true ;;
 	no)  enable_xmms_plugin=false ;;
@@ -368,7 +368,7 @@ AM_CONDITIONAL(FLaC__HAS_XMMS, test -n "$XMMS_INPUT_PLUGIN_DIR")
 
 dnl build FLAC++ or not
 AC_ARG_ENABLE([cpplibs],
-AC_HELP_STRING([--disable-cpplibs], [Do not build libFLAC++]),
+AS_HELP_STRING([--disable-cpplibs],[Do not build libFLAC++]),
 [case "${enableval}" in
 	yes) disable_cpplibs=false ;;
 	no)  disable_cpplibs=true ;;
@@ -404,7 +404,7 @@ AC_SUBST([LIB_FUZZING_ENGINE])
 
 dnl check for ogg library
 AC_ARG_ENABLE([ogg],
-	AC_HELP_STRING([--disable-ogg], [Disable ogg support (default: test for libogg)]),
+	AS_HELP_STRING([--disable-ogg],[Disable ogg support (default: test for libogg)]),
 	[ want_ogg=$enableval ], [ want_ogg=yes ] )
 
 if test "x$want_ogg" != "xno"; then

--- a/include/FLAC++/export.h
+++ b/include/FLAC++/export.h
@@ -55,15 +55,22 @@
  *
  * \{
  */
+ 
+/* This has grown quite complicated. FLAC__NO_DLL is used by MSVC sln
+ * files and CMake, which build either static or shared. autotools can
+ * build static, shared or **both**. Therefore, DLL_EXPORT, which is set
+ * by libtool, must override FLAC__NO_DLL on building shared components
+ */
+#if defined(_WIN32)
 
-#if defined(FLAC__NO_DLL)
+#if defined(FLAC__NO_DLL) && !(defined(DLL_EXPORT))
 #define FLACPP_API
-
-#elif defined(_WIN32)
+#else
 #ifdef FLACPP_API_EXPORTS
 #define	FLACPP_API __declspec(dllexport)
 #else
 #define FLACPP_API __declspec(dllimport)
+#endif
 #endif
 
 #elif defined(FLAC__USE_VISIBILITY_ATTR)

--- a/include/FLAC/export.h
+++ b/include/FLAC/export.h
@@ -56,14 +56,21 @@
  * \{
  */
 
-#if defined(FLAC__NO_DLL)
-#define FLAC_API
+/* This has grown quite complicated. FLAC__NO_DLL is used by MSVC sln
+ * files and CMake, which build either static or shared. autotools can
+ * build static, shared or **both**. Therefore, DLL_EXPORT, which is set
+ * by libtool, must override FLAC__NO_DLL on building shared components
+ */
+#if defined(_WIN32)
 
-#elif defined(_WIN32)
+#if defined(FLAC__NO_DLL) && !(defined(DLL_EXPORT))
+#define FLAC_API
+#else
 #ifdef FLAC_API_EXPORTS
 #define	FLAC_API __declspec(dllexport)
 #else
 #define FLAC_API __declspec(dllimport)
+#endif
 #endif
 
 #elif defined(FLAC__USE_VISIBILITY_ATTR)

--- a/m4/add_cflags.m4
+++ b/m4/add_cflags.m4
@@ -6,13 +6,10 @@ AC_DEFUN([XIPH_ADD_CFLAGS],
 [AC_MSG_CHECKING([if $CC accepts $1])
 	ac_add_cflags__old_cflags="$CFLAGS"
 	CFLAGS="$1"
-	AC_TRY_LINK([
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 			#include <stdio.h>
-			],
-		[puts("Hello, World!"); return 0;],
-		AC_MSG_RESULT([yes])
-			CFLAGS="$ac_add_cflags__old_cflags $1",
-		AC_MSG_RESULT([no])
+			]], [[puts("Hello, World!"); return 0;]])],[AC_MSG_RESULT(yes)
+			CFLAGS="$ac_add_cflags__old_cflags $1"],[AC_MSG_RESULT(no)
 			CFLAGS="$ac_add_cflags__old_cflags"
-		)
+		])
 ])# XIPH_ADD_CFLAGS

--- a/m4/add_cxxflags.m4
+++ b/m4/add_cxxflags.m4
@@ -7,13 +7,10 @@ AC_DEFUN([XIPH_ADD_CXXFLAGS],
 	AC_LANG_ASSERT([C++])
 	ac_add_cxxflags__old_cxxflags="$CXXFLAGS"
 	CXXFLAGS="$1"
-	AC_TRY_LINK([
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 			#include <cstdio>
-			],
-		[puts("Hello, World!"); return 0;],
-		AC_MSG_RESULT([yes])
-			CXXFLAGS="$ac_add_cxxflags__old_cxxflags $1",
-		AC_MSG_RESULT([no])
+			]], [[puts("Hello, World!"); return 0;]])],[AC_MSG_RESULT(yes)
+			CXXFLAGS="$ac_add_cxxflags__old_cxxflags $1"],[AC_MSG_RESULT(no)
 			CXXFLAGS="$ac_add_cxxflags__old_cxxflags"
-		)
+		])
 ])# XIPH_ADD_CXXFLAGS

--- a/m4/bswap.m4
+++ b/m4/bswap.m4
@@ -43,11 +43,9 @@ AC_DEFUN([XIPH_C_BSWAP32],
   ac_cv_c_bswap32=no
   HAVE_BSWAP32=0
 
-  [AC_TRY_LINK([],
-    return __builtin_bswap32 (0) ;,
-    ac_cv_c_bswap32=yes
+  [AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return __builtin_bswap32 (0) ;]])],[ac_cv_c_bswap32=yes
     HAVE_BSWAP32=1
-  )]
+  ],[])]
   AC_DEFINE_UNQUOTED(HAVE_BSWAP32, ${HAVE_BSWAP32},
     [Compiler has the __builtin_bswap32 intrinsic])
 
@@ -70,11 +68,9 @@ AC_DEFUN([XIPH_C_BSWAP16],
   ac_cv_c_bswap16=no
   HAVE_BSWAP16=0
 
-  [AC_TRY_LINK([],
-    return __builtin_bswap16 (0) ;,
-    ac_cv_c_bswap16=yes
+  [AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return __builtin_bswap16 (0) ;]])],[ac_cv_c_bswap16=yes
     HAVE_BSWAP16=1
-  )]
+  ],[])]
   AC_DEFINE_UNQUOTED(HAVE_BSWAP16, ${HAVE_BSWAP16},
     [Compiler has the __builtin_bswap16 intrinsic])
 

--- a/m4/clang.m4
+++ b/m4/clang.m4
@@ -16,16 +16,13 @@ AC_DEFUN([XIPH_C_COMPILER_IS_CLANG],
 [AC_CACHE_CHECK(whether we are using the CLANG C compiler,
 	xiph_cv_c_compiler_clang,
 	[	AC_LANG_ASSERT(C)
-		AC_TRY_LINK([
+		AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 			#include <stdio.h>
-			],
-			[
+			]], [[
 			#ifndef __clang__
 				This is not clang!
 			#endif
-			],
-		xiph_cv_c_compiler_clang=yes,
-		xiph_cv_c_compiler_clang=no
-		])
+			]])],[xiph_cv_c_compiler_clang=yes],[xiph_cv_c_compiler_clang=no
+		])]
 	)]
 )

--- a/m4/endian.m4
+++ b/m4/endian.m4
@@ -36,7 +36,7 @@ dnl @author Erik de Castro Lopo <erikd@mega-nerd.com>
 dnl
 dnl Majority written from scratch to replace the standard autoconf macro
 dnl AC_C_BIGENDIAN. Only part remaining from the original is the invocation
-dnl of the AC_TRY_RUN macro.
+dnl of the AC_RUN_IFELSE([AC_LANG_SOURCE([[]])],[],[],[]) macro.
 dnl
 dnl Find endian-ness in the following way:
 dnl    1) Look in <endian.h>.
@@ -55,37 +55,33 @@ if test x$ac_cv_header_endian_h = xyes ; then
 
 	# First try <endian.h> which should set BYTE_ORDER.
 
-	[AC_TRY_LINK([
+	[AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 		#include <endian.h>
 		#if BYTE_ORDER != LITTLE_ENDIAN
 			not big endian
 		#endif
-		], return 0 ;,
-			ac_cv_c_byte_order=little
-		)]
+		]], [[return 0 ;]])],[ac_cv_c_byte_order=little
+		],[])]
 
-	[AC_TRY_LINK([
+	[AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 		#include <endian.h>
 		#if BYTE_ORDER != BIG_ENDIAN
 			not big endian
 		#endif
-		], return 0 ;,
-			ac_cv_c_byte_order=big
-		)]
+		]], [[return 0 ;]])],[ac_cv_c_byte_order=big
+		],[])]
 
 	fi
 
 if test $ac_cv_c_byte_order = unknown ; then
 
-	[AC_TRY_LINK([
+	[AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 		#include <sys/types.h>
 		#include <sys/param.h>
 		#if !BYTE_ORDER || !BIG_ENDIAN || !LITTLE_ENDIAN
 			bogus endian macros
 		#endif
-		], return 0 ;,
-
-		[AC_TRY_LINK([
+		]], [[return 0 ;]])],[_au_m4_changequote([,])AC_TRY_LINK([
 			#include <sys/types.h>
 			#include <sys/param.h>
 			#if BYTE_ORDER != LITTLE_ENDIAN
@@ -93,9 +89,9 @@ if test $ac_cv_c_byte_order = unknown ; then
 			#endif
 			], return 0 ;,
 				ac_cv_c_byte_order=little
-			)]
+			)
 
-		[AC_TRY_LINK([
+		_au_m4_changequote([,])AC_TRY_LINK([
 			#include <sys/types.h>
 			#include <sys/param.h>
 			#if BYTE_ORDER != LITTLE_ENDIAN
@@ -103,9 +99,9 @@ if test $ac_cv_c_byte_order = unknown ; then
 			#endif
 			], return 0 ;,
 				ac_cv_c_byte_order=little
-			)]
+			)
 
-		)]
+		],[])]
 
  	fi
 
@@ -126,8 +122,7 @@ if test $ac_cv_c_byte_order = unknown ; then
 			esac
 		]
 	else
-		AC_TRY_RUN(
-		[[
+		AC_RUN_IFELSE([AC_LANG_SOURCE([[[
 		int main (void)
 		{	/* Are we little or big endian?  From Harbison&Steele.  */
 			union
@@ -137,11 +132,9 @@ if test $ac_cv_c_byte_order = unknown ; then
 			u.l = 1 ;
 			return (u.c [sizeof (long) - 1] == 1);
 			}
-			]], , ac_cv_c_byte_order=big,
-			)
+			]]])],[],[ac_cv_c_byte_order=big],[])
 
-		AC_TRY_RUN(
-		[[int main (void)
+		AC_RUN_IFELSE([AC_LANG_SOURCE([[[int main (void)
 		{	/* Are we little or big endian?  From Harbison&Steele.  */
 			union
 			{	long l ;
@@ -149,8 +142,7 @@ if test $ac_cv_c_byte_order = unknown ; then
 			} u ;
 			u.l = 1 ;
 			return (u.c [0] == 1);
-			}]], , ac_cv_c_byte_order=little,
-			)
+			}]]])],[],[ac_cv_c_byte_order=little],[])
 		fi
 	fi
 

--- a/m4/lib-prefix.m4
+++ b/m4/lib-prefix.m4
@@ -9,7 +9,7 @@ dnl From Bruno Haible.
 dnl AC_LIB_ARG_WITH is synonymous to AC_ARG_WITH in autoconf-2.13, and
 dnl similar to AC_ARG_WITH in autoconf 2.52...2.57 except that is doesn't
 dnl require excessive bracketing.
-ifdef([AC_HELP_STRING],
+ifdef([AS_HELP_STRING],
 [AC_DEFUN([AC_LIB_ARG_WITH], [AC_ARG_WITH([$1],[[$2]],[$3],[$4])])],
 [AC_DEFUN([AC_][LIB_ARG_WITH], [AC_ARG_WITH([$1],[$2],[$3],[$4])])])
 

--- a/m4/ogg.m4
+++ b/m4/ogg.m4
@@ -9,10 +9,10 @@ AC_DEFUN([XIPH_PATH_OGG],
 [dnl 
 dnl Get the cflags and libraries
 dnl
-AC_ARG_WITH(ogg,AC_HELP_STRING([--with-ogg=PFX],[Prefix where libogg is installed (optional)]), ogg_prefix="$withval", ogg_prefix="")
-AC_ARG_WITH(ogg-libraries,AC_HELP_STRING([--with-ogg-libraries=DIR],[Directory where libogg library is installed (optional)]), ogg_libraries="$withval", ogg_libraries="")
-AC_ARG_WITH(ogg-includes,AC_HELP_STRING([--with-ogg-includes=DIR],[Directory where libogg header files are installed (optional)]), ogg_includes="$withval", ogg_includes="")
-AC_ARG_ENABLE(oggtest,AC_HELP_STRING([--disable-oggtest],[Do not try to compile and run a test Ogg program]),, enable_oggtest=yes)
+AC_ARG_WITH(ogg,AS_HELP_STRING([--with-ogg=PFX],[Prefix where libogg is installed (optional)]), ogg_prefix="$withval", ogg_prefix="")
+AC_ARG_WITH(ogg-libraries,AS_HELP_STRING([--with-ogg-libraries=DIR],[Directory where libogg library is installed (optional)]), ogg_libraries="$withval", ogg_libraries="")
+AC_ARG_WITH(ogg-includes,AS_HELP_STRING([--with-ogg-includes=DIR],[Directory where libogg header files are installed (optional)]), ogg_includes="$withval", ogg_includes="")
+AC_ARG_ENABLE(oggtest,AS_HELP_STRING([--disable-oggtest],[Do not try to compile and run a test Ogg program]),, enable_oggtest=yes)
 
   if test "x$ogg_libraries" != "x" ; then
     OGG_LIBS="-L$ogg_libraries"
@@ -56,7 +56,7 @@ dnl
 dnl Now check if the installed Ogg is sufficiently new.
 dnl
       rm -f conf.oggtest
-      AC_TRY_RUN([
+      AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -68,7 +68,7 @@ int main ()
   return 0;
 }
 
-],, no_ogg=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
+]])],[],[no_ogg=yes],[echo $ac_n "cross compiling; assumed OK... $ac_c"])
        CFLAGS="$ac_save_CFLAGS"
        LIBS="$ac_save_LIBS"
   fi
@@ -87,11 +87,10 @@ int main ()
        echo "*** Could not run Ogg test program, checking why..."
        CFLAGS="$CFLAGS $OGG_CFLAGS"
        LIBS="$LIBS $OGG_LIBS"
-       AC_TRY_LINK([
+       AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <stdio.h>
 #include <ogg/ogg.h>
-],     [ return 0; ],
-       [ echo "*** The test program compiled, but did not run. This usually means"
+]], [[ return 0; ]])],[ echo "*** The test program compiled, but did not run. This usually means"
        echo "*** that the run-time linker is not finding Ogg or finding the wrong"
        echo "*** version of Ogg. If it is not finding Ogg, you'll need to set your"
        echo "*** LD_LIBRARY_PATH environment variable, or edit /etc/ld.so.conf to point"
@@ -99,8 +98,7 @@ int main ()
        echo "*** is required on your system"
        echo "***"
        echo "*** If you have an old version installed, it is best to remove it, although"
-       echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH"],
-       [ echo "*** The test program failed to compile or link. See the file config.log for the"
+       echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH"],[ echo "*** The test program failed to compile or link. See the file config.log for the"
        echo "*** exact error that occurred. This usually means Ogg was incorrectly installed"
        echo "*** or that you have moved Ogg since it was installed." ])
        CFLAGS="$ac_save_CFLAGS"

--- a/m4/really_gcc.m4
+++ b/m4/really_gcc.m4
@@ -17,16 +17,13 @@ dnl
 AC_DEFUN([XIPH_GCC_REALLY_IS_GCC],
 [	AC_LANG_ASSERT(C)
 	if test "x$ac_cv_c_compiler_gnu" = "xyes" ; then
-		AC_TRY_LINK([
+		AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 			#include <stdio.h>
-			],
-			[
+			]], [[
 			#ifdef __clang__
 				This is clang!
 			#endif
-			],
-		ac_cv_c_compiler_gnu=yes,
-		ac_cv_c_compiler_gnu=no
-		)
+			]])],[ac_cv_c_compiler_gnu=yes],[ac_cv_c_compiler_gnu=no
+		])
 		fi
 ])

--- a/m4/stack_protect.m4
+++ b/m4/stack_protect.m4
@@ -43,15 +43,12 @@ AC_DEFUN([XIPH_GCC_STACK_PROTECTOR],
 	xiph_stack_check_old_cflags="$CFLAGS"
 	SSP_FLAGS="-fstack-protector-strong"
 	CFLAGS=$SSP_FLAGS
-	AC_TRY_LINK([
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 			#include <stdio.h>
-			],
-		[puts("Hello, World!"); return 0;],
-		AC_MSG_RESULT([yes])
-			CFLAGS="$xiph_stack_check_old_cflags $SSP_FLAGS",
-		AC_MSG_RESULT([no])
+			]], [[puts("Hello, World!"); return 0;]])],[AC_MSG_RESULT(yes)
+			CFLAGS="$xiph_stack_check_old_cflags $SSP_FLAGS"],[AC_MSG_RESULT(no)
 			CFLAGS="$xiph_stack_check_old_cflags"
-		)
+		])
 ])# XIPH_GCC_STACK_PROTECTOR
 
 AC_DEFUN([XIPH_GXX_STACK_PROTECTOR],
@@ -60,14 +57,11 @@ AC_DEFUN([XIPH_GXX_STACK_PROTECTOR],
 	xiph_stack_check_old_cflags="$CFLAGS"
 	SSP_FLAGS="-fstack-protector-strong"
 	CFLAGS=$SSP_FLAGS
-	AC_TRY_LINK([
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 			#include <cstdio>
-			],
-		[puts("Hello, World!"); return 0;],
-		AC_MSG_RESULT([yes])
-			CFLAGS="$xiph_stack_check_old_cflags $SSP_FLAGS",
-		AC_MSG_RESULT([no])
+			]], [[puts("Hello, World!"); return 0;]])],[AC_MSG_RESULT(yes)
+			CFLAGS="$xiph_stack_check_old_cflags $SSP_FLAGS"],[AC_MSG_RESULT(no)
 			CFLAGS="$xiph_stack_check_old_cflags"
-		)
+		])
 	AC_LANG_POP([C++])
 ])# XIPH_GXX_STACK_PROTECTOR

--- a/src/libFLAC++/stream_encoder.cpp
+++ b/src/libFLAC++/stream_encoder.cpp
@@ -198,26 +198,17 @@ namespace FLAC {
 		bool Stream::set_metadata(FLAC::Metadata::Prototype **metadata, uint32_t num_blocks)
 		{
 			FLAC__ASSERT(is_valid());
-#ifndef HAVE_CXX_VARARRAYS
-			// some compilers (MSVC++, Borland C, SunPro, some GCCs w/ -pedantic) can't handle:
-			// ::FLAC__StreamMetadata *m[num_blocks];
-			// so we do this ugly workaround
+			// because C++ doesn't have VLA's (variable length arrays)
+			// this ugly workaround is needed
 			::FLAC__StreamMetadata **m = new ::FLAC__StreamMetadata*[num_blocks];
-#else
-			::FLAC__StreamMetadata *m[num_blocks];
-#endif
 			for(uint32_t i = 0; i < num_blocks; i++) {
 				// we can get away with the const_cast since we know the encoder will only correct the is_last flags
 				m[i] = const_cast< ::FLAC__StreamMetadata*>(static_cast<const ::FLAC__StreamMetadata*>(*metadata[i]));
 			}
-#ifndef HAVE_CXX_VARARRAYS
 			// complete the hack
 			const bool ok = static_cast<bool>(::FLAC__stream_encoder_set_metadata(encoder_, m, num_blocks));
 			delete [] m;
 			return ok;
-#else
-			return static_cast<bool>(::FLAC__stream_encoder_set_metadata(encoder_, m, num_blocks));
-#endif
 		}
 
 		Stream::State Stream::get_state() const


### PR DESCRIPTION
Autoconf 2.70 and newer versions trigger warnings about obsolete macro's and revealed a problem with variable-length arrays being used in C++ code (which is apparently not according to spec). Also, two fixed specific to MinGW are included. See commit descriptions for details