### PR TITLE
Close file when stream_encoder init fails

### DIFF
--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -1455,6 +1455,11 @@ FLAC_API FLAC__bool FLAC__stream_encoder_finish(FLAC__StreamEncoder *encoder)
 			encoder->protected_->metadata = 0;
 			encoder->protected_->num_metadata_blocks = 0;
 		}
+		if(0 != encoder->private_->file) {
+			if(encoder->private_->file != stdout)
+				fclose(encoder->private_->file);
+			encoder->private_->file = 0;
+		}
 		return true;
 	}
 


### PR DESCRIPTION
This popped up during fuzzing, after some time the fuzzer returned 'FLAC__STREAM_ENCODER_IO_ERROR' which turned out to be because fopen failed with 'EMFILE: Too many open files'. It also fixes the otherwise rather vague error below

```
INFO: libFuzzer disabled leak detection after every mutation.
      Most likely the target function accumulates allocated
      memory in a global state w/o actually leaking it.
      You may try running this binary with -trace_malloc=[12]      to get a trace of mallocs and frees.
      If LeakSanitizer is enabled in this process it will still
      run on the process shutdown.
```