### PR TITLE
fix broken bswap.m4:

### DIFF
--- a/m4/bswap.m4
+++ b/m4/bswap.m4
@@ -39,16 +39,10 @@ AC_DEFUN([XIPH_C_BSWAP32],
 [AC_CACHE_CHECK(for bswap32 intrinsic,
   ac_cv_c_bswap32,
 
-  # Initialize to no
-  ac_cv_c_bswap32=no
-  HAVE_BSWAP32=0
-
-  [AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return __builtin_bswap32 (0) ;]])],[ac_cv_c_bswap32=yes
-    HAVE_BSWAP32=1
-  ],[])]
-  AC_DEFINE_UNQUOTED(HAVE_BSWAP32, ${HAVE_BSWAP32},
-    [Compiler has the __builtin_bswap32 intrinsic])
-
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([], [[return __builtin_bswap32 (0) ;]])],[ac_cv_c_bswap32=yes],[ac_cv_c_bswap32=no])
+  if test $ac_cv_c_bswap32 = yes; then
+     AC_DEFINE_UNQUOTED(HAVE_BSWAP32, [1], [Compiler has the __builtin_bswap32 intrinsic])
+    fi
   )]
 )# XIPH_C_BSWAP32
 
@@ -64,15 +58,9 @@ AC_DEFUN([XIPH_C_BSWAP16],
 [AC_CACHE_CHECK(for bswap16 intrinsic,
   ac_cv_c_bswap16,
 
-  # Initialize to no
-  ac_cv_c_bswap16=no
-  HAVE_BSWAP16=0
-
-  [AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[return __builtin_bswap16 (0) ;]])],[ac_cv_c_bswap16=yes
-    HAVE_BSWAP16=1
-  ],[])]
-  AC_DEFINE_UNQUOTED(HAVE_BSWAP16, ${HAVE_BSWAP16},
-    [Compiler has the __builtin_bswap16 intrinsic])
-
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([], [[return __builtin_bswap16 (0) ;]])],[ac_cv_c_bswap16=yes],[ac_cv_c_bswap16=no])
+  if test $ac_cv_c_bswap16 = yes; then
+     AC_DEFINE_UNQUOTED(HAVE_BSWAP16, [1], [Compiler has the __builtin_bswap16 intrinsic])
+    fi
   )]
 )# XIPH_C_BSWAP16


### PR DESCRIPTION
it used to always define HAVE_BSWAP32 and HAVE_BSWAP16 even if the builtin isn't supported.