### PR TITLE
Only search for backslash in filename on Windows

### DIFF
--- a/src/share/grabbag/file.c
+++ b/src/share/grabbag/file.c
@@ -84,8 +84,10 @@ const char *grabbag__file_get_basename(const char *srcpath)
 
 	p = strrchr(srcpath, '/');
 	if(0 == p) {
+#if defined _WIN32 && !defined __CYGWIN__
 		p = strrchr(srcpath, '\\');
 		if(0 == p)
+#endif
 			return srcpath;
 	}
 	return ++p;


### PR DESCRIPTION
This should solve the problem https://github.com/xiph/flac/issues/71, but apparently it doesn't quite. With this patch I'm no longer able to reproduce the problem though.