### PR TITLE
MinGW build fixes with CMake

### DIFF
--- a/config.cmake.h.in
+++ b/config.cmake.h.in
@@ -176,7 +176,9 @@
 
 #ifndef _XOPEN_SOURCE
 #cmakedefine DODEFINE_XOPEN_SOURCE 500
+#ifdef DODEFINE_XOPEN_SOURCE
 #define _XOPEN_SOURCE DODEFINE_XOPEN_SOURCE
+#endif
 #endif
 
 /* Enable threading extensions on Solaris.  */
@@ -190,7 +192,9 @@
 /* Enable general extensions on Solaris.  */
 #ifndef __EXTENSIONS__
 #cmakedefine DODEFINE_EXTENSIONS
+#ifdef DODEFINE_EXTENSIONS
 #define __EXTENSIONS__ DODEFINE_EXTENSIONS
+#endif
 #endif
 
 

--- a/src/libFLAC/metadata_iterators.c
+++ b/src/libFLAC/metadata_iterators.c
@@ -3422,7 +3422,7 @@ FLAC__bool get_file_stats_(const char *filename, struct flac_stat_s *stats)
 
 void set_file_stats_(const char *filename, struct flac_stat_s *stats)
 {
-#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L)
+#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L) && !defined(_WIN32)
 	struct timespec srctime[2] = {};
 	srctime[0].tv_sec = stats->st_atime;
 	srctime[1].tv_sec = stats->st_mtime;

--- a/src/share/grabbag/file.c
+++ b/src/share/grabbag/file.c
@@ -54,7 +54,7 @@ void grabbag__file_copy_metadata(const char *srcpath, const char *destpath)
 	struct flac_stat_s srcstat;
 
 	if(0 == flac_stat(srcpath, &srcstat)) {
-#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L)
+#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L) && !defined(_WIN32)
 		struct timespec srctime[2] = {};
 		srctime[0].tv_sec = srcstat.st_atime;
 		srctime[1].tv_sec = srcstat.st_mtime;

--- a/src/test_libFLAC++/metadata_manip.cpp
+++ b/src/test_libFLAC++/metadata_manip.cpp
@@ -272,7 +272,7 @@ void set_file_stats_(const char *filename, struct flac_stat_s *stats)
 	FLAC__ASSERT(0 != filename);
 	FLAC__ASSERT(0 != stats);
 
-#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L)
+#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L) && !defined(_WIN32)
 	struct timespec srctime[2] = {};
 	srctime[0].tv_sec = stats->st_atime;
 	srctime[1].tv_sec = stats->st_mtime;

--- a/src/test_libFLAC/metadata_manip.c
+++ b/src/test_libFLAC/metadata_manip.c
@@ -255,7 +255,7 @@ static FLAC__bool get_file_stats_(const char *filename, struct flac_stat_s *stat
 
 static void set_file_stats_(const char *filename, struct flac_stat_s *stats)
 {
-#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L)
+#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L) && !defined(_WIN32)
 	struct timespec srctime[2] = {};
 	srctime[0].tv_sec = stats->st_atime;
 	srctime[1].tv_sec = stats->st_mtime;


### PR DESCRIPTION
This fixes the following issues:
- ~~`-fstack-protector-strong` isn't a valid parameter for NASM.~~
- ~~`libssp` is required when building with `-fstack-protector-strong`, but isn't linked by default with MinGW.~~
- `flac_internal_utime_utf8` is always used on Windows instead of `utime` or `utimensat`, so `utimbuf` should always be used regardless of how `_POSIX_C_SOURCE` is defined.
- If CMake detects that `mbstate_t` is available without explicitly defining `_XOPEN_SOURCE`, it results in lots of `"DODEFINE_XOPEN_SOURCE" is not defined, evaluates to 0 [-Wundef]` warnings when building with MinGW.OSDN.
