### PR TITLE
Add git commit tag, hash and date to vendor string when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,6 @@ include(GNUInstallDirs)
 include(UseSystemExtensions)
 include(TestBigEndian)
 
-
-
 check_include_file("byteswap.h" HAVE_BYTESWAP_H)
 check_include_file("inttypes.h" HAVE_INTTYPES_H)
 check_include_file("stdint.h" HAVE_STDINT_H)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,32 @@ if(WITH_OGG)
     set(OGG_PACKAGE "ogg")
 endif()
 
+find_program (HAVE_GIT git)
+
+if(HAVE_GIT)
+    execute_process(
+        COMMAND git describe --tags --exact-match
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_COMMIT_TAG
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        )
+    execute_process(
+        COMMAND git log -1 --pretty=format:%h
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_COMMIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        )
+    execute_process(
+        COMMAND git log -1 --pretty=format:%cd --date=format:%Y%m%d
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_COMMIT_DATE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        )
+endif()
+
 find_package(Iconv)
 set(HAVE_ICONV ${Iconv_FOUND})
 
@@ -53,6 +79,8 @@ include(CheckCXXSourceCompiles)
 include(GNUInstallDirs)
 include(UseSystemExtensions)
 include(TestBigEndian)
+
+
 
 check_include_file("byteswap.h" HAVE_BYTESWAP_H)
 check_include_file("inttypes.h" HAVE_INTTYPES_H)

--- a/Makefile.am
+++ b/Makefile.am
@@ -59,4 +59,6 @@ EXTRA_DIST = \
 	ltmain.sh \
 	strip_non_asm_libtool_args.sh
 
+DISTCHECK_CONFIGURE_FLAGS = '--disable-version-from-git'
+
 CLEANFILES = *~

--- a/config.cmake.h.in
+++ b/config.cmake.h.in
@@ -50,6 +50,15 @@
 /* define to enable use of VSX instructions */
 #cmakedefine FLAC__USE_VSX
 
+/* Define to the commit date of the current git HEAD */
+#cmakedefine GIT_COMMIT_DATE "@GIT_COMMIT_DATE@"
+
+/* Define to the short hash of the current git HEAD */
+#cmakedefine GIT_COMMIT_HASH "@GIT_COMMIT_HASH@"
+
+/* Define to the tag of the current git HEAD */
+#cmakedefine GIT_COMMIT_TAG "@GIT_COMMIT_TAG@"
+
 /* Compiler has the __builtin_bswap16 intrinsic */
 #cmakedefine01 HAVE_BSWAP16
 

--- a/configure.ac
+++ b/configure.ac
@@ -547,6 +547,28 @@ dnl for correct FLAC_API
 	CPPFLAGS="-DFLAC__NO_DLL $CPPFLAGS"
 	fi
 
