### PR TITLE
Check asserts in fuzzing and prepare for OOM fuzzing

### DIFF
--- a/include/FLAC/assert.h
+++ b/include/FLAC/assert.h
@@ -34,6 +34,10 @@
 #define FLAC__ASSERT_H
 
 /* we need this since some compilers (like MSVC) leave assert()s on release code (and we don't want to use their ASSERT) */
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#define FLAC__ASSERT(x) if(!(x)) __builtin_abort();
+#define FLAC__ASSERT_DECLARATION(x) x
+#else
 #ifndef NDEBUG
 #include <assert.h>
 #define FLAC__ASSERT(x) assert(x)
@@ -41,6 +45,7 @@
 #else
 #define FLAC__ASSERT(x)
 #define FLAC__ASSERT_DECLARATION(x)
+#endif
 #endif
 
 #endif

--- a/oss-fuzz/fuzzer_metadata.cc
+++ b/oss-fuzz/fuzzer_metadata.cc
@@ -267,10 +267,14 @@ static void run_tests_with_level_2_interface(char filename[], bool ogg, bool use
 							num_comments = vorbiscomment->get_num_comments();
 							if(num_comments > 0) {
 								entry = metadata_c->data.vorbis_comment.comments[min(data[i]>>4,num_comments-1)];
-								entry_cpp = vorbiscomment->get_comment(min(data[i]>>4,num_comments-1));
-								if(entry.entry == 0 || (entry_cpp.is_valid() && entry_cpp.get_field() == 0))
+								if(entry.entry == 0)
 									abort();
-								vorbiscomment->find_entry_from(0,"TEST");
+								if(vorbiscomment->get_comment(min(data[i]>>4,num_comments-1)).is_valid()) {
+									entry_cpp = vorbiscomment->get_comment(min(data[i]>>4,num_comments-1));
+									if(entry_cpp.is_valid() && entry_cpp.get_field() == 0)
+										abort();
+									vorbiscomment->find_entry_from(0,"TEST");
+								}
 							}
 
 						}
