### PR TITLE
Warn user for incompatibility with MSVC Windows XP targetting

### DIFF
--- a/include/share/compat.h
+++ b/include/share/compat.h
@@ -138,6 +138,9 @@
 #    define PRId64 "I64d"
 #    define PRIx64 "I64x"
 #  endif
+#  ifdef _USING_V110_SDK71_
+#    error "libFLAC is not compatible with V110_SDK71. See github.com/xiph/flac/issues/72#issuecomment-934777777 for details"
+#  endif
 #endif /* defined _MSC_VER */
 
 #ifdef _WIN32

--- a/include/share/compat.h
+++ b/include/share/compat.h
@@ -138,14 +138,14 @@
 #    define PRId64 "I64d"
 #    define PRIx64 "I64x"
 #  endif
-#  ifdef _USING_V110_SDK71_
-#    error "libFLAC is not compatible with V110_SDK71. See comments in include/share/compat.h for details"
+#  if defined(_USING_V110_SDK71_) && !defined(_DLL)
+#    pragma message("WARNING: This compile will NOT FUNCTION PROPERLY on Windows XP. See comments in include/share/compat.h for details")
 /*
  *************************************************************************************
  * V110_SDK71, in MSVC 2017 also known as v141_xp, is a platform toolset that is supposed
  * to target Windows XP. It turns out however that certain functions provided silently fail
- * on Windows XP only, which makes debugging challenging. This problem has been reported
- * to Microsoft, but there hasn't been a fix for years. See
+ * on Windows XP only, which makes debugging challenging. This only occurs when building with
+ * /MT. This problem has been reported to Microsoft, but there hasn't been a fix for years. See
  * https://web.archive.org/web/20170327195018/https://connect.microsoft.com/VisualStudio/feedback/details/1557168/wstat64-returns-1-on-xp-always
  *
  * It is known that this problem affects the functions _wstat64 (used by flac_stat i.e.
@@ -153,19 +153,11 @@
  * several places as well as the flac and metaflac command line tools
  *
  * As the extent of this problem is unknown and Microsoft seems unwilling to fix it,
- * users of libFLAC are encouraged to use MinGW instead of Visual Studio when explicitly
- * targeting Windows XP. When Visual Studio is used with this problematic toolset,
- * remove the #error above to enable compilation, and be sure to check whether your
- * application works properly on Windows XP. A possible workaround stub for fixing
- * flac_fstat can be found below
+ * users of libFLAC building with Visual Studio are encouraged to not use the /MT compile
+ * switch when explicitly targeting Windows XP. When use of /MT is deemed necessary with
+ * this toolset, be sure to check whether your application works properly on Windows XP.
+ * It is also possible to build for Windows XP with MinGW instead.
  *************************************************************************************
-static int flac_fstat(int fd, struct __stat64 *buffer) {
-	FLAC__int64 filelength = _filelengthi64 (fd);
-	if(filelength < 0)
-		return -1;
-	buffer->st_size = filelength;
-	return 0;
-}
 */
 #  endif
 #endif /* defined _MSC_VER */

--- a/include/share/compat.h
+++ b/include/share/compat.h
@@ -140,6 +140,7 @@
 #  endif
 #  if defined(_USING_V110_SDK71_) && !defined(_DLL)
 #    pragma message("WARNING: This compile will NOT FUNCTION PROPERLY on Windows XP. See comments in include/share/compat.h for details")
+#define FLAC__USE_FILELENGTHI64
 /*
  *************************************************************************************
  * V110_SDK71, in MSVC 2017 also known as v141_xp, is a platform toolset that is supposed

--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -3645,7 +3645,13 @@ FLAC__StreamDecoderLengthStatus file_length_callback_(const FLAC__StreamDecoder 
 
 	if(decoder->private_->file == stdin)
 		return FLAC__STREAM_DECODER_LENGTH_STATUS_UNSUPPORTED;
-	else if(flac_fstat(fileno(decoder->private_->file), &filestats) != 0)
+
+#ifndef FLAC__USE_FILELENGTHI64
+	if(flac_fstat(fileno(decoder->private_->file), &filestats) != 0)
+#else
+	filestats.st_size = _filelengthi64(fileno(decoder->private_->file));
+	if(filestats.st_size < 0)
+#endif
 		return FLAC__STREAM_DECODER_LENGTH_STATUS_ERROR;
 	else {
 		*stream_length = (FLAC__uint64)filestats.st_size;


### PR DESCRIPTION
This closes #72, as it provides an error referencing the issue for anyone targeting XP, instead of silently compiling a library that doesn't function correctly.