### PR TITLE
Always take compression level as first compression setting

### DIFF
--- a/src/flac/main.c
+++ b/src/flac/main.c
@@ -1140,9 +1140,16 @@ void add_compression_setting_uint32_t(compression_setting_type_t type, uint32_t 
 {
 	if(option_values.num_compression_settings >= sizeof(option_values.compression_settings)/sizeof(option_values.compression_settings[0]))
 		die("too many compression settings");
-	option_values.compression_settings[option_values.num_compression_settings].type = type;
-	option_values.compression_settings[option_values.num_compression_settings].value.t_unsigned = value;
-	option_values.num_compression_settings++;
+	if(type == CST_COMPRESSION_LEVEL) {
+		/* Compression level always goes first */
+		option_values.compression_settings[0].type = type;
+		option_values.compression_settings[0].value.t_unsigned = value;
+	}
+	else {
+		option_values.compression_settings[option_values.num_compression_settings].type = type;
+		option_values.compression_settings[option_values.num_compression_settings].value.t_unsigned = value;
+		option_values.num_compression_settings++;
+	}
 }
 
 int usage_error(const char *message, ...)


### PR DESCRIPTION
Without this patch, the order of the arguments matter, with it it does not: specific compression settings now always override the more generic compression levels. This fixes #20