### PR TITLE
Introduce subdivide_tukey apodization

### DIFF
--- a/man/flac.md
+++ b/man/flac.md
@@ -472,14 +472,13 @@ the HTML documentation.
 :	Synonymous with -l 8 -b 4096 -m -r 5
 
 **-6, \--compression-level-6**
-:	Synonymous with -l 8 -b 4096 -m -r 6 -A tukey(0.5) -A partial_tukey(2)
+:	Synonymous with -l 8 -b 4096 -m -r 6 -A subdivide_tukey(2)
 
 **-7, \--compression-level-7**
-:	Synonymous with -l 12 -b 4096 -m -r 6 -A tukey(0.5) -A partial_tukey(2)
+:	Synonymous with -l 12 -b 4096 -m -r 6 -A subdivide_tukey(2)
 
 **-8, \--compression-level-8**
-:	Synonymous with -l 12 -b 4096 -m -r 6 -A tukey(0.5) -A partial_tukey(2)
-	-A punchout_tukey(3)
+:	Synonymous with -l 12 -b 4096 -m -r 6 -A subdivide_tukey(3)
 
 **\--fast**
 :	Fastest compression. Currently synonymous with -0.
@@ -698,7 +697,7 @@ selected with one or more **-A** options. Possible functions are:
 bartlett, bartlett_hann, blackman, blackman_harris_4term_92db,
 connes, flattop, gauss(STDDEV), hamming, hann, kaiser_bessel, nuttall,
 rectangle, triangle, tukey(P), partial_tukey(n\[/ov\[/P\]\]),
-punchout_tukey(n\[/ov\[/P\]\]), welch.
+punchout_tukey(n\[/ov\[/P\]\]), subdivide_tukey(n\[/P\]) welch.
 
 - For gauss(STDDEV), STDDEV is the standard deviation (0\<STDDEV\<=0.5).
 
@@ -717,8 +716,24 @@ encoder will try each different added apodization (each covering a
 different part of the block) to see which resulting predictor results in
 the smallest representation.
 
+- subdivide_tukey(n) is a more efficient reimplementation of partial_tukey
+and punchout_tukey taken together, recycling as much data as possible. It
+combines all possible non-redundant partial_tukey(n) and punchout_tukey(n)
+up to the n specified.  Specifying subdivide_tukey(3) is equivalent to
+specifying tukey, partial_tukey(2), partial_tukey(3) and punchout_tukey(3),
+specifying subdivide_tukey(5) equivalently adds partial_tukey(4),
+punchout_tukey(4), partial_tukey(5) and punchout_tukey(5). To be able to
+reuse data as much as possible, the tukey taper is taken equal for all
+windows, and the P specified is applied for the smallest used window.
+In other words, subdivide_tukey(2/0.5) results in a taper equal to that
+of tukey(0.25) and subdivide_tukey(5) in a taper equal to that of
+tukey(0.1). The default P for subdivide_tukey when none is specified is
+0.5.
+
 Note that P, STDDEV and ov are locale specific, so a comma as
-decimal separator might be required instead of a dot.
+decimal separator might be required instead of a dot. Use scientific
+notation for a locale-independent specification, for example
+tukey(5e-1) instead of tukey(0.5) or tukey(0,5).
 
 More than one -A option (up to 32) may be used. Any function that is
 specified erroneously is silently dropped. The encoder chooses suitable

--- a/src/flac/main.c
+++ b/src/flac/main.c
@@ -1622,12 +1622,12 @@ void show_explain(void)
 	printf("                                     connes, flattop, gauss(STDDEV), hamming,\n");
 	printf("                                     hann, kaiser_bessel, nuttall, rectangle,\n");
 	printf("                                     triangle, tukey(P), welch, partial_tukey(n)\n");
-	printf("                                     punchout_tukey(n). More than one may be\n");
-	printf("                                     specified but encoding time is a multiple\n");
-	printf("                                     of the number of functions since they are\n");
-	printf("                                     each tried in turn.  The encoder chooses\n");
-	printf("                                     suitable defaults in the absence of any -A\n");
-	printf("                                     options.\n");
+	printf("                                     punchout_tukey(n) and subdivide_tukey(n).\n");
+	printf("                                     More than one may be specified but encoding\n");
+	printf("                                     time is a multiple of the number of\n");
+	printf("                                     functions since they are each tried in \n");
+	printf("                                     turn.  The encoder chooses suitable\n");
+	printf("                                     defaults in the absence of any -A options.\n");
 	printf("  -l, --max-lpc-order=#              Max LPC order; 0 => only fixed predictors.\n");
 	printf("                                     Must be <= 12 for Subset streams if sample\n");
 	printf("                                     rate is <=48kHz.\n");

--- a/src/libFLAC/include/private/lpc.h
+++ b/src/libFLAC/include/private/lpc.h
@@ -56,6 +56,8 @@
  */
 void FLAC__lpc_window_data(const FLAC__int32 in[], const FLAC__real window[], FLAC__real out[], uint32_t data_len);
 void FLAC__lpc_window_data_wide(const FLAC__int64 in[], const FLAC__real window[], FLAC__real out[], uint32_t data_len);
