### PR TITLE
[CMake] Don't search for libiconv and libintl on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,10 @@ if(HAVE_GIT)
         )
 endif()
 
-find_package(Iconv)
-set(HAVE_ICONV ${Iconv_FOUND})
+if(NOT WIN32)
+    find_package(Iconv)
+    set(HAVE_ICONV ${Iconv_FOUND})
+endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wstrict-prototypes -Wmissing-prototypes -Waggregate-return -Wcast-align -Wnested-externs -Wshadow -Wundef -Wmissing-declarations -Winline")

--- a/src/share/getopt/CMakeLists.txt
+++ b/src/share/getopt/CMakeLists.txt
@@ -1,6 +1,8 @@
 check_include_file("string.h" HAVE_STRING_H)
 
-find_package(Intl)
+if(NOT WIN32)
+    find_package(Intl)
+endif()
 
 add_library(getopt STATIC getopt.c getopt1.c)
 


### PR DESCRIPTION
The functions these libs provide don't seem to be used on Windows anyway. This fixes https://github.com/xiph/flac/issues/249