### PR TITLE
stream_decoder.c: move sys/stat.h include after sys/types.h.

### DIFF
--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -37,8 +37,8 @@
 #include <stdio.h>
 #include <stdlib.h> /* for malloc() */
 #include <string.h> /* for memset/memcpy() */
-#include <sys/stat.h> /* for stat() */
 #include <sys/types.h> /* for off_t */
+#include <sys/stat.h>  /* for stat() */
 #include "share/compat.h"
 #include "FLAC/assert.h"
 #include "share/alloc.h"
@@ -3683,3 +3683,4 @@ FLAC__bool file_eof_callback_(const FLAC__StreamDecoder *decoder, void *client_d
 
 	return feof(decoder->private_->file)? true : false;
 }
+

--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -3683,4 +3683,3 @@ FLAC__bool file_eof_callback_(const FLAC__StreamDecoder *decoder, void *client_d
 
 	return feof(decoder->private_->file)? true : false;
 }
-


### PR DESCRIPTION
It is common practice that sys/types.h is usually included before
sys/stat.h, see e.g. stat/fstat man page.  Without this, some old
systems might emit warnings.  (I remember running into it quite a
while ago, can't really remember which environment though..)