+void FLAC__lpc_window_data_partial(const FLAC__int32 in[], const FLAC__real window[], FLAC__real out[], uint32_t data_len, uint32_t part_size, uint32_t data_shift);
+void FLAC__lpc_window_data_partial_wide(const FLAC__int64 in[], const FLAC__real window[], FLAC__real out[], uint32_t data_len, uint32_t part_size, uint32_t data_shift);
 
 /*
  *	FLAC__lpc_compute_autocorrelation()

--- a/src/libFLAC/include/protected/stream_encoder.h
+++ b/src/libFLAC/include/protected/stream_encoder.h
@@ -61,6 +61,7 @@ typedef enum {
 	FLAC__APODIZATION_TUKEY,
 	FLAC__APODIZATION_PARTIAL_TUKEY,
 	FLAC__APODIZATION_PUNCHOUT_TUKEY,
+	FLAC__APODIZATION_SUBDIVIDE_TUKEY,
 	FLAC__APODIZATION_WELCH
 } FLAC__ApodizationFunction;
 
@@ -78,6 +79,10 @@ typedef struct {
 			FLAC__real start;
 			FLAC__real end;
 		} multiple_tukey;
+		struct {
+			FLAC__real p;
+			FLAC__int32 parts;
+		} subdivide_tukey;
 	} parameters;
 } FLAC__ApodizationSpecification;
 

--- a/src/libFLAC/lpc.c
+++ b/src/libFLAC/lpc.c
@@ -43,6 +43,7 @@
 #include "private/bitmath.h"
 #include "private/lpc.h"
 #include "private/macros.h"
+
 #if !defined(NDEBUG) || defined FLAC__OVERFLOW_DETECT || defined FLAC__OVERFLOW_DETECT_VERBOSE
 #include <stdio.h>
 #endif
@@ -76,6 +77,34 @@ void FLAC__lpc_window_data_wide(const FLAC__int64 in[], const FLAC__real window[
 	uint32_t i;
 	for(i = 0; i < data_len; i++)
 		out[i] = in[i] * window[i];
+}
+
+void FLAC__lpc_window_data_partial(const FLAC__int32 in[], const FLAC__real window[], FLAC__real out[], uint32_t data_len, uint32_t part_size, uint32_t data_shift)
+{
+	uint32_t i, j;
+	if((part_size + data_shift) < data_len){
+		for(i = 0; i < part_size; i++)
+			out[i] = in[data_shift+i] * window[i];
+		i = flac_min(i,data_len - part_size - data_shift);
+		for(j = data_len - part_size; j < data_len; i++, j++)
+			out[i] = in[data_shift+i] * window[j];
+		if(i < data_len)
+			out[i] = 0.0f;
+	}
+}
+
+void FLAC__lpc_window_data_partial_wide(const FLAC__int64 in[], const FLAC__real window[], FLAC__real out[], uint32_t data_len, uint32_t part_size, uint32_t data_shift)
+{
+	uint32_t i, j;
+	if((part_size + data_shift) < data_len){
+		for(i = 0; i < part_size; i++)
+			out[i] = in[data_shift+i] * window[i];
+		i = flac_min(i,data_len - part_size - data_shift);
+		for(j = data_len - part_size; j < data_len; i++, j++)
+			out[i] = in[data_shift+i] * window[j];
+		if(i < data_len)
+			out[i] = 0.0f;
+	}
 }
 
 void FLAC__lpc_compute_autocorrelation(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[])

--- a/test/test_streams.sh
+++ b/test/test_streams.sh
@@ -229,6 +229,15 @@ for disable in '' '--disable-verbatim-subframes --disable-constant-subframes' '-
 	done
 done
 
+echo "Testing blocksize variations with subdivide apodization..."
+for blocksize in 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 ; do
+	for lpc_order in 0 1 2 3 4 5 7 8 9 15 16 17 31 32 ; do
+		if [ $lpc_order = 0 ] || [ $lpc_order -le $blocksize ] ; then
+			test_file noise8m32 1 8 "-8 -p -e -A \"subdivide_tukey(32)\" -l $lpc_order --lax --blocksize=$blocksize"
+		fi
+	done
+done
+
 echo "Testing some frame header variations..."
 test_file sine16-01 1 16 "-0 -l $max_lpc_order -m -e -p --lax -b $max_lpc_order"
 test_file sine16-01 1 16 "-0 -l $max_lpc_order -m -e -p --lax -b 65535"


### PR DESCRIPTION
Subdivide_tukey is intended to replace partial_tukey and punchout_tukey. It works in rougly the same way, but uses a more efficient algorithm, recyling more data.

subdivide_tukey has 2 arguments, of which 1 is optional. The first states the maximum number of parts the signal has to be split up in, the second is the tukey parameter, divided by the max num of parts.

subdivide_tukey(3) analyses audio with an unsplit block, with the block split in 2 and split in 3. Here the default p of 0.5 applies to the smallest parts, so the unsplit block effectively has a p of 0.5/3. subdivide_tukey(3/2e-1) does the same but with p of 0.2.

With this change, encoding with compression levels 6, 7 and 8 is approximately 10% faster with on average (depending on the input material) no change in compression. Other compression levels are not affected.