### PR TITLE
Warn user when encoding to stdout that checksum isn't written

### DIFF
--- a/src/flac/encode.c
+++ b/src/flac/encode.c
@@ -2154,6 +2154,13 @@ FLAC__bool EncoderSession_init_encoder(EncoderSession *e, encode_options_t optio
 		}
 		FLAC__stream_encoder_set_do_md5(e->encoder, false);
 	}
+	else if(e->is_stdout) {
+		flac__utils_printf(stderr, 1, "%s: WARNING, cannot write back MD5 sum when encoding to stdout\n", e->inbasefilename);
+		if(e->treat_warnings_as_errors) {
+			static_metadata_clear(&static_metadata);
+			return false;
+		}
+	}
 
 #if FLAC__HAS_OGG
 	if(e->use_ogg) {


### PR DESCRIPTION
Fixes https://github.com/xiph/flac/issues/428