### PR TITLE
[CMake] Fix ARM64 intrinsics activation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
     dist: focal
     arch: arm64
     compiler: gcc
-    env: BUILD_SYSTEM="cmake" CONFIGURE_OPTS=-DFLAC__NO_ASM=1
+    env: BUILD_SYSTEM="cmake" CONFIGURE_OPTS=-DWITH_ASM=0
   - os: linux
     dist: focal
     arch: arm64
@@ -31,7 +31,7 @@ jobs:
     dist: focal
     arch: ppc64le
     compiler: gcc
-    env: BUILD_SYSTEM="cmake" CONFIGURE_OPTS=-DFLAC__NO_ASM=1
+    env: BUILD_SYSTEM="cmake" CONFIGURE_OPTS=-DWITH_ASM=0
   - os: linux
     dist: focal
     arch: ppc64le

--- a/config.cmake.h.in
+++ b/config.cmake.h.in
@@ -9,6 +9,9 @@
 /* Target processor is little endian. */
 #cmakedefine01 CPU_IS_LITTLE_ENDIAN
 
+/* Target processor ARM64 */
+#cmakedefine FLAC__CPU_ARM64
+
 /* Target processor PPC */
 #cmakedefine FLAC__CPU_PPC
 
@@ -42,6 +45,9 @@
 
 /* Set to 1 if <arm_neon.h> is available. */
 #cmakedefine01 FLAC__HAS_NEONINTRIN
+
+/* Set to 1 if <arm_neon.h> contains A64 intrinsics */
+#cmakedefine01 FLAC__HAS_A64NEONINTRIN
 
 /* define if building for Darwin / MacOS X */
 #cmakedefine FLAC__SYS_DARWIN

--- a/src/libFLAC/lpc_intrin_neon.c
+++ b/src/libFLAC/lpc_intrin_neon.c
@@ -41,7 +41,7 @@
 #include "private/macros.h"
 #include <arm_neon.h>
 
-#ifdef FLAC__HAS_A64NEONINTRIN
+#if FLAC__HAS_A64NEONINTRIN
 void FLAC__lpc_compute_autocorrelation_intrin_neon_lag_14(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[])
 {
 #undef MAX_LAG

--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -906,8 +906,10 @@ static FLAC__StreamEncoderInitStatus init_stream_internal_(
 			encoder->private_->local_lpc_compute_autocorrelation = FLAC__lpc_compute_autocorrelation;
 	}
 #endif
-#endif
-#if defined FLAC__CPU_ARM64 && FLAC__HAS_NEONINTRIN && FLAC__HAS_A64NEONINTRIN
+#endif /* defined(FLAC__CPU_PPC64) && defined(FLAC__USE_VSX) */
+
+#if defined FLAC__CPU_ARM64 && FLAC__HAS_NEONINTRIN
+#if FLAC__HAS_A64NEONINTRIN
 	if(encoder->protected_->max_lpc_order < 8)
 		encoder->private_->local_lpc_compute_autocorrelation = FLAC__lpc_compute_autocorrelation_intrin_neon_lag_8;
 	else if(encoder->protected_->max_lpc_order < 10)
@@ -917,6 +919,11 @@ static FLAC__StreamEncoderInitStatus init_stream_internal_(
 	else
 		encoder->private_->local_lpc_compute_autocorrelation = FLAC__lpc_compute_autocorrelation;
 #endif
+    encoder->private_->local_lpc_compute_residual_from_qlp_coefficients_16bit = FLAC__lpc_compute_residual_from_qlp_coefficients_intrin_neon;
+    encoder->private_->local_lpc_compute_residual_from_qlp_coefficients       = FLAC__lpc_compute_residual_from_qlp_coefficients_intrin_neon;
+    encoder->private_->local_lpc_compute_residual_from_qlp_coefficients_64bit = FLAC__lpc_compute_residual_from_qlp_coefficients_wide_intrin_neon;
+#endif /* defined FLAC__CPU_ARM64 && FLAC__HAS_NEONINTRIN */
+
 	if(encoder->private_->cpuinfo.use_asm) {
 #  ifdef FLAC__CPU_IA32
 		FLAC__ASSERT(encoder->private_->cpuinfo.type == FLAC__CPUINFO_TYPE_IA32);
@@ -1013,14 +1020,6 @@ static FLAC__StreamEncoderInitStatus init_stream_internal_(
 #    endif
 #   endif /* FLAC__HAS_X86INTRIN */
 #  endif /* FLAC__CPU_... */
-
-	#if defined FLAC__CPU_ARM64 && FLAC__HAS_NEONINTRIN
-
-    encoder->private_->local_lpc_compute_residual_from_qlp_coefficients_16bit = FLAC__lpc_compute_residual_from_qlp_coefficients_intrin_neon;
-    encoder->private_->local_lpc_compute_residual_from_qlp_coefficients       = FLAC__lpc_compute_residual_from_qlp_coefficients_intrin_neon;
-    encoder->private_->local_lpc_compute_residual_from_qlp_coefficients_64bit = FLAC__lpc_compute_residual_from_qlp_coefficients_wide_intrin_neon;
-	# endif
-
 	}
 # endif /* !FLAC__NO_ASM */
 

--- a/src/test_streams/main.c
+++ b/src/test_streams/main.c
@@ -956,14 +956,15 @@ static FLAC__bool generate_noisy_sine(void)
 	int64_t randstate = 0x1243456;
 	double sample, last_val = 0.0;
 	int k;
+	int seconds = 300;
 
 	if(0 == (f = fopen("noisy-sine.wav", "wb")))
 		return false;
 
-	if(!write_simple_wavex_header (f, 44100, 1, 2, 220500))
+	if(!write_simple_wavex_header (f, 44100, 1, 2, 44100*seconds))
 		goto foo;
 
-	for (k = 0 ; k < 5 * 44100 ; k++) {
+	for (k = 0 ; k < seconds * 44100 ; k++) {
 		/* Obvioulsy not a crypto quality RNG. */
 		randstate = 11117 * randstate + 211231;
 		randstate = 11117 * randstate + 211231;


### PR DESCRIPTION
In 95e2c52 the autotools build worked fine, but CMake missed a few defines. Activition of the  lpc_compute_residual_from_qlp_coefficients depended on encoder->private_->cpuinfo.use_asm for no reason, so this dependency is removed