### PR TITLE
Wrap find_package Ogg with a "found" condition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ option(WITH_OGG "ogg support (default: test for libogg)" ON)
 set(VERSION ${PROJECT_VERSION})
 
 if(WITH_OGG)
-    find_package(Ogg REQUIRED)
+    if(NOT TARGET Ogg::ogg)
+        find_package(Ogg REQUIRED)
+    endif()
     set(OGG_PACKAGE "ogg")
 endif()
 

--- a/flac-config.cmake.in
+++ b/flac-config.cmake.in
@@ -1,7 +1,9 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Ogg)
+if(NOT TARGET Ogg::ogg)
+    find_dependency(Ogg)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/targets.cmake")
 


### PR DESCRIPTION
This is needed in the case of using `add_subdirectory` with libflac in a build tree containing Ogg