### PR TITLE
add strings.h

### DIFF
--- a/src/libFLAC/metadata_object.c
+++ b/src/libFLAC/metadata_object.c
@@ -36,6 +36,9 @@
 
 #include <stdlib.h>
 #include <string.h>
+#ifndef _MSC_VER
+#include <strings.h>
+#endif
 
 #include "private/metadata.h"
 #include "private/memory.h"


### PR DESCRIPTION
Needed for strncasecmp under macOS.

Signed-off-by: Rosen Penev <rosenp@gmail.com>