### PR TITLE
Remove assert that is no longer true

### DIFF
--- a/src/libFLAC/format.c
+++ b/src/libFLAC/format.c
@@ -586,8 +586,6 @@ FLAC__bool FLAC__format_entropy_coding_method_partitioned_rice_contents_ensure_s
 {
 	FLAC__ASSERT(0 != object);
 
-	FLAC__ASSERT(object->capacity_by_order > 0 || (0 == object->parameters && 0 == object->raw_bits));
-
 	if(object->capacity_by_order < max_partition_order || object->parameters == NULL || object->raw_bits == NULL) {
 		if(0 == (object->parameters = safe_realloc_(object->parameters, sizeof(uint32_t)*(1 << max_partition_order))))
 			return false;


### PR DESCRIPTION
This was never strictly true, but the assert fired in normal use since commit a2c8ae5