### PR TITLE
Do not make empty man pages, use either pandoc or prebuild

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -481,7 +481,7 @@ else
 AC_CHECK_FILE($srcdir/man/flac.1,[HAVE_MAN_FLAC=yes])
 AC_CHECK_FILE($srcdir/man/metaflac.1,[HAVE_MAN_METAFLAC=yes])
 fi
-AM_CONDITIONAL(FLaC__HAS_PREBUILD_MANPAGES, test "x$HAVE_MAN_FLAC$HAVE_MAN_METAFLAC" = "xyesyes")
+AM_CONDITIONAL(FLaC__HAS_PREBUILT_MANPAGES, test "x$HAVE_MAN_FLAC$HAVE_MAN_METAFLAC" = "xyesyes")
 
 AC_CHECK_LIB(rt, clock_gettime,
         LIB_CLOCK_GETTIME=-lrt

--- a/configure.ac
+++ b/configure.ac
@@ -477,7 +477,11 @@ AM_CONDITIONAL(FLaC__HAS_PANDOC, test -n "$PANDOC")
 if test -n "$PANDOC" ; then
 AC_DEFINE(FLAC__HAS_PANDOC)
 AH_TEMPLATE(FLAC__HAS_PANDOC, [define if you have pandoc])
+else
+AC_CHECK_FILE($srcdir/man/flac.1,[HAVE_MAN_FLAC=yes])
+AC_CHECK_FILE($srcdir/man/metaflac.1,[HAVE_MAN_METAFLAC=yes])
 fi
+AM_CONDITIONAL(FLaC__HAS_PREBUILD_MANPAGES, test "x$HAVE_MAN_FLAC$HAVE_MAN_METAFLAC" = "xyesyes")
 
 AC_CHECK_LIB(rt, clock_gettime,
         LIB_CLOCK_GETTIME=-lrt

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -22,16 +22,13 @@ flac.1: flac.md
 
 metaflac.1: metaflac.md
 	pandoc --standalone --to man $? > $@
-	
-else
-flac.1:
-	echo "*** Warning: docbook-to-man not found; man pages will not be built."
-	touch $@
-
-metaflac.1:
-	touch $@
-endif
 
 man_MANS = flac.1 metaflac.1
 
-EXTRA_DIST = $(man_MANS) flac.md metaflac.md
+else
+if FLaC__HAS_PREBUILD_MANPAGES
+man_MANS = flac.1 metaflac.1
+endif
+endif
+
+EXTRA_DIST = flac.1 metaflac.1 flac.md metaflac.md

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -26,7 +26,7 @@ metaflac.1: metaflac.md
 man_MANS = flac.1 metaflac.1
 
 else
-if FLaC__HAS_PREBUILD_MANPAGES
+if FLaC__HAS_PREBUILT_MANPAGES
 man_MANS = flac.1 metaflac.1
 endif
 endif


### PR DESCRIPTION
A check is added to configure whether flac.1 and metaflac.1 are already build when pandoc is not available. This is the case in for example dist packages