### PR TITLE
Fix make check on MinGW when building shared library

### DIFF
--- a/src/share/Makefile.am
+++ b/src/share/Makefile.am
@@ -44,7 +44,6 @@ noinst_LTLIBRARIES = \
 if OS_IS_WINDOWS
 win_utf8_io_libwin_utf8_io_la_SOURCES =	win_utf8_io/win_utf8_io.c
 libwin_utf8_io = win_utf8_io/libwin_utf8_io.la
-win_utf8_io_libwin_utf8_io_la_LIBADD = $(top_builddir)/src/libFLAC/libFLAC.la -lm
 else
 win_utf8_io_libwin_utf8_io_la_SOURCES =
 libwin_utf8_io =

--- a/src/test_libFLAC/Makefile.am
+++ b/src/test_libFLAC/Makefile.am
@@ -19,13 +19,14 @@
 EXTRA_DIST = \
 	CMakeLists.txt
 
-AM_CPPFLAGS = -I$(top_builddir) -I$(srcdir)/include -I$(top_srcdir)/include -I$(top_srcdir)/src/libFLAC/include
-
 check_PROGRAMS = test_libFLAC
 
 if OS_IS_WINDOWS
 win_utf8_lib = $(top_builddir)/src/share/win_utf8_io/libwin_utf8_io.la
+flac__no_dll = -DFLAC__NO_DLL
 endif
+
+AM_CPPFLAGS = -I$(top_builddir) -I$(srcdir)/include -I$(top_srcdir)/include -I$(top_srcdir)/src/libFLAC/include $(flac__no_dll)
 
 test_libFLAC_LDADD = \
 	$(top_builddir)/src/share/grabbag/libgrabbag.la \


### PR DESCRIPTION
Recently I've only tested with `--enable-static --disable-shared`, but just running plain `./configure` I found out that `make check` doesn't work. test_libFLAC fails to build as it was being compiled with both the static as well as the shared library linked.