### PR TITLE
Prepare oom checking in fuzzing

### DIFF
--- a/oss-fuzz/Makefile.am
+++ b/oss-fuzz/Makefile.am
@@ -21,6 +21,7 @@ AM_CXXFLAGS = -std=c++11
 
 EXTRA_DIST = \
 	fuzzer_encoder.dict \
+	fuzzer_common.h \
 	Readme.md \
 	fuzzing/datasource/datasource.hpp \
 	fuzzing/datasource/id.hpp \

--- a/oss-fuzz/fuzzer_common.h
+++ b/oss-fuzz/fuzzer_common.h
@@ -1,0 +1,2 @@
+extern int alloc_check_threshold, alloc_check_counter;
+int alloc_check_threshold = INT32_MAX, alloc_check_counter = 0;


### PR DESCRIPTION
By merging oom checking in fuzzing in steps, it is possible to implement it without having oss-fuzz build failures