### PR TITLE
getopt: avoid K&R function definitions

### DIFF
--- a/src/share/getopt/getopt.c
+++ b/src/share/getopt/getopt.c
@@ -312,8 +312,7 @@ static void exchange (char **);
 #endif
 
 static void
-exchange (argv)
-     char **argv;
+exchange (char **argv)
 {
   int bottom = first_nonopt;
   int middle = last_nonopt;
@@ -397,10 +396,7 @@ exchange (argv)
 static const char *share___getopt_initialize (int, char *const *, const char *);
 #endif
 static const char *
-share___getopt_initialize (argc, argv, optstring)
-     int argc;
-     char *const *argv;
-     const char *optstring;
+share___getopt_initialize (int argc, char *const *argv, const char *optstring )
 {
   /* Start processing options with ARGV-element 1 (since ARGV-element 0
      is the program name); the sequence of previously skipped
@@ -521,13 +517,13 @@ share___getopt_initialize (argc, argv, optstring)
    long-named options.  */
 
 int
-share___getopt_internal (argc, argv, optstring, longopts, longind, long_only)
-     int argc;
-     char *const *argv;
-     const char *optstring;
-     const struct share__option *longopts;
-     int *longind;
-     int long_only;
+share___getopt_internal (
+     int argc,
+     char *const *argv,
+     const char *optstring,
+     const struct share__option *longopts,
+     int *longind,
+     int long_only )
 {
   share__optarg = NULL;
 
@@ -976,10 +972,7 @@ share___getopt_internal (argc, argv, optstring, longopts, longind, long_only)
 }
 
 int
-share__getopt (argc, argv, optstring)
-     int argc;
-     char *const *argv;
-     const char *optstring;
+share__getopt (int argc, char *const *argv, const char *optstring)
 {
   return share___getopt_internal (argc, argv, optstring,
 			   (const struct share__option *) 0,
@@ -995,9 +988,7 @@ share__getopt (argc, argv, optstring)
    the above definition of `share__getopt'.  */
 
 int
-main (argc, argv)
-     int argc;
-     char **argv;
+main (int argc, char **argv)
 {
   int c;
   int digit_optind = 0;


### PR DESCRIPTION
This avoids warnings on clang-16 such as:

```
getopt/getopt.c:315:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
exchange (argv)
^
```