### PR TITLE
Move initialization of state up in stream_encoder_new

### DIFF
--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -536,6 +536,8 @@ FLAC_API FLAC__StreamEncoder *FLAC__stream_encoder_new(void)
 
 	encoder->private_->file = 0;
 
+	encoder->protected_->state = FLAC__STREAM_ENCODER_UNINITIALIZED;
+
 	set_defaults_(encoder);
 
 	encoder->private_->is_being_deleted = false;
@@ -567,8 +569,6 @@ FLAC_API FLAC__StreamEncoder *FLAC__stream_encoder_new(void)
 	}
 	for(i = 0; i < 2; i++)
 		FLAC__format_entropy_coding_method_partitioned_rice_contents_init(&encoder->private_->partitioned_rice_contents_extra[i]);
-
-	encoder->protected_->state = FLAC__STREAM_ENCODER_UNINITIALIZED;
 
 	return encoder;
 }


### PR DESCRIPTION
In stream_encoder_new, set_defaults_ was called before setting encoder->protected_->state to uninitialized. However, this state
was being accessed by set_compression_level in set_defaults_. As this is undefined behaviour, move the initialization of encoder->protected_->state up to before calling set_default_