### PR TITLE
Further improve fuzzer_encoder_v2

### DIFF
--- a/include/share/private.h
+++ b/include/share/private.h
@@ -36,6 +36,7 @@
  * Unpublished debug routines from libFLAC. This should not be used from any
  * client code other than code shipped with the FLAC sources.
  */
+FLAC_API FLAC__bool FLAC__stream_encoder_disable_instruction_set(FLAC__StreamEncoder *encoder, FLAC__bool value);
 FLAC_API FLAC__bool FLAC__stream_encoder_disable_constant_subframes(FLAC__StreamEncoder *encoder, FLAC__bool value);
 FLAC_API FLAC__bool FLAC__stream_encoder_disable_fixed_subframes(FLAC__StreamEncoder *encoder, FLAC__bool value);
 FLAC_API FLAC__bool FLAC__stream_encoder_disable_verbatim_subframes(FLAC__StreamEncoder *encoder, FLAC__bool value);

--- a/oss-fuzz/fuzzer_encoder_v2.cc
+++ b/oss-fuzz/fuzzer_encoder_v2.cc
@@ -238,6 +238,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		}
 	}
 
+	if(FLAC__stream_encoder_get_state(encoder) != FLAC__STREAM_ENCODER_OK &&
+	   FLAC__stream_encoder_get_state(encoder) != FLAC__STREAM_ENCODER_UNINITIALIZED &&
+	   FLAC__stream_encoder_get_state(encoder) != FLAC__STREAM_ENCODER_CLIENT_ERROR){
+		fprintf(stderr,"-----\nERROR: stream encoder returned %s\n-----\n",FLAC__stream_encoder_get_resolved_state_string(encoder));
+		abort();
+	}
+
 	FLAC__stream_encoder_finish(encoder);
 
 	/* now that encoding is finished, the metadata can be freed */

--- a/oss-fuzz/fuzzer_encoder_v2.cc
+++ b/oss-fuzz/fuzzer_encoder_v2.cc
@@ -58,7 +58,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
 	unsigned sample_rate, channels, bps;
 	uint64_t samples_estimate;
-	unsigned compression_level, input_data_width, blocksize, max_lpc_order, qlp_coeff_precision, min_residual_partition_order, max_residual_partition_order, metadata_mask;
+	unsigned compression_level, input_data_width, blocksize, max_lpc_order, qlp_coeff_precision, min_residual_partition_order, max_residual_partition_order, metadata_mask, instruction_set_disable_mask;
 	FLAC__bool ogg, interleaved;
 
 	FLAC__bool data_bools[24];
@@ -90,9 +90,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	qlp_coeff_precision = data[14];
 	min_residual_partition_order = data[15] & 0b1111;
 	max_residual_partition_order = data[15] & 0b11110000;
-	metadata_mask = (unsigned)data[16];
-
-	/* data[17] is spare */
+	metadata_mask = data[16];
+	instruction_set_disable_mask = data[17];
 
 	/* Get array of bools from configuration */
 	for(int i = 0; i < 16; i++)
@@ -107,6 +106,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	encoder_valid &= FLAC__stream_encoder_set_bits_per_sample(encoder, bps);
 	encoder_valid &= FLAC__stream_encoder_set_sample_rate(encoder, sample_rate);
 	encoder_valid &= FLAC__stream_encoder_set_total_samples_estimate(encoder, samples_estimate);
+	encoder_valid &= FLAC__stream_encoder_disable_instruction_set(encoder, instruction_set_disable_mask);
 
 	/* Set compression related parameters */
 	encoder_valid &= FLAC__stream_encoder_set_compression_level(encoder, compression_level);


### PR DESCRIPTION
This should improve code coverage by being able to disable instruction set optimizations. It now also triggers on verify problems. Finally, it changes the fuzzers as explained here: https://github.com/google/oss-fuzz/pull/7687