+AC_CHECK_PROG(GIT_FOUND,git,yes)
+
+if test x$GIT_FOUND = "xyes"; then
+	GIT_COMMIT_TAG=`git -C $srcdir describe --tags --exact-match 2>/dev/null`
+	GIT_COMMIT_HASH=`git -C $srcdir log -1 --pretty=format:%h 2>/dev/null`
+	GIT_COMMIT_DATE=`git -C $srcdir log -1 --pretty=format:%cd --date=format:%Y%m%d 2>/dev/null`
+	if test ${#GIT_COMMIT_HASH} = 8 && test ${#GIT_COMMIT_DATE} = 8; then
+		GIT_COMMIT_VERSION_AVAIL=yes
+		if test ${#GIT_COMMIT_TAG} != 0 ; then
+			GIT_COMMIT_TAG_AVAIL=yes
+			AC_DEFINE_UNQUOTED(GIT_COMMIT_TAG, "${GIT_COMMIT_TAG}", "Define to the tag of the current git HEAD")
+		else
+			GIT_COMMIT_VERSION_HASH=yes
+		fi
+		AC_DEFINE_UNQUOTED(GIT_COMMIT_HASH, "${GIT_COMMIT_HASH}", "Define to the short hash of the current git HEAD")
+		AC_DEFINE_UNQUOTED(GIT_COMMIT_DATE, "${GIT_COMMIT_DATE}", "Define to the commit date of the current git HEAD")
+	fi
+fi
+
+AC_SUBST(GIT_COMMIT_VERSION_HASH)
+
+
 AC_CONFIG_FILES([ \
 	Makefile \
 	src/Makefile \
@@ -621,6 +643,12 @@ AC_MSG_RESULT([
     Host OS : ................................. ${host_os}
 ])
 
+if test x$GIT_COMMIT_TAG_AVAIL = xyes ; then
+	echo "    Version string : reference libFLAC ${GIT_COMMIT_TAG} ${GIT_COMMIT_DATE}"
+elif test x$GIT_COMMIT_VERSION_AVAIL = xyes ; then
+	echo "    Version string : reference libFLAC git-${GIT_COMMIT_HASH} ${GIT_COMMIT_DATE}"
+fi
+	echo ""
 	echo "    Compiler is GCC : ......................... ${ac_cv_c_compiler_gnu}"
 if test x$ac_cv_c_compiler_gnu = xyes ; then
 	echo "    GCC version : ............................. ${GCC_VERSION}"

--- a/configure.ac
+++ b/configure.ac
@@ -428,6 +428,12 @@ AC_ARG_ENABLE([examples],
 	AS_HELP_STRING([--disable-examples], [Don't build and install examples]))
 AM_CONDITIONAL([EXAMPLES], [test "x$enable_examples" != "xno"])
 
+dnl Ask git which version FLAC is
+AC_ARG_ENABLE([version-from-git],
+	AS_HELP_STRING([--disable-version-from-git], [Don't use git tag, commit hash and commit date for version number]),
+       [ enable_version_from_git=$enableval ], [ enable_version_from_git=yes ])
+
+
 dnl check for i18n(internationalization); these are from libiconv/gettext
 AM_ICONV
 AM_LANGINFO_CODESET
@@ -549,7 +555,7 @@ dnl for correct FLAC_API
 
 AC_CHECK_PROG(GIT_FOUND,git,yes)
 
-if test x$GIT_FOUND = "xyes"; then
+if test x$GIT_FOUND$enable_version_from_git = "xyesyes"; then
 	GIT_COMMIT_TAG=`git -C $srcdir describe --tags --exact-match 2>/dev/null`
 	GIT_COMMIT_HASH=`git -C $srcdir log -1 --pretty=format:%h 2>/dev/null`
 	GIT_COMMIT_DATE=`git -C $srcdir log -1 --pretty=format:%cd --date=format:%Y%m%d 2>/dev/null`

--- a/src/libFLAC/format.c
+++ b/src/libFLAC/format.c
@@ -49,7 +49,7 @@
 FLAC_API const char *FLAC__VERSION_STRING = GIT_COMMIT_TAG;
 FLAC_API const char *FLAC__VENDOR_STRING = "reference libFLAC " GIT_COMMIT_TAG " " GIT_COMMIT_DATE;
 # else
-FLAC_API const char *FLAC__VERSION_STRING = "git-" GIT_COMMIT_HASH;
+FLAC_API const char *FLAC__VERSION_STRING = "git-" GIT_COMMIT_HASH " " GIT_COMMIT_DATE;
 FLAC_API const char *FLAC__VENDOR_STRING = "reference libFLAC git-" GIT_COMMIT_HASH " " GIT_COMMIT_DATE;
 # endif
 #else

--- a/src/libFLAC/format.c
+++ b/src/libFLAC/format.c
@@ -44,10 +44,19 @@
 #include "private/format.h"
 #include "private/macros.h"
 
+#if (defined GIT_COMMIT_HASH && defined GIT_COMMIT_DATE)
+# ifdef GIT_COMMIT_TAG
+FLAC_API const char *FLAC__VERSION_STRING = GIT_COMMIT_TAG;
+FLAC_API const char *FLAC__VENDOR_STRING = "reference libFLAC " GIT_COMMIT_TAG " " GIT_COMMIT_DATE;
+# else
+FLAC_API const char *FLAC__VERSION_STRING = "git-" GIT_COMMIT_HASH;
+FLAC_API const char *FLAC__VENDOR_STRING = "reference libFLAC git-" GIT_COMMIT_HASH " " GIT_COMMIT_DATE;
+# endif
+#else
 /* PACKAGE_VERSION should come from configure */
 FLAC_API const char *FLAC__VERSION_STRING = PACKAGE_VERSION;
-
 FLAC_API const char *FLAC__VENDOR_STRING = "reference libFLAC " PACKAGE_VERSION " 20220220";
+#endif
 
 FLAC_API const FLAC__byte FLAC__STREAM_SYNC_STRING[4] = { 'f','L','a','C' };
 FLAC_API const uint32_t FLAC__STREAM_SYNC = 0x664C6143;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,10 @@ endif()
 
 set(top_srcdir "${PROJECT_SOURCE_DIR}")
 set(top_builddir "${PROJECT_BINARY_DIR}")
+if(NOT GIT_COMMIT_TAG AND GIT_COMMIT_HASH AND GIT_COMMIT_DATE)
+    set(GIT_COMMIT_VERSION_HASH yes)
+endif()
+
 configure_file(common.sh.in common.sh @ONLY)
 
 set(ALL_TESTS libFLAC grabbag flac metaflac replaygain seeking streams compression)

--- a/test/common.sh.in
+++ b/test/common.sh.in
@@ -49,6 +49,7 @@ EXE=@EXEEXT@
 # and build products in the $top_builddir tree.
 top_srcdir=@top_srcdir@
 top_builddir=@top_builddir@
+git_commit_version_hash=@GIT_COMMIT_VERSION_HASH@
 
 # Set `is_win` variable which is used in other scripts that source this one.
 if test $(env | grep -ic '^comspec=') != 0 ; then

--- a/test/test_metaflac.sh
+++ b/test/test_metaflac.sh
@@ -147,7 +147,9 @@ run_metaflac --set-tag="TITLE=He_who_smelt_it_dealt_it" $flacfile
 check_flac
 metaflac_test case06 "--set-tag=TITLE" "--list"
 
-metaflac_test case07 "--show-vendor-tag --show-tag=ARTIST" "--show-vendor-tag --show-tag=ARTIST"
+if [ -v $git_commit_version_hash ] ; then
+	metaflac_test case07 "--show-vendor-tag --show-tag=ARTIST" "--show-vendor-tag --show-tag=ARTIST"
+fi
 
 run_metaflac --remove-first-tag=ARTIST $flacfile
 check_flac

--- a/test/test_metaflac.sh
+++ b/test/test_metaflac.sh
@@ -147,8 +147,10 @@ run_metaflac --set-tag="TITLE=He_who_smelt_it_dealt_it" $flacfile
 check_flac
 metaflac_test case06 "--set-tag=TITLE" "--list"
 
-if [ -v $git_commit_version_hash ] ; then
+if [ ! $git_commit_version_hash ] ; then
 	metaflac_test case07 "--show-vendor-tag --show-tag=ARTIST" "--show-vendor-tag --show-tag=ARTIST"
+else
+	echo "test case07 is skipped because version is taken from git"
 fi
 
 run_metaflac --remove-first-tag=ARTIST $flacfile


### PR DESCRIPTION
In some circles (Hydrogenaud.io for example) people share binaries compiled from git, i.e. inbetween official releases. Files  created with these binaries cannot be discerned from others. To improve troubleshooting, compiles from a git repository are marked with the commit hash and date (or tag when available) when configured with autotools or CMake