### PR TITLE
Revert "Enable encoder to use INT32_MIN as residual value"

### DIFF
--- a/src/libFLAC/fixed.c
+++ b/src/libFLAC/fixed.c
@@ -377,32 +377,33 @@ uint32_t FLAC__fixed_compute_best_predictor_limit_residual(const FLAC__int32 dat
 #endif
 {
 	FLAC__uint64 total_error_0 = 0, total_error_1 = 0, total_error_2 = 0, total_error_3 = 0, total_error_4 = 0, smallest_error = UINT64_MAX;
-	FLAC__int64 error_0, error_1, error_2, error_3, error_4;
+	FLAC__uint64 error_0, error_1, error_2, error_3, error_4;
 	FLAC__bool order_0_is_valid = true, order_1_is_valid = true, order_2_is_valid = true, order_3_is_valid = true, order_4_is_valid = true;
 	uint32_t order = 0;
 
 	for(int i = 0; i < (int)data_len; i++) {
-		error_0 = (FLAC__int64)data[i];
-		error_1 = (i > 0) ? (FLAC__int64)data[i] - data[i-1] : 0 ;
-		error_2 = (i > 1) ? (FLAC__int64)data[i] - 2 * (FLAC__int64)data[i-1] + data[i-2] : 0;
-		error_3 = (i > 2) ? (FLAC__int64)data[i] - 3 * (FLAC__int64)data[i-1] + 3 * (FLAC__int64)data[i-2] - data[i-3] : 0;
-		error_4 = (i > 3) ? (FLAC__int64)data[i] - 4 * (FLAC__int64)data[i-1] + 6 * (FLAC__int64)data[i-2] - 4 * (FLAC__int64)data[i-3] + data[i-4] : 0;
+		error_0 = local_abs64((FLAC__int64)data[i]);
+		error_1 = (i > 0) ? local_abs64((FLAC__int64)data[i] - data[i-1]) : 0 ;
+		error_2 = (i > 1) ? local_abs64((FLAC__int64)data[i] - 2 * (FLAC__int64)data[i-1] + data[i-2]) : 0;
+		error_3 = (i > 2) ? local_abs64((FLAC__int64)data[i] - 3 * (FLAC__int64)data[i-1] + 3 * (FLAC__int64)data[i-2] - data[i-3]) : 0;
+		error_4 = (i > 3) ? local_abs64((FLAC__int64)data[i] - 4 * (FLAC__int64)data[i-1] + 6 * (FLAC__int64)data[i-2] - 4 * (FLAC__int64)data[i-3] + data[i-4]) : 0;
 
-		total_error_0 += local_abs64(error_0);
-		total_error_1 += local_abs64(error_1);
-		total_error_2 += local_abs64(error_2);
-		total_error_3 += local_abs64(error_3);
-		total_error_4 += local_abs64(error_4);
+		total_error_0 += error_0;
+		total_error_1 += error_1;
+		total_error_2 += error_2;
+		total_error_3 += error_3;
+		total_error_4 += error_4;
 
-		if(error_0 > INT32_MAX || error_0 < INT32_MIN)
+		/* residual must not be INT32_MIN because abs(INT32_MIN) is undefined */
+		if(error_0 > INT32_MAX)
 			order_0_is_valid = false;
-		if(error_1 > INT32_MAX || error_1 < INT32_MIN)
+		if(error_1 > INT32_MAX)
 			order_1_is_valid = false;
-		if(error_2 > INT32_MAX || error_2 < INT32_MIN)
+		if(error_2 > INT32_MAX)
 			order_2_is_valid = false;
-		if(error_3 > INT32_MAX || error_3 < INT32_MIN)
+		if(error_3 > INT32_MAX)
 			order_3_is_valid = false;
-		if(error_4 > INT32_MAX || error_4 < INT32_MIN)
+		if(error_4 > INT32_MAX)
 			order_4_is_valid = false;
 	}
 
@@ -422,33 +423,33 @@ uint32_t FLAC__fixed_compute_best_predictor_limit_residual_33bit(const FLAC__int
 #endif
 {
 	FLAC__uint64 total_error_0 = 0, total_error_1 = 0, total_error_2 = 0, total_error_3 = 0, total_error_4 = 0, smallest_error = UINT64_MAX;
-	FLAC__int64 error_0, error_1, error_2, error_3, error_4;
+	FLAC__uint64 error_0, error_1, error_2, error_3, error_4;
 	FLAC__bool order_0_is_valid = true, order_1_is_valid = true, order_2_is_valid = true, order_3_is_valid = true, order_4_is_valid = true;
 	uint32_t order = 0;
 
 	for(int i = 0; i < (int)data_len; i++) {
-		error_0 = data[i];
-		error_1 = (i > 0) ? data[i] - data[i-1] : 0 ;
-		error_2 = (i > 1) ? data[i] - 2 * data[i-1] + data[i-2] : 0;
-		error_3 = (i > 2) ? data[i] - 3 * data[i-1] + 3 * data[i-2] - data[i-3] : 0;
-		error_4 = (i > 3) ? data[i] - 4 * data[i-1] + 6 * data[i-2] - 4 * data[i-3] + data[i-4] : 0;
+		error_0 = local_abs64(data[i]);
+		error_1 = (i > 0) ? local_abs64(data[i] - data[i-1]) : 0 ;
+		error_2 = (i > 1) ? local_abs64(data[i] - 2 * data[i-1] + data[i-2]) : 0;
+		error_3 = (i > 2) ? local_abs64(data[i] - 3 * data[i-1] + 3 * data[i-2] - data[i-3]) : 0;
+		error_4 = (i > 3) ? local_abs64(data[i] - 4 * data[i-1] + 6 * data[i-2] - 4 * data[i-3] + data[i-4]) : 0;
 
-		total_error_0 += local_abs64(error_0);
-		total_error_1 += local_abs64(error_1);
-		total_error_2 += local_abs64(error_2);
-		total_error_3 += local_abs64(error_3);
-		total_error_4 += local_abs64(error_4);
+		total_error_0 += error_0;
+		total_error_1 += error_1;
+		total_error_2 += error_2;
+		total_error_3 += error_3;
+		total_error_4 += error_4;
 
-
-		if(error_0 > INT32_MAX || error_0 < INT32_MIN)
+		/* residual must not be INT32_MIN because abs(INT32_MIN) is undefined */
+		if(error_0 > INT32_MAX)
 			order_0_is_valid = false;
-		if(error_1 > INT32_MAX || error_1 < INT32_MIN)
+		if(error_1 > INT32_MAX)
 			order_1_is_valid = false;
-		if(error_2 > INT32_MAX || error_2 < INT32_MIN)
+		if(error_2 > INT32_MAX)
 			order_2_is_valid = false;
-		if(error_3 > INT32_MAX || error_3 < INT32_MIN)
+		if(error_3 > INT32_MAX)
 			order_3_is_valid = false;
-		if(error_4 > INT32_MAX || error_4 < INT32_MIN)
+		if(error_4 > INT32_MAX)
 			order_4_is_valid = false;
 	}
 

--- a/src/libFLAC/include/private/stream_encoder.h
+++ b/src/libFLAC/include/private/stream_encoder.h
@@ -37,23 +37,29 @@
 #include <config.h>
 #endif
 
+/*
+ * This is used to avoid overflow with unusual signals in 32-bit
+ * accumulator in the *precompute_partition_info_sums_* functions.
+ */
+#define FLAC__MAX_EXTRA_RESIDUAL_BPS 4
+
 #if (defined FLAC__CPU_IA32 || defined FLAC__CPU_X86_64) && defined FLAC__HAS_X86INTRIN
 #include "private/cpu.h"
 #include "FLAC/format.h"
 
 #ifdef FLAC__SSE2_SUPPORTED
 extern void FLAC__precompute_partition_info_sums_intrin_sse2(const FLAC__int32 residual[], FLAC__uint64 abs_residual_partition_sums[],
-			uint32_t residual_samples, uint32_t predictor_order, uint32_t min_partition_order, uint32_t max_partition_order, uint32_t max_residual_bps);
+			uint32_t residual_samples, uint32_t predictor_order, uint32_t min_partition_order, uint32_t max_partition_order, uint32_t bps);
 #endif
 
 #ifdef FLAC__SSSE3_SUPPORTED
 extern void FLAC__precompute_partition_info_sums_intrin_ssse3(const FLAC__int32 residual[], FLAC__uint64 abs_residual_partition_sums[],
-			uint32_t residual_samples, uint32_t predictor_order, uint32_t min_partition_order, uint32_t max_partition_order, uint32_t max_residual_bps);
+			uint32_t residual_samples, uint32_t predictor_order, uint32_t min_partition_order, uint32_t max_partition_order, uint32_t bps);
 #endif
 
 #ifdef FLAC__AVX2_SUPPORTED
 extern void FLAC__precompute_partition_info_sums_intrin_avx2(const FLAC__int32 residual[], FLAC__uint64 abs_residual_partition_sums[],
-			uint32_t residual_samples, uint32_t predictor_order, uint32_t min_partition_order, uint32_t max_partition_order, uint32_t max_residual_bps);
+			uint32_t residual_samples, uint32_t predictor_order, uint32_t min_partition_order, uint32_t max_partition_order, uint32_t bps);
 #endif
 
 #endif

--- a/src/libFLAC/lpc.c
+++ b/src/libFLAC/lpc.c
@@ -828,7 +828,8 @@ FLAC__bool FLAC__lpc_compute_residual_from_qlp_coefficients_limit_residual(const
 			case  1: sum += qlp_coeff[ 0] * (FLAC__int64)data[i- 1];
 		}
 		residual_to_check = data[i] - (sum >> lp_quantization);
-		if(residual_to_check < INT32_MIN || residual_to_check > INT32_MAX)
+		 /* residual must not be INT32_MIN because abs(INT32_MIN) is undefined */
+		if(residual_to_check <= INT32_MIN || residual_to_check > INT32_MAX)
 			return false;
 		else
 			residual[i] = residual_to_check;
@@ -881,7 +882,8 @@ FLAC__bool FLAC__lpc_compute_residual_from_qlp_coefficients_limit_residual_33bit
 			case  1: sum += qlp_coeff[ 0] * data[i- 1];
 		}
 		residual_to_check = data[i] - (sum >> lp_quantization);
