### PR TITLE
Rename FLAC__get_decoder_client_data to FLAC__stream_decoder_get_client_data

### DIFF
--- a/include/FLAC/stream_decoder.h
+++ b/include/FLAC/stream_decoder.h
@@ -1013,6 +1013,16 @@ FLAC_API uint32_t FLAC__stream_decoder_get_blocksize(const FLAC__StreamDecoder *
  */
 FLAC_API FLAC__bool FLAC__stream_decoder_get_decode_position(const FLAC__StreamDecoder *decoder, FLAC__uint64 *position);
 
+/** Return client_data from decoder.
+ *  The data pointed to by the pointer should not be modified.
+ *
+ * \param  decoder  A decoder instance.
+ * \retval const void *
+ *    The callee's client data set through FLAC__stream_decoder_init_*().
+ *    Do not modify the contents.
+ */
+FLAC_API const void *FLAC__stream_decoder_get_client_data(FLAC__StreamDecoder *decoder);
+
 /** Initialize the decoder instance to decode native FLAC streams.
  *
  *  This flavor of initialization sets up the decoder to decode from a
@@ -1556,16 +1566,6 @@ FLAC_API FLAC__bool FLAC__stream_decoder_skip_single_frame(FLAC__StreamDecoder *
  *    \c true if successful, else \c false.
  */
 FLAC_API FLAC__bool FLAC__stream_decoder_seek_absolute(FLAC__StreamDecoder *decoder, FLAC__uint64 sample);
-
-/** Return client_data from decoder.
- *  The data pointed to by the pointer should not be modified.
- *
- * \param  decoder  A decoder instance.
- * \retval const void *
- *    The callee's client data set through FLAC__stream_decoder_init_*().
- *    Do not modify the contents.
- */
-FLAC_API const void *FLAC__get_decoder_client_data(FLAC__StreamDecoder *decoder);
 
 /* \} */
 

--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -919,6 +919,11 @@ FLAC_API FLAC__bool FLAC__stream_decoder_get_decode_position(const FLAC__StreamD
 	return true;
 }
 
+FLAC_API const void *FLAC__stream_decoder_get_client_data(FLAC__StreamDecoder *decoder)
+{
+	return decoder->private_->client_data;
+}
+
 FLAC_API FLAC__bool FLAC__stream_decoder_flush(FLAC__StreamDecoder *decoder)
 {
 	FLAC__ASSERT(0 != decoder);
@@ -3597,9 +3602,4 @@ FLAC__bool file_eof_callback_(const FLAC__StreamDecoder *decoder, void *client_d
 	(void)client_data;
 
 	return feof(decoder->private_->file)? true : false;
-}
-
-FLAC_API const void *FLAC__get_decoder_client_data(FLAC__StreamDecoder *decoder)
-{
-	return decoder->private_->client_data;
 }


### PR DESCRIPTION
Also the function definition was moved to its 'siblings'. This way, the function fits better in the API with respect to naming. This implements the change [suggested here](https://github.com/xiph/flac/pull/124#issuecomment-519453916)

@sezero  and @ChristopD do you agree with this? It is yet another change to the name, but as the first change has been kept out of 1.3.4, I think this should be fixed while we still can.

