### PR TITLE
Fix compression of loose mid-side

### DIFF
--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -3346,7 +3346,11 @@ FLAC__bool process_subframes_(FLAC__StreamEncoder *encoder)
 
 			channel_assignment = FLAC__CHANNEL_ASSIGNMENT_INDEPENDENT;
 			min_bits = bits[channel_assignment];
-			for(ca = 1; ca <= 3; ca++) {
+
+			/* When doing loose mid-side stereo, ignore left-side
+			 * and right-side options */
+			ca = encoder->protected_->loose_mid_side_stereo ? 3 : 1;
+			for( ; ca <= 3; ca++) {
 				if(bits[ca] < min_bits) {
 					min_bits = bits[ca];
 					channel_assignment = (FLAC__ChannelAssignment)ca;


### PR DESCRIPTION
The loose mid-side option only fully evaluates stereo decorrelation once every few frames. However, in case of finding left-side or right-side to be the best option, subsequent frames were coded mid-side, which could be worse off. To not complicate code too much (to make it possible to evaluate only left or right and side frame for example), evaluation of left-side and right-side is completely disabled when loose mid-side is enabled.