-		if(residual_to_check < INT32_MIN || residual_to_check > INT32_MAX)
+		/* residual must not be INT32_MIN because abs(INT32_MIN) is undefined */
+		if(residual_to_check <= INT32_MIN || residual_to_check > INT32_MAX)
 			return false;
 		else
 			residual[i] = residual_to_check;

--- a/src/libFLAC/stream_encoder_intrin_sse2.c
+++ b/src/libFLAC/stream_encoder_intrin_sse2.c
@@ -59,7 +59,7 @@ static inline __m128i local_abs_epi32(__m128i val)
 
 FLAC__SSE_TARGET("sse2")
 void FLAC__precompute_partition_info_sums_intrin_sse2(const FLAC__int32 residual[], FLAC__uint64 abs_residual_partition_sums[],
-		uint32_t residual_samples, uint32_t predictor_order, uint32_t min_partition_order, uint32_t max_partition_order, uint32_t max_residual_bps)
+		uint32_t residual_samples, uint32_t predictor_order, uint32_t min_partition_order, uint32_t max_partition_order, uint32_t bps)
 {
 	const uint32_t default_partition_samples = (residual_samples + predictor_order) >> max_partition_order;
 	uint32_t partitions = 1u << max_partition_order;
@@ -71,7 +71,7 @@ void FLAC__precompute_partition_info_sums_intrin_sse2(const FLAC__int32 residual
 		const uint32_t threshold = 32 - FLAC__bitmath_ilog2(default_partition_samples);
 		uint32_t partition, residual_sample, end = (uint32_t)(-(int32_t)predictor_order);
 
-		if(max_residual_bps < threshold) {
+		if(bps + FLAC__MAX_EXTRA_RESIDUAL_BPS < threshold) {
 			for(partition = residual_sample = 0; partition < partitions; partition++) {
 				__m128i mm_sum = _mm_setzero_si128();
 				uint32_t e1, e3;
@@ -106,7 +106,7 @@ void FLAC__precompute_partition_info_sums_intrin_sse2(const FLAC__int32 residual
 #endif
 			}
 		}
-		else if(max_residual_bps < 32) { /* have to pessimistically use 64 bits for accumulator */
+		else { /* have to pessimistically use 64 bits for accumulator */
 			for(partition = residual_sample = 0; partition < partitions; partition++) {
 				__m128i mm_sum = _mm_setzero_si128();
 				uint32_t e1, e3;
@@ -135,19 +135,6 @@ void FLAC__precompute_partition_info_sums_intrin_sse2(const FLAC__int32 residual
 				_mm_storel_epi64((__m128i*)(void*)(abs_residual_partition_sums+partition), mm_sum);
 			}
 		}
-                else { /* must handle abs(INT32_MIN) */
-                        for(partition = residual_sample = 0; partition < partitions; partition++) {
-                                FLAC__uint64 abs_residual_partition_sum64 = 0;
-                                end += default_partition_samples;
-                                for( ; residual_sample < end; residual_sample++)
-                                        if(residual[residual_sample] == INT32_MIN)
-                                                abs_residual_partition_sum64 -= (FLAC__int64)INT32_MIN;
-                                        else
-                                                abs_residual_partition_sum64 += abs(residual[residual_sample]);
-                                abs_residual_partition_sums[partition] = abs_residual_partition_sum64;
-                        }
-                }
-
 	}
 
 	/* now merge partitions for lower orders */

--- a/src/libFLAC/stream_encoder_intrin_ssse3.c
+++ b/src/libFLAC/stream_encoder_intrin_ssse3.c
@@ -48,7 +48,7 @@
 
 FLAC__SSE_TARGET("ssse3")
 void FLAC__precompute_partition_info_sums_intrin_ssse3(const FLAC__int32 residual[], FLAC__uint64 abs_residual_partition_sums[],
-		uint32_t residual_samples, uint32_t predictor_order, uint32_t min_partition_order, uint32_t max_partition_order, uint32_t max_residual_bps)
+		uint32_t residual_samples, uint32_t predictor_order, uint32_t min_partition_order, uint32_t max_partition_order, uint32_t bps)
 {
 	const uint32_t default_partition_samples = (residual_samples + predictor_order) >> max_partition_order;
 	uint32_t partitions = 1u << max_partition_order;
@@ -60,7 +60,7 @@ void FLAC__precompute_partition_info_sums_intrin_ssse3(const FLAC__int32 residua
 		const uint32_t threshold = 32 - FLAC__bitmath_ilog2(default_partition_samples);
 		uint32_t partition, residual_sample, end = (uint32_t)(-(int32_t)predictor_order);
 
-		if(max_residual_bps < threshold) {
+		if(bps + FLAC__MAX_EXTRA_RESIDUAL_BPS < threshold) {
 			for(partition = residual_sample = 0; partition < partitions; partition++) {
 				__m128i mm_sum = _mm_setzero_si128();
 				uint32_t e1, e3;
@@ -95,7 +95,7 @@ void FLAC__precompute_partition_info_sums_intrin_ssse3(const FLAC__int32 residua
 #endif
 			}
 		}
-		else if(max_residual_bps < 32) { /* have to pessimistically use 64 bits for accumulator */
+		else { /* have to pessimistically use 64 bits for accumulator */
 			for(partition = residual_sample = 0; partition < partitions; partition++) {
 				__m128i mm_sum = _mm_setzero_si128();
 				uint32_t e1, e3;
@@ -124,18 +124,6 @@ void FLAC__precompute_partition_info_sums_intrin_ssse3(const FLAC__int32 residua
 				_mm_storel_epi64((__m128i*)(void*)(abs_residual_partition_sums+partition), mm_sum);
 			}
 		}
-                else { /* must handle abs(INT32_MIN) */
-                        for(partition = residual_sample = 0; partition < partitions; partition++) {
-                                FLAC__uint64 abs_residual_partition_sum64 = 0;
-                                end += default_partition_samples;
-                                for( ; residual_sample < end; residual_sample++)
-                                        if(residual[residual_sample] == INT32_MIN)
-                                                abs_residual_partition_sum64 -= (FLAC__int64)INT32_MIN;
-                                        else
-                                                abs_residual_partition_sum64 += abs(residual[residual_sample]);
-                                abs_residual_partition_sums[partition] = abs_residual_partition_sum64;
-                        }
-                }
 	}
 
 	/* now merge partitions for lower orders */


### PR DESCRIPTION
This reverts commit 7e0a0e572305e9004a6fa9bba3dd6be936553b03. This is in accordance with https://github.com/ietf-wg-cellar/flac-specification/pull/148 It turns out using INT32_MIN is actually quite a hassle.