### PR TITLE
Fix rolled up version of lpc_restore_signal_wide

### DIFF
--- a/src/libFLAC/lpc.c
+++ b/src/libFLAC/lpc.c
@@ -1214,7 +1214,7 @@ void FLAC__lpc_restore_signal_wide(const FLAC__int32 * flac_restrict residual, u
 			break;
 		}
 #endif
-		*(data++) = *(r++) + (FLAC__int32)(sum >> lp_quantization);
+		*(data++) = (FLAC__int32)(*(r++) + (sum >> lp_quantization));
 	}
 }
 #else /* fully unrolled version for normal use */


### PR DESCRIPTION
This fixes https://github.com/xiph/flac/issues/393