### PR TITLE
Fix uclibc build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ AM_PROG_CC_C_O
 AC_C_INLINE
 AC_C_TYPEOF
 
-AC_CHECK_HEADERS([stdint.h inttypes.h byteswap.h sys/param.h sys/ioctl.h termios.h x86intrin.h cpuid.h arm_neon.h])
+AC_CHECK_HEADERS([stdint.h inttypes.h byteswap.h sys/auxv.h sys/param.h sys/ioctl.h termios.h x86intrin.h cpuid.h arm_neon.h])
 
 XIPH_C_BSWAP32
 XIPH_C_BSWAP16
@@ -89,6 +89,9 @@ fi
 
 # For the XMMS plugin.
 AC_CHECK_TYPES(socklen_t, [], [])
+
+dnl check for getauxval in standard library
+AC_CHECK_FUNCS(getauxval)
 
 dnl check for getopt in standard library
 dnl AC_CHECK_FUNCS(getopt_long , , [LIBOBJS="$LIBOBJS getopt.o getopt1.o"] )

--- a/src/libFLAC/cpu.c
+++ b/src/libFLAC/cpu.c
@@ -53,10 +53,8 @@
 #define dfprintf(file, format, ...)
 #endif
 
-#if defined FLAC__CPU_PPC
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(HAVE_SYS_AUXV_H)
 #include <sys/auxv.h>
-#endif
 #endif
 
 #if (defined FLAC__CPU_IA32 || defined FLAC__CPU_X86_64) && (defined FLAC__HAS_NASM || FLAC__HAS_X86INTRIN) && !defined FLAC__NO_ASM
@@ -247,13 +245,13 @@ ppc_cpu_info (FLAC__CPUInfo *info)
 #define PPC_FEATURE2_ARCH_2_07		0x80000000
 #endif
 
-#ifdef __linux__
+#if defined (__linux__) && defined(HAVE_GETAUXVAL)
 	if (getauxval(AT_HWCAP2) & PPC_FEATURE2_ARCH_3_00) {
 		info->ppc.arch_3_00 = true;
 	} else if (getauxval(AT_HWCAP2) & PPC_FEATURE2_ARCH_2_07) {
 		info->ppc.arch_2_07 = true;
 	}
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) && defined(HAVE_GETAUXVAL)
 	unsigned long hwcaps;
 	elf_aux_info(AT_HWCAP2, &hwcaps, sizeof(hwcaps));
 	if (hwcaps & PPC_FEATURE2_ARCH_3_00) {
@@ -266,7 +264,8 @@ ppc_cpu_info (FLAC__CPUInfo *info)
 	info->ppc.arch_2_07 = false;
 	info->ppc.arch_3_00 = false;
 #else
-#error Unsupported platform! Please add support for reading ppc hwcaps.
+	info->ppc.arch_2_07 = false;
+	info->ppc.arch_3_00 = false;
 #endif
 
 #else


### PR DESCRIPTION
Commit 4fbb6d4f2ecf2a96c17ea9880108409f852c08a9 reverted commit 44036c9a9b45d03373fe90e9c112852bfc054c51 and so broke again the build on uclibc

So put back the `sys/auxv.h` check as well as a `getauxval` check in a way that doesn't break iOS

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>