### PR TITLE
Replace seek error with handling when hitting EOF while reading frame

### DIFF
--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -3154,8 +3154,14 @@ FLAC__bool seek_to_absolute_sample_(FLAC__StreamDecoder *decoder, FLAC__uint64 s
 		 * FLAC__stream_decoder_process_single() to return false.
 		 */
 		decoder->private_->unparseable_frame_count = 0;
-		if(!FLAC__stream_decoder_process_single(decoder) ||
-		   decoder->protected_->state == FLAC__STREAM_DECODER_ABORTED) {
+		if(!FLAC__stream_decoder_process_single(decoder) && decoder->private_->eof_callback(decoder, decoder->private_->client_data)){
+			/* decoder has hit end of stream while processing corrupt
+			 * frame, try again. This is very inefficient but shouldn't
+			 * happen often, and a more efficient solution would require
+			 * quite a bit more code */
+			upper_bound--;
+			continue;
+		}else if(decoder->protected_->state == FLAC__STREAM_DECODER_ABORTED) {
 			decoder->protected_->state = FLAC__STREAM_DECODER_SEEK_ERROR;
 			return false;
 		}


### PR DESCRIPTION
This fixes the issue mentioned by @wader in https://github.com/xiph/flac/issues/276#issuecomment-1026603582 and for which the file can be found here: https://trac.ffmpeg.org/ticket/9621

The issue resolved here caused a seek error when seeking to a sample near the end of the stream, when the last frame is truncated or a fake header causes libFLAC to try to read beyond the end of the stream.