@@ -349,13 +353,15 @@ static void run_tests_with_level_2_interface(char filename[], bool ogg, bool use
 							if(vorbiscomment == 0)
 								break;
 							num_comments = vorbiscomment->get_num_comments();
-							if(num_comments > 0) {
-								entry = vorbiscomment->get_comment(min(data[i]>>5,num_comments-1));
-								if(entry.is_valid()) {
-									vorbiscomment->replace_comment(entry,data[i] & 16);
-									vorbiscomment->set_comment(0,entry);
-									vorbiscomment->append_comment(entry);
-									vorbiscomment->insert_comment(0,entry);
+							if(num_comments > 0 && entry.is_valid()) {
+								if(vorbiscomment->get_comment(min(data[i]>>5,num_comments-1)).is_valid()) {
+									entry = vorbiscomment->get_comment(min(data[i]>>5,num_comments-1));
+									if(entry.is_valid()) {
+										vorbiscomment->replace_comment(entry,data[i] & 16);
+										vorbiscomment->set_comment(0,entry);
+										vorbiscomment->append_comment(entry);
+										vorbiscomment->insert_comment(0,entry);
+									}
 								}
 							}
 						}

--- a/oss-fuzz/fuzzer_metadata.cc
+++ b/oss-fuzz/fuzzer_metadata.cc
@@ -122,7 +122,7 @@ static void run_tests_with_level_1_interface(char filename[], bool readonly, boo
 	if(!iterator.init(filename,readonly,preservestats))
 		return;
 
-	for(size_t i = 0; i < size; i++) {
+	for(size_t i = 0; i < size && iterator.status() == FLAC__METADATA_SIMPLE_ITERATOR_STATUS_OK; i++) {
 		switch(data[i] & 7) {
 			case 0:
 				iterator.get_block_type();

--- a/src/libFLAC/metadata_iterators.c
+++ b/src/libFLAC/metadata_iterators.c
@@ -1276,6 +1276,11 @@ static FLAC__bool chain_read_cb_(FLAC__Metadata_Chain *chain, FLAC__IOHandle han
 		chain->last_offset = (FLAC__off_t)pos;
 	}
 
+	if(chain->head->data->type != FLAC__METADATA_TYPE_STREAMINFO) {
+		chain->status = FLAC__METADATA_CHAIN_STATUS_BAD_METADATA;
+		return false;
+	}
+
 	chain->initial_length = chain_calculate_length_(chain);
 
 	return true;
@@ -1368,7 +1373,7 @@ static FLAC__bool chain_read_ogg_cb_(FLAC__Metadata_Chain *chain, FLAC__IOHandle
 
 	chain->initial_length = chain_calculate_length_(chain);
 
-	if(chain->initial_length == 0) {
+	if(chain->initial_length == 0 || chain->head->data->type != FLAC__METADATA_TYPE_STREAMINFO) {
 		/* Ogg FLAC file must have at least streaminfo and vorbis comment */
 		chain->status = FLAC__METADATA_CHAIN_STATUS_BAD_METADATA;
 		return false;
@@ -2276,7 +2281,8 @@ FLAC__Metadata_SimpleIteratorStatus read_metadata_block_data_seektable_cb_(FLAC_
 	uint32_t i;
 	FLAC__byte buffer[FLAC__STREAM_METADATA_SEEKPOINT_LENGTH];
 
-	FLAC__ASSERT(block_length % FLAC__STREAM_METADATA_SEEKPOINT_LENGTH == 0);
+	if(block_length % FLAC__STREAM_METADATA_SEEKPOINT_LENGTH != 0)
+		return FLAC__METADATA_SIMPLE_ITERATOR_STATUS_BAD_METADATA;
 
 	block->num_points = block_length / FLAC__STREAM_METADATA_SEEKPOINT_LENGTH;
 

--- a/src/libFLAC/metadata_iterators.c
+++ b/src/libFLAC/metadata_iterators.c
@@ -524,6 +524,7 @@ FLAC_API FLAC__bool FLAC__metadata_simple_iterator_next(FLAC__Metadata_SimpleIte
 {
 	FLAC__ASSERT(0 != iterator);
 	FLAC__ASSERT(0 != iterator->file);
+	FLAC__ASSERT(iterator->status == FLAC__METADATA_SIMPLE_ITERATOR_STATUS_OK);
 
 	if(iterator->is_last)
 		return false;
@@ -544,6 +545,7 @@ FLAC_API FLAC__bool FLAC__metadata_simple_iterator_prev(FLAC__Metadata_SimpleIte
 
 	FLAC__ASSERT(0 != iterator);
 	FLAC__ASSERT(0 != iterator->file);
+	FLAC__ASSERT(iterator->status == FLAC__METADATA_SIMPLE_ITERATOR_STATUS_OK);
 
 	if(iterator->offset[iterator->depth] == iterator->first_offset)
 		return false;
@@ -577,6 +579,7 @@ FLAC_API FLAC__bool FLAC__metadata_simple_iterator_is_last(const FLAC__Metadata_
 {
 	FLAC__ASSERT(0 != iterator);
 	FLAC__ASSERT(0 != iterator->file);
+	FLAC__ASSERT(iterator->status == FLAC__METADATA_SIMPLE_ITERATOR_STATUS_OK);
 
 	return iterator->is_last;
 }
@@ -586,6 +589,7 @@ FLAC_API off_t FLAC__metadata_simple_iterator_get_block_offset(const FLAC__Metad
 {
 	FLAC__ASSERT(0 != iterator);
 	FLAC__ASSERT(0 != iterator->file);
+	FLAC__ASSERT(iterator->status == FLAC__METADATA_SIMPLE_ITERATOR_STATUS_OK);
 
 	return (off_t)iterator->offset[iterator->depth];
 }
@@ -594,6 +598,7 @@ FLAC_API FLAC__MetadataType FLAC__metadata_simple_iterator_get_block_type(const 
 {
 	FLAC__ASSERT(0 != iterator);
 	FLAC__ASSERT(0 != iterator->file);
+	FLAC__ASSERT(iterator->status == FLAC__METADATA_SIMPLE_ITERATOR_STATUS_OK);
 
 	return iterator->type;
 }
@@ -603,6 +608,7 @@ FLAC_API uint32_t FLAC__metadata_simple_iterator_get_block_length(const FLAC__Me
 {
 	FLAC__ASSERT(0 != iterator);
 	FLAC__ASSERT(0 != iterator->file);
+	FLAC__ASSERT(iterator->status == FLAC__METADATA_SIMPLE_ITERATOR_STATUS_OK);
 
 	return iterator->length;
 }
@@ -615,6 +621,7 @@ FLAC_API FLAC__bool FLAC__metadata_simple_iterator_get_application_id(FLAC__Meta
 	FLAC__ASSERT(0 != iterator);
 	FLAC__ASSERT(0 != iterator->file);
 	FLAC__ASSERT(0 != id);
+	FLAC__ASSERT(iterator->status == FLAC__METADATA_SIMPLE_ITERATOR_STATUS_OK);
 
 	if(iterator->type != FLAC__METADATA_TYPE_APPLICATION) {
 		iterator->status = FLAC__METADATA_SIMPLE_ITERATOR_STATUS_ILLEGAL_INPUT;
@@ -641,6 +648,7 @@ FLAC_API FLAC__StreamMetadata *FLAC__metadata_simple_iterator_get_block(FLAC__Me
 
 	FLAC__ASSERT(0 != iterator);
 	FLAC__ASSERT(0 != iterator->file);
+	FLAC__ASSERT(iterator->status == FLAC__METADATA_SIMPLE_ITERATOR_STATUS_OK);
 
 	if(0 != block) {
 		block->is_last = iterator->is_last;
@@ -672,6 +680,7 @@ FLAC_API FLAC__bool FLAC__metadata_simple_iterator_set_block(FLAC__Metadata_Simp
 	FLAC__ASSERT(0 != iterator);
 	FLAC__ASSERT(0 != iterator->file);
 	FLAC__ASSERT(0 != block);
+	FLAC__ASSERT(iterator->status == FLAC__METADATA_SIMPLE_ITERATOR_STATUS_OK);
 
 	if(!iterator->is_writable) {
 		iterator->status = FLAC__METADATA_SIMPLE_ITERATOR_STATUS_NOT_WRITABLE;
@@ -773,6 +782,7 @@ FLAC_API FLAC__bool FLAC__metadata_simple_iterator_insert_block_after(FLAC__Meta
 	FLAC__ASSERT(0 != iterator);
 	FLAC__ASSERT(0 != iterator->file);
 	FLAC__ASSERT(0 != block);
+	FLAC__ASSERT(iterator->status == FLAC__METADATA_SIMPLE_ITERATOR_STATUS_OK);
 
 	if(!iterator->is_writable) {
 		iterator->status = FLAC__METADATA_SIMPLE_ITERATOR_STATUS_NOT_WRITABLE;
@@ -847,6 +857,8 @@ FLAC_API FLAC__bool FLAC__metadata_simple_iterator_delete_block(FLAC__Metadata_S
 {
 	FLAC__ASSERT_DECLARATION(FLAC__off_t debug_target_offset = iterator->offset[iterator->depth];)
 	FLAC__bool ret;
+
+	FLAC__ASSERT(iterator->status == FLAC__METADATA_SIMPLE_ITERATOR_STATUS_OK);
 
 	if(!iterator->is_writable) {
 		iterator->status = FLAC__METADATA_SIMPLE_ITERATOR_STATUS_NOT_WRITABLE;

--- a/src/libFLAC/metadata_iterators.c
+++ b/src/libFLAC/metadata_iterators.c
@@ -310,6 +310,8 @@ FLAC_API FLAC__bool FLAC__metadata_get_picture(const char *filename, FLAC__Strea
 					FLAC__metadata_object_delete(obj);
 				}
 			}
+			else
+				break;
 		}
 	} while(FLAC__metadata_simple_iterator_next(it));
 

--- a/src/libFLAC/metadata_iterators.c
+++ b/src/libFLAC/metadata_iterators.c
@@ -708,9 +708,10 @@ FLAC_API FLAC__bool FLAC__metadata_simple_iterator_set_block(FLAC__Metadata_Simp
 			return ret;
 		}
 		else {
-			ret = rewrite_whole_file_(iterator, block, /*append=*/false);
-			FLAC__ASSERT(!ret || iterator->offset[iterator->depth] == debug_target_offset);
-			FLAC__ASSERT(!ret || ftello(iterator->file) == debug_target_offset + (FLAC__off_t)FLAC__STREAM_METADATA_HEADER_LENGTH);
+			if((ret = rewrite_whole_file_(iterator, block, /*append=*/false))) {
+				FLAC__ASSERT(!ret || iterator->offset[iterator->depth] == debug_target_offset);
+				FLAC__ASSERT(!ret || ftello(iterator->file) == debug_target_offset + (FLAC__off_t)FLAC__STREAM_METADATA_HEADER_LENGTH);
+			}
 			return ret;
 		}
 	}
@@ -765,9 +766,10 @@ FLAC_API FLAC__bool FLAC__metadata_simple_iterator_set_block(FLAC__Metadata_Simp
 			}
 		}
 		else {
-			ret = rewrite_whole_file_(iterator, block, /*append=*/false);
-			FLAC__ASSERT(!ret || iterator->offset[iterator->depth] == debug_target_offset);
-			FLAC__ASSERT(!ret || ftello(iterator->file) == debug_target_offset + (FLAC__off_t)FLAC__STREAM_METADATA_HEADER_LENGTH);
+			if((ret = rewrite_whole_file_(iterator, block, /*append=*/false))) {
+				FLAC__ASSERT(!ret || iterator->offset[iterator->depth] == debug_target_offset);
+				FLAC__ASSERT(!ret || ftello(iterator->file) == debug_target_offset + (FLAC__off_t)FLAC__STREAM_METADATA_HEADER_LENGTH);
+			}
 			return ret;
 		}
 	}
@@ -848,9 +850,10 @@ FLAC_API FLAC__bool FLAC__metadata_simple_iterator_insert_block_after(FLAC__Meta
 		}
 	}
 	else {
-		ret = rewrite_whole_file_(iterator, block, /*append=*/true);
-		FLAC__ASSERT(iterator->offset[iterator->depth] == debug_target_offset);
-		FLAC__ASSERT(ftello(iterator->file) == debug_target_offset + (FLAC__off_t)FLAC__STREAM_METADATA_HEADER_LENGTH);
+		if((ret = rewrite_whole_file_(iterator, block, /*append=*/true))) {
+			FLAC__ASSERT(iterator->offset[iterator->depth] == debug_target_offset);
+			FLAC__ASSERT(ftello(iterator->file) == debug_target_offset + (FLAC__off_t)FLAC__STREAM_METADATA_HEADER_LENGTH);
+		}
 		return ret;
 	}
 }
@@ -891,9 +894,10 @@ FLAC_API FLAC__bool FLAC__metadata_simple_iterator_delete_block(FLAC__Metadata_S
 		return true;
 	}
 	else {
-		ret = rewrite_whole_file_(iterator, 0, /*append=*/false);
-		FLAC__ASSERT(iterator->offset[iterator->depth] + (FLAC__off_t)FLAC__STREAM_METADATA_HEADER_LENGTH + (FLAC__off_t)iterator->length == debug_target_offset);
-		FLAC__ASSERT(ftello(iterator->file) + (FLAC__off_t)iterator->length == debug_target_offset);
+		if((ret = rewrite_whole_file_(iterator, 0, /*append=*/false))) {
+			FLAC__ASSERT(iterator->offset[iterator->depth] + (FLAC__off_t)FLAC__STREAM_METADATA_HEADER_LENGTH + (FLAC__off_t)iterator->length == debug_target_offset);
+			FLAC__ASSERT(ftello(iterator->file) + (FLAC__off_t)iterator->length == debug_target_offset);
+		}
 		return ret;
 	}
 }

--- a/src/libFLAC/metadata_object.c
+++ b/src/libFLAC/metadata_object.c
@@ -1089,7 +1089,6 @@ FLAC_API FLAC__bool FLAC__metadata_object_seektable_template_append_spaced_point
 {
 	FLAC__ASSERT(object != NULL);
 	FLAC__ASSERT(object->type == FLAC__METADATA_TYPE_SEEKTABLE);
-	FLAC__ASSERT(total_samples > 0);
 
 	if (num > 0 && total_samples > 0) {
 		FLAC__StreamMetadata_SeekTable *seek_table = &object->data.seek_table;
@@ -1114,8 +1113,6 @@ FLAC_API FLAC__bool FLAC__metadata_object_seektable_template_append_spaced_point
 {
 	FLAC__ASSERT(object != NULL);
 	FLAC__ASSERT(object->type == FLAC__METADATA_TYPE_SEEKTABLE);
-	FLAC__ASSERT(samples > 0);
-	FLAC__ASSERT(total_samples > 0);
 
 	if (samples > 0 && total_samples > 0) {
 		FLAC__StreamMetadata_SeekTable *seek_table = &object->data.seek_table;

--- a/src/libFLAC/metadata_object.c
+++ b/src/libFLAC/metadata_object.c
@@ -136,7 +136,6 @@ static FLAC__bool copy_vcentry_(FLAC__StreamMetadata_VorbisComment_Entry *to, co
 	}
 	else {
 		FLAC__byte *x;
-		FLAC__ASSERT(from->length > 0);
 		if ((x = safe_malloc_add_2op_(from->length, /*+*/1)) == NULL)
 			return false;
 		memcpy(x, from->entry, from->length);
@@ -1283,7 +1282,7 @@ FLAC_API FLAC__bool FLAC__metadata_object_vorbiscomment_append_comment(FLAC__Str
 
 FLAC_API FLAC__bool FLAC__metadata_object_vorbiscomment_replace_comment(FLAC__StreamMetadata *object, FLAC__StreamMetadata_VorbisComment_Entry entry, FLAC__bool all, FLAC__bool copy)
 {
-	FLAC__ASSERT(entry.entry != NULL && entry.length > 0);
+	FLAC__ASSERT(entry.entry != NULL);
 
 	if (!FLAC__format_vorbiscomment_entry_is_legal(entry.entry, entry.length))
 		return false;
@@ -1373,7 +1372,7 @@ FLAC_API FLAC__bool FLAC__metadata_object_vorbiscomment_entry_from_name_value_pa
 
 FLAC_API FLAC__bool FLAC__metadata_object_vorbiscomment_entry_to_name_value_pair(const FLAC__StreamMetadata_VorbisComment_Entry entry, char **field_name, char **field_value)
 {
-	FLAC__ASSERT(entry.entry != NULL && entry.length > 0);
+	FLAC__ASSERT(entry.entry != NULL);
 	FLAC__ASSERT(field_name != NULL);
 	FLAC__ASSERT(field_value != NULL);
 
@@ -1404,7 +1403,7 @@ FLAC_API FLAC__bool FLAC__metadata_object_vorbiscomment_entry_to_name_value_pair
 
 FLAC_API FLAC__bool FLAC__metadata_object_vorbiscomment_entry_matches(const FLAC__StreamMetadata_VorbisComment_Entry entry, const char *field_name, uint32_t field_name_length)
 {
-	FLAC__ASSERT(entry.entry != NULL && entry.length > 0);
+	FLAC__ASSERT(entry.entry != NULL);
 	{
 		const FLAC__byte *eq = (FLAC__byte*)memchr(entry.entry, '=', entry.length);
 		return (eq != NULL && (uint32_t)(eq-entry.entry) == field_name_length && FLAC__STRNCASECMP(field_name, (const char *)entry.entry, field_name_length) == 0);

--- a/src/libFLAC/metadata_object.c
+++ b/src/libFLAC/metadata_object.c
@@ -217,7 +217,7 @@ static void vorbiscomment_entry_array_delete_(FLAC__StreamMetadata_VorbisComment
 {
 	uint32_t i;
 
-	FLAC__ASSERT(object_array != NULL && num_comments > 0);
+	FLAC__ASSERT(object_array != NULL);
 
 	for (i = 0; i < num_comments; i++)
 		free(object_array[i].entry);
@@ -651,7 +651,6 @@ void FLAC__metadata_object_delete_data(FLAC__StreamMetadata *object)
 				object->data.vorbis_comment.vendor_string.entry = 0;
 			}
 			if (object->data.vorbis_comment.comments != NULL) {
-				FLAC__ASSERT(object->data.vorbis_comment.num_comments > 0);
 				vorbiscomment_entry_array_delete_(object->data.vorbis_comment.comments, object->data.vorbis_comment.num_comments);
 				object->data.vorbis_comment.comments = NULL;
 				object->data.vorbis_comment.num_comments = 0;

--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -2575,8 +2575,11 @@ FLAC__bool read_subframe_(FLAC__StreamDecoder *decoder, uint32_t channel, uint32
 		if(!FLAC__bitreader_read_unary_unsigned(decoder->private_->input, &u))
 			return false; /* read_callback_ sets the state for us */
 		decoder->private_->frame.subframes[channel].wasted_bits = u+1;
-		if (decoder->private_->frame.subframes[channel].wasted_bits >= bps)
-			return false;
+		if (decoder->private_->frame.subframes[channel].wasted_bits >= bps) {
+			send_error_to_client_(decoder, FLAC__STREAM_DECODER_ERROR_STATUS_LOST_SYNC);
+			decoder->protected_->state = FLAC__STREAM_DECODER_SEARCH_FOR_FRAME_SYNC;
+			return true;
+		}
 		bps -= decoder->private_->frame.subframes[channel].wasted_bits;
 	}
 	else

--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -1008,7 +1008,6 @@ FLAC_API FLAC__bool FLAC__stream_decoder_process_single(FLAC__StreamDecoder *dec
 			case FLAC__STREAM_DECODER_ABORTED:
 				return true;
 			default:
-				FLAC__ASSERT(0);
 				return false;
 		}
 	}
@@ -1035,7 +1034,6 @@ FLAC_API FLAC__bool FLAC__stream_decoder_process_until_end_of_metadata(FLAC__Str
 			case FLAC__STREAM_DECODER_ABORTED:
 				return true;
 			default:
-				FLAC__ASSERT(0);
 				return false;
 		}
 	}
@@ -1069,7 +1067,6 @@ FLAC_API FLAC__bool FLAC__stream_decoder_process_until_end_of_stream(FLAC__Strea
 			case FLAC__STREAM_DECODER_ABORTED:
 				return true;
 			default:
-				FLAC__ASSERT(0);
 				return false;
 		}
 	}
@@ -1100,7 +1097,6 @@ FLAC_API FLAC__bool FLAC__stream_decoder_skip_single_frame(FLAC__StreamDecoder *
 			case FLAC__STREAM_DECODER_ABORTED:
 				return true;
 			default:
-				FLAC__ASSERT(0);
 				return false;
 		}
 	}

--- a/src/test_libFLAC++/metadata_manip.cpp
+++ b/src/test_libFLAC++/metadata_manip.cpp
@@ -958,6 +958,9 @@ static bool test_level_1_()
 		return die_("iterator.set_block() returned true but shouldn't have");
 	}
 
+        if(iterator.status() != FLAC__METADATA_SIMPLE_ITERATOR_STATUS_ILLEGAL_INPUT)
+                return die_("iterator.status() should have been FLAC__METADATA_SIMPLE_ITERATOR_STATUS_ILLEGAL_INPUT");
+
 	printf("[S]VP\tnext\n");
 	if(!iterator.next()) {
 		delete app;
@@ -1014,6 +1017,9 @@ static bool test_level_1_()
 	printf("[S]VPPP\tdelete (STREAMINFO block), must fail\n");
 	if(iterator.delete_block(false))
 		return die_ss_("iterator.delete_block(false) should have returned false", iterator);
+
+        if(iterator.status() != FLAC__METADATA_SIMPLE_ITERATOR_STATUS_ILLEGAL_INPUT)
+                return die_("iterator.status() should have been FLAC__METADATA_SIMPLE_ITERATOR_STATUS_ILLEGAL_INPUT");
 
 	if(!test_file_(/*is_ogg=*/false, /*ignore_metadata=*/false))
 		return false;

--- a/src/test_libFLAC/metadata_manip.c
+++ b/src/test_libFLAC/metadata_manip.c
@@ -907,6 +907,9 @@ static FLAC__bool test_level_1_(void)
 	else
 		return die_("FLAC__metadata_simple_iterator_set_block() returned true but shouldn't have");
 
+	if(FLAC__metadata_simple_iterator_status(iterator) != FLAC__METADATA_SIMPLE_ITERATOR_STATUS_ILLEGAL_INPUT)
+		return die_("FLAC__metadata_simple_iterator_status() should have been FLAC__METADATA_SIMPLE_ITERATOR_STATUS_ILLEGAL_INPUT");
+
 	printf("[S]VP\tnext\n");
 	if(!FLAC__metadata_simple_iterator_next(iterator))
 		return die_("iterator ended early\n");
@@ -957,6 +960,9 @@ static FLAC__bool test_level_1_(void)
 	printf("[S]VPPP\tdelete (STREAMINFO block), must fail\n");
 	if(FLAC__metadata_simple_iterator_delete_block(iterator, false))
 		return die_ss_("FLAC__metadata_simple_iterator_delete_block(iterator, false) should have returned false", iterator);
+
+	if(FLAC__metadata_simple_iterator_status(iterator) != FLAC__METADATA_SIMPLE_ITERATOR_STATUS_ILLEGAL_INPUT)
+		return die_("FLAC__metadata_simple_iterator_status() should have been FLAC__METADATA_SIMPLE_ITERATOR_STATUS_ILLEGAL_INPUT");
 
 	if(!test_file_(/*is_ogg=*/false, decoder_metadata_callback_compare_))
 		return false;


### PR DESCRIPTION
First two commits are to check asserts in fuzzing

Third commit prepares for out-of-memory fuzzing. That needs a change in the oss-fuzz repository, which in turn depends on fuzzing_common.h being present, so that is merged in advance

Last commit fixes a condition found because an assert was triggered