### PR TITLE
Fix endianness display in endswap test (cosmetic issue)

### DIFF
--- a/config.cmake.h.in
+++ b/config.cmake.h.in
@@ -6,9 +6,6 @@
 /* Target processor is big endian. */
 #cmakedefine01 CPU_IS_BIG_ENDIAN
 
-/* Target processor is little endian. */
-#cmakedefine01 CPU_IS_LITTLE_ENDIAN
-
 /* Target processor ARM64 */
 #cmakedefine FLAC__CPU_ARM64
 

--- a/src/test_libFLAC/endswap.c
+++ b/src/test_libFLAC/endswap.c
@@ -43,7 +43,7 @@ FLAC__bool test_endswap(void)
 		uint32_t u32;
 	} data;
 
-	printf("\n+++ libFLAC unit test: endswap (%s endian host)\n\n", CPU_IS_LITTLE_ENDIAN ? "little" : "big");
+	printf("\n+++ libFLAC unit test: endswap (%s endian host)\n\n", CPU_IS_BIG_ENDIAN ? "big" : "little");
 
 	printf("testing ENDSWAP_16 on int16_t ... ");
 	if (((int16_t) ENDSWAP_16(i16)) == i16) {


### PR DESCRIPTION
As CPU_IS_LITTLE_ENDIAN is used nowehere except in test_libflac, switch to CPU_IS_BIG_ENDIAN instead, which is actually used in the code at several places. CMake didn't set the former but does set the latter.

Fixes cosmetic issue mentioned in #437 