### PR TITLE
Add 'fact' chunk for WAVE_FORMAT_EXTENSIBLE

### DIFF
--- a/src/flac/decode.c
+++ b/src/flac/decode.c
@@ -753,7 +753,7 @@ FLAC__bool write_iff_headers(FILE *f, DecoderSession *decoder_session, FLAC__uin
 				if(flac__utils_fwrite("\x66\x61\x63\x74\xF3\xAC\xD3\x11\x8C\xD1\x00\xC0\x4F\x8E\xDB\x8A", 1, 16, f) != 16)
 					return false;
 
-				if(!write_little_endian_uint64(f, 16+8+8)) /* chunk size +16+8+8 for GUID, size and sample length */
+				if(!write_little_endian_uint64(f, 8)) /* chunk size = 8 because all Wave64 fields are 64-bit */
 					return false;
 
 				if(!write_little_endian_uint64(f, samples))

--- a/src/test_streams/main.c
+++ b/src/test_streams/main.c
@@ -826,6 +826,28 @@ static FLAC__bool generate_wav(const char *filename, unsigned sample_rate, unsig
 		if(fwrite("\x01\x00\x00\x00\x00\x00\x10\x00\x80\x00\x00\xaa\x00\x38\x9b\x71", 1, 16, f) != 16)
 			goto foo;
 	}
+	/* fact chunk */
+	if(flavor < 2) {
+		if(waveformatextensible) {
+			if(fwrite("fact", 1, 4, f) < 4)
+				goto foo;
+			if(!write_little_endian_uint32(f, 4)) /* chunk size */
+				goto foo;
+			if(!write_little_endian_uint32(f, (FLAC__uint32)samples)) /* dwSampleLength */
+				goto foo;
+		}
+	}
+	else { /* wave64 */
+		if(waveformatextensible) {
+			/* fact GUID 74636166-ACF3-11D3-8CD1-00C04F8EDB8A */
+			if(fwrite("\x66\x61\x63\x74\xF3\xAC\xD3\x11\x8C\xD1\x00\xC0\x4F\x8E\xDB\x8A", 1, 16, f) < 16)
+				goto foo;
+			if(!write_little_endian_uint64(f, 4)) /* chunk size */
+				goto foo;
+			if(!write_little_endian_uint64(f, samples)) /* dwSampleLength */
+				goto foo;
+		}
+	}
 	/* data chunk */
 	if(flavor < 2) {
 		if(fwrite("data", 1, 4, f) < 4)

--- a/src/test_streams/main.c
+++ b/src/test_streams/main.c
@@ -840,7 +840,7 @@ static FLAC__bool generate_wav(const char *filename, unsigned sample_rate, unsig
 			/* fact GUID 74636166-ACF3-11D3-8CD1-00C04F8EDB8A */
 			if(fwrite("\x66\x61\x63\x74\xF3\xAC\xD3\x11\x8C\xD1\x00\xC0\x4F\x8E\xDB\x8A", 1, 16, f) < 16)
 				goto foo;
-			if(!write_little_endian_uint64(f, 4)) /* chunk size */
+			if(!write_little_endian_uint64(f, 8)) /* chunk size */
 				goto foo;
 			if(!write_little_endian_uint64(f, samples)) /* dwSampleLength */
 				goto foo;

--- a/src/test_streams/main.c
+++ b/src/test_streams/main.c
@@ -827,8 +827,8 @@ static FLAC__bool generate_wav(const char *filename, unsigned sample_rate, unsig
 			goto foo;
 	}
 	/* fact chunk */
-	if(flavor < 2) {
-		if(waveformatextensible) {
+	if(waveformatextensible) {
+		if(flavor < 2) {
 			if(fwrite("fact", 1, 4, f) < 4)
 				goto foo;
 			if(!write_little_endian_uint32(f, 4)) /* chunk size */
@@ -836,9 +836,7 @@ static FLAC__bool generate_wav(const char *filename, unsigned sample_rate, unsig
 			if(!write_little_endian_uint32(f, (FLAC__uint32)samples)) /* dwSampleLength */
 				goto foo;
 		}
-	}
-	else { /* wave64 */
-		if(waveformatextensible) {
+		else { /* wave64 */
 			/* fact GUID 74636166-ACF3-11D3-8CD1-00C04F8EDB8A */
 			if(fwrite("\x66\x61\x63\x74\xF3\xAC\xD3\x11\x8C\xD1\x00\xC0\x4F\x8E\xDB\x8A", 1, 16, f) < 16)
 				goto foo;


### PR DESCRIPTION
Draft PR as this is a work in progress (lots of assumptions are made) and tests are failing.

Started working on this as a solution to #141. The [linked page](http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html) suggests `There is a question as to whether the fact chunk should be used for (including those with PCM) WAVE_FORMAT_EXTENSIBLE files. One example of a WAVE_FORMAT_EXTENSIBLE with PCM data from Microsoft, does not have a fact chunk.`, but libsndfile will complain of a missing `fact` chunk if there is no `fact` chunk present in a WAVE_FORMAT_EXTENSIBLE file, so I'm not sure how necessary the field actually is, especially considering the data for the chunk is redundant (and we aren't using it in any meaningful way).