### PR TITLE
fix a typo in stream_encoder.h

### DIFF
--- a/include/FLAC++/metadata.h
+++ b/include/FLAC++/metadata.h
@@ -274,7 +274,7 @@ namespace FLAC {
 
 		/** STREAMINFO metadata block.
 		 *  See the \link flacpp_metadata_object overview \endlink for more,
-		 *  and the <A HREF="../format.html#metadata_block_streaminfo">format specification</A>.
+		 *  and the <A HREF="https://xiph.org/flac/format.html#metadata_block_streaminfo">format specification</A>.
 		 */
 		class FLACPP_API StreamInfo : public Prototype {
 		public:
@@ -323,7 +323,7 @@ namespace FLAC {
 			//@}
 
 			//@{
-			/** See <A HREF="../format.html#metadata_block_streaminfo">format specification</A>. */
+			/** See <A HREF="https://xiph.org/flac/format.html#metadata_block_streaminfo">format specification</A>. */
 			uint32_t get_min_blocksize() const;
 			uint32_t get_max_blocksize() const;
 			uint32_t get_min_framesize() const;
@@ -348,7 +348,7 @@ namespace FLAC {
 
 		/** PADDING metadata block.
 		 *  See the \link flacpp_metadata_object overview \endlink for more,
-		 *  and the <A HREF="../format.html#metadata_block_padding">format specification</A>.
+		 *  and the <A HREF="https://xiph.org/flac/format.html#metadata_block_padding">format specification</A>.
 		 */
 		class FLACPP_API Padding : public Prototype {
 		public:
@@ -407,7 +407,7 @@ namespace FLAC {
 
 		/** APPLICATION metadata block.
 		 *  See the \link flacpp_metadata_object overview \endlink for more,
-		 *  and the <A HREF="../format.html#metadata_block_application">format specification</A>.
+		 *  and the <A HREF="https://xiph.org/flac/format.html#metadata_block_application">format specification</A>.
 		 */
 		class FLACPP_API Application : public Prototype {
 		public:
@@ -466,7 +466,7 @@ namespace FLAC {
 
 		/** SEEKTABLE metadata block.
 		 *  See the \link flacpp_metadata_object overview \endlink for more,
-		 *  and the <A HREF="../format.html#metadata_block_seektable">format specification</A>.
+		 *  and the <A HREF="https://xiph.org/flac/format.html#metadata_block_seektable">format specification</A>.
 		 */
 		class FLACPP_API SeekTable : public Prototype {
 		public:
@@ -553,7 +553,7 @@ namespace FLAC {
 
 		/** VORBIS_COMMENT metadata block.
 		 *  See the \link flacpp_metadata_object overview \endlink for more,
-		 *  and the <A HREF="../format.html#metadata_block_vorbis_comment">format specification</A>.
+		 *  and the <A HREF="https://xiph.org/flac/format.html#metadata_block_vorbis_comment">format specification</A>.
 		 */
 		class FLACPP_API VorbisComment : public Prototype {
 		public:
@@ -720,7 +720,7 @@ namespace FLAC {
 
 		/** CUESHEET metadata block.
 		 *  See the \link flacpp_metadata_object overview \endlink for more,
-		 *  and the <A HREF="../format.html#metadata_block_cuesheet">format specification</A>.
+		 *  and the <A HREF="https://xiph.org/flac/format.html#metadata_block_cuesheet">format specification</A>.
 		 */
 		class FLACPP_API CueSheet : public Prototype {
 		public:
@@ -859,7 +859,7 @@ namespace FLAC {
 
 		/** PICTURE metadata block.
 		 *  See the \link flacpp_metadata_object overview \endlink for more,
-		 *  and the <A HREF="../format.html#metadata_block_picture">format specification</A>.
+		 *  and the <A HREF="https://xiph.org/flac/format.html#metadata_block_picture">format specification</A>.
 		 */
 		class FLACPP_API Picture : public Prototype {
 		public:

--- a/include/FLAC/all.h
+++ b/include/FLAC/all.h
@@ -52,7 +52,7 @@
  * level idea of the structure and how to find the information you
  * need.  As a prerequisite you should have at least a basic
  * knowledge of the FLAC format, documented
- * <A HREF="../format.html">here</A>.
+ * <A HREF="https://xiph.org/flac/format.html">here</A>.
  *
  * \section c_api FLAC C API
  *
@@ -64,7 +64,7 @@
  *
  * By writing a little code and linking against libFLAC, it is
  * relatively easy to add FLAC support to another program.  The
- * library is licensed under <A HREF="../license.html">Xiph's BSD license</A>.
+ * library is licensed under <A HREF="https://xiph.org/flac/license.html">Xiph's BSD license</A>.
  * Complete source code of libFLAC as well as the command-line
  * encoder and plugins is available and is a useful source of
  * examples.
@@ -97,7 +97,7 @@
  * example /usr/include/FLAC++/...).
  *
  * libFLAC++ is also licensed under
- * <A HREF="../license.html">Xiph's BSD license</A>.
+ * <A HREF="https://xiph.org/flac/license.html">Xiph's BSD license</A>.
  *
  * \section getting_started Getting Started
  *
@@ -113,7 +113,7 @@
  * functions through the links in top bar across this page.
  *
  * If you prefer a more hands-on approach, you can jump right to some
- * <A HREF="../documentation_example_code.html">example code</A>.
+ * <A HREF="https://xiph.org/flac/documentation_example_code.html">example code</A>.
  *
  * \section porting_guide Porting Guide
  *

--- a/include/FLAC/format.h
+++ b/include/FLAC/format.h
@@ -60,7 +60,7 @@ extern "C" {
  *  structures used by the rest of the interfaces.
  *
  *  First, you should be familiar with the
- *  <A HREF="../format.html">FLAC format</A>.  Many of the values here
+ *  <A HREF="https://xiph.org/flac/format.html">FLAC format</A>.  Many of the values here
  *  follow directly from the specification.  As a user of libFLAC, the
  *  interesting parts really are the structures that describe the frame
  *  header and metadata blocks.
@@ -225,7 +225,7 @@ typedef struct {
 	 */
 } FLAC__EntropyCodingMethod_PartitionedRiceContents;
 
-/** Header for a Rice partitioned residual.  (c.f. <A HREF="../format.html#partitioned_rice">format specification</A>)
+/** Header for a Rice partitioned residual.  (c.f. <A HREF="https://xiph.org/flac/format.html#partitioned_rice">format specification</A>)
  */
 typedef struct {
 
@@ -247,7 +247,7 @@ extern FLAC_API const uint32_t FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE_ESCA
 extern FLAC_API const uint32_t FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE2_ESCAPE_PARAMETER;
 /**< == (1<<FLAC__ENTROPY_CODING_METHOD_PARTITIONED_RICE2_PARAMETER_LEN)-1 */
 
-/** Header for the entropy coding method.  (c.f. <A HREF="../format.html#residual">format specification</A>)
+/** Header for the entropy coding method.  (c.f. <A HREF="https://xiph.org/flac/format.html#residual">format specification</A>)
  */
 typedef struct {
 	FLAC__EntropyCodingMethodType type;
@@ -276,7 +276,7 @@ typedef enum {
 extern FLAC_API const char * const FLAC__SubframeTypeString[];
 
 
-/** CONSTANT subframe.  (c.f. <A HREF="../format.html#subframe_constant">format specification</A>)
+/** CONSTANT subframe.  (c.f. <A HREF="https://xiph.org/flac/format.html#subframe_constant">format specification</A>)
  */
 typedef struct {
 	FLAC__int64 value; /**< The constant signal value. */
@@ -289,7 +289,7 @@ typedef enum {
 } FLAC__VerbatimSubframeDataType;
 
 
-/** VERBATIM subframe.  (c.f. <A HREF="../format.html#subframe_verbatim">format specification</A>)
+/** VERBATIM subframe.  (c.f. <A HREF="https://xiph.org/flac/format.html#subframe_verbatim">format specification</A>)
  */
 typedef struct {
 	union {
@@ -300,7 +300,7 @@ typedef struct {
 } FLAC__Subframe_Verbatim;
 
 
-/** FIXED subframe.  (c.f. <A HREF="../format.html#subframe_fixed">format specification</A>)
+/** FIXED subframe.  (c.f. <A HREF="https://xiph.org/flac/format.html#subframe_fixed">format specification</A>)
  */
 typedef struct {
 	FLAC__EntropyCodingMethod entropy_coding_method;
@@ -317,7 +317,7 @@ typedef struct {
 } FLAC__Subframe_Fixed;
 
 
-/** LPC subframe.  (c.f. <A HREF="../format.html#subframe_lpc">format specification</A>)
+/** LPC subframe.  (c.f. <A HREF="https://xiph.org/flac/format.html#subframe_lpc">format specification</A>)
  */
 typedef struct {
 	FLAC__EntropyCodingMethod entropy_coding_method;
@@ -346,7 +346,7 @@ extern FLAC_API const uint32_t FLAC__SUBFRAME_LPC_QLP_COEFF_PRECISION_LEN; /**< 
 extern FLAC_API const uint32_t FLAC__SUBFRAME_LPC_QLP_SHIFT_LEN; /**< == 5 (bits) */
 
 
-/** FLAC subframe structure.  (c.f. <A HREF="../format.html#subframe">format specification</A>)
+/** FLAC subframe structure.  (c.f. <A HREF="https://xiph.org/flac/format.html#subframe">format specification</A>)
  */
 typedef struct {
 	FLAC__SubframeType type;
@@ -413,7 +413,7 @@ typedef enum {
 extern FLAC_API const char * const FLAC__FrameNumberTypeString[];
 
 
-/** FLAC frame header structure.  (c.f. <A HREF="../format.html#frame_header">format specification</A>)
+/** FLAC frame header structure.  (c.f. <A HREF="https://xiph.org/flac/format.html#frame_header">format specification</A>)
  */
 typedef struct {
 	uint32_t blocksize;
@@ -462,7 +462,7 @@ extern FLAC_API const uint32_t FLAC__FRAME_HEADER_ZERO_PAD_LEN; /**< == 1 (bit) 
 extern FLAC_API const uint32_t FLAC__FRAME_HEADER_CRC_LEN; /**< == 8 (bits) */
 
 
-/** FLAC frame footer structure.  (c.f. <A HREF="../format.html#frame_footer">format specification</A>)
+/** FLAC frame footer structure.  (c.f. <A HREF="https://xiph.org/flac/format.html#frame_footer">format specification</A>)
  */
 typedef struct {
 	FLAC__uint16 crc;
@@ -475,7 +475,7 @@ typedef struct {
 extern FLAC_API const uint32_t FLAC__FRAME_FOOTER_CRC_LEN; /**< == 16 (bits) */
 
 
-/** FLAC frame structure.  (c.f. <A HREF="../format.html#frame">format specification</A>)
+/** FLAC frame structure.  (c.f. <A HREF="https://xiph.org/flac/format.html#frame">format specification</A>)
  */
 typedef struct {
 	FLAC__FrameHeader header;
@@ -496,25 +496,25 @@ typedef struct {
 typedef enum {
 
 	FLAC__METADATA_TYPE_STREAMINFO = 0,
-	/**< <A HREF="../format.html#metadata_block_streaminfo">STREAMINFO</A> block */
+	/**< <A HREF="https://xiph.org/flac/format.html#metadata_block_streaminfo">STREAMINFO</A> block */
 
 	FLAC__METADATA_TYPE_PADDING = 1,
-	/**< <A HREF="../format.html#metadata_block_padding">PADDING</A> block */
+	/**< <A HREF="https://xiph.org/flac/format.html#metadata_block_padding">PADDING</A> block */
 
 	FLAC__METADATA_TYPE_APPLICATION = 2,
-	/**< <A HREF="../format.html#metadata_block_application">APPLICATION</A> block */
+	/**< <A HREF="https://xiph.org/flac/format.html#metadata_block_application">APPLICATION</A> block */
 
 	FLAC__METADATA_TYPE_SEEKTABLE = 3,
-	/**< <A HREF="../format.html#metadata_block_seektable">SEEKTABLE</A> block */
+	/**< <A HREF="https://xiph.org/flac/format.html#metadata_block_seektable">SEEKTABLE</A> block */
 
 	FLAC__METADATA_TYPE_VORBIS_COMMENT = 4,
-	/**< <A HREF="../format.html#metadata_block_vorbis_comment">VORBISCOMMENT</A> block (a.k.a. FLAC tags) */
+	/**< <A HREF="https://xiph.org/flac/format.html#metadata_block_vorbis_comment">VORBISCOMMENT</A> block (a.k.a. FLAC tags) */
 
 	FLAC__METADATA_TYPE_CUESHEET = 5,
-	/**< <A HREF="../format.html#metadata_block_cuesheet">CUESHEET</A> block */
+	/**< <A HREF="https://xiph.org/flac/format.html#metadata_block_cuesheet">CUESHEET</A> block */
 
 	FLAC__METADATA_TYPE_PICTURE = 6,
-	/**< <A HREF="../format.html#metadata_block_picture">PICTURE</A> block */
+	/**< <A HREF="https://xiph.org/flac/format.html#metadata_block_picture">PICTURE</A> block */
 
 	FLAC__METADATA_TYPE_UNDEFINED = 7,
 	/**< marker to denote beginning of undefined type range; this number will increase as new metadata types are added */
@@ -531,7 +531,7 @@ typedef enum {
 extern FLAC_API const char * const FLAC__MetadataTypeString[];
 
 
-/** FLAC STREAMINFO structure.  (c.f. <A HREF="../format.html#metadata_block_streaminfo">format specification</A>)
+/** FLAC STREAMINFO structure.  (c.f. <A HREF="https://xiph.org/flac/format.html#metadata_block_streaminfo">format specification</A>)
  */
 typedef struct {
 	uint32_t min_blocksize, max_blocksize;
@@ -556,7 +556,7 @@ extern FLAC_API const uint32_t FLAC__STREAM_METADATA_STREAMINFO_MD5SUM_LEN; /**<
 /** The total stream length of the STREAMINFO block in bytes. */
 #define FLAC__STREAM_METADATA_STREAMINFO_LENGTH (34u)
 
-/** FLAC PADDING structure.  (c.f. <A HREF="../format.html#metadata_block_padding">format specification</A>)
+/** FLAC PADDING structure.  (c.f. <A HREF="https://xiph.org/flac/format.html#metadata_block_padding">format specification</A>)
  */
 typedef struct {
 	int dummy;
@@ -567,7 +567,7 @@ typedef struct {
 } FLAC__StreamMetadata_Padding;
 
 
-/** FLAC APPLICATION structure.  (c.f. <A HREF="../format.html#metadata_block_application">format specification</A>)
+/** FLAC APPLICATION structure.  (c.f. <A HREF="https://xiph.org/flac/format.html#metadata_block_application">format specification</A>)
  */
 typedef struct {
 	FLAC__byte id[4];
@@ -576,7 +576,7 @@ typedef struct {
 
 extern FLAC_API const uint32_t FLAC__STREAM_METADATA_APPLICATION_ID_LEN; /**< == 32 (bits) */
 
-/** SeekPoint structure used in SEEKTABLE blocks.  (c.f. <A HREF="../format.html#seekpoint">format specification</A>)
+/** SeekPoint structure used in SEEKTABLE blocks.  (c.f. <A HREF="https://xiph.org/flac/format.html#seekpoint">format specification</A>)
  */
 typedef struct {
 	FLAC__uint64 sample_number;
@@ -604,7 +604,7 @@ extern FLAC_API const uint32_t FLAC__STREAM_METADATA_SEEKPOINT_FRAME_SAMPLES_LEN
 extern FLAC_API const FLAC__uint64 FLAC__STREAM_METADATA_SEEKPOINT_PLACEHOLDER;
 
 
-/** FLAC SEEKTABLE structure.  (c.f. <A HREF="../format.html#metadata_block_seektable">format specification</A>)
+/** FLAC SEEKTABLE structure.  (c.f. <A HREF="https://xiph.org/flac/format.html#metadata_block_seektable">format specification</A>)
  *
  * \note From the format specification:
  * - The seek points must be sorted by ascending sample number.
@@ -622,7 +622,7 @@ typedef struct {
 } FLAC__StreamMetadata_SeekTable;
 
 
-/** Vorbis comment entry structure used in VORBIS_COMMENT blocks.  (c.f. <A HREF="../format.html#metadata_block_vorbis_comment">format specification</A>)
+/** Vorbis comment entry structure used in VORBIS_COMMENT blocks.  (c.f. <A HREF="https://xiph.org/flac/format.html#metadata_block_vorbis_comment">format specification</A>)
  *
  *  For convenience, the APIs maintain a trailing NUL character at the end of
  *  \a entry which is not counted toward \a length, i.e.
@@ -636,7 +636,7 @@ typedef struct {
 extern FLAC_API const uint32_t FLAC__STREAM_METADATA_VORBIS_COMMENT_ENTRY_LENGTH_LEN; /**< == 32 (bits) */
 
 
-/** FLAC VORBIS_COMMENT structure.  (c.f. <A HREF="../format.html#metadata_block_vorbis_comment">format specification</A>)
+/** FLAC VORBIS_COMMENT structure.  (c.f. <A HREF="https://xiph.org/flac/format.html#metadata_block_vorbis_comment">format specification</A>)
  */
 typedef struct {
 	FLAC__StreamMetadata_VorbisComment_Entry vendor_string;
@@ -648,7 +648,7 @@ extern FLAC_API const uint32_t FLAC__STREAM_METADATA_VORBIS_COMMENT_NUM_COMMENTS
 
 
 /** FLAC CUESHEET track index structure.  (See the
- * <A HREF="../format.html#cuesheet_track_index">format specification</A> for
+ * <A HREF="https://xiph.org/flac/format.html#cuesheet_track_index">format specification</A> for
  * the full description of each field.)
  */
 typedef struct {
@@ -667,7 +667,7 @@ extern FLAC_API const uint32_t FLAC__STREAM_METADATA_CUESHEET_INDEX_RESERVED_LEN
 
 
 /** FLAC CUESHEET track structure.  (See the
- * <A HREF="../format.html#cuesheet_track">format specification</A> for
+ * <A HREF="https://xiph.org/flac/format.html#cuesheet_track">format specification</A> for
  * the full description of each field.)
  */
 typedef struct {
@@ -704,7 +704,7 @@ extern FLAC_API const uint32_t FLAC__STREAM_METADATA_CUESHEET_TRACK_NUM_INDICES_
 
 
 /** FLAC CUESHEET structure.  (See the
- * <A HREF="../format.html#metadata_block_cuesheet">format specification</A>
+ * <A HREF="https://xiph.org/flac/format.html#metadata_block_cuesheet">format specification</A>
  * for the full description of each field.)
  */
 typedef struct {
@@ -770,7 +770,7 @@ typedef enum {
 extern FLAC_API const char * const FLAC__StreamMetadata_Picture_TypeString[];
 
 /** FLAC PICTURE structure.  (See the
- * <A HREF="../format.html#metadata_block_picture">format specification</A>
+ * <A HREF="https://xiph.org/flac/format.html#metadata_block_picture">format specification</A>
  * for the full description of each field.)
  */
 typedef struct {
@@ -836,7 +836,7 @@ typedef struct {
 } FLAC__StreamMetadata_Unknown;
 
 
-/** FLAC metadata block structure.  (c.f. <A HREF="../format.html#metadata_block">format specification</A>)
+/** FLAC metadata block structure.  (c.f. <A HREF="https://xiph.org/flac/format.html#metadata_block">format specification</A>)
  */
 typedef struct FLAC__StreamMetadata {
 	FLAC__MetadataType type;

--- a/include/FLAC/metadata.h
+++ b/include/FLAC/metadata.h
@@ -510,7 +510,7 @@ FLAC_API FLAC__MetadataType FLAC__metadata_simple_iterator_get_block_type(const 
  * \retval uint32_t
  *    The length of the metadata block at the current iterator position.
  *    The is same length as that in the
- *    <a href="http://xiph.org/flac/format.html#metadata_block_header">metadata block header</a>,
+ *    <a href="http://xiph.org/flhttps://xiph.org/flac/format.html#metadata_block_header">metadata block header</a>,
  *    i.e. the length of the metadata body that follows the header.
  */
 FLAC_API uint32_t FLAC__metadata_simple_iterator_get_block_length(const FLAC__Metadata_SimpleIterator *iterator);

--- a/include/FLAC/stream_decoder.h
+++ b/include/FLAC/stream_decoder.h
@@ -681,7 +681,7 @@ typedef FLAC__bool (*FLAC__StreamDecoderEofCallback)(const FLAC__StreamDecoder *
  *                  samples of length \a frame->header.blocksize.
  *                  Channels will be ordered according to the FLAC
  *                  specification; see the documentation for the
- *                  <A HREF="../format.html#frame_header">frame header</A>.
+ *                  <A HREF="https://xiph.org/flac/format.html#frame_header">frame header</A>.
  * \param  client_data  The callee's client data set through
  *                      FLAC__stream_decoder_init_*().
  * \retval FLAC__StreamDecoderWriteStatus

--- a/include/FLAC/stream_encoder.h
+++ b/include/FLAC/stream_encoder.h
@@ -1295,7 +1295,7 @@ FLAC_API void FLAC__stream_encoder_get_verify_decoder_error_stats(const FLAC__St
  */
 FLAC_API FLAC__bool FLAC__stream_encoder_get_verify(const FLAC__StreamEncoder *encoder);
 
-/** Get the <A HREF="../format.html#subset>Subset</A> flag.
+/** Get the <A HREF="../format.html#subset">Subset</A> flag.
  *
  * \param  encoder  An encoder instance to query.
  * \assert

--- a/include/FLAC/stream_encoder.h
+++ b/include/FLAC/stream_encoder.h
@@ -129,8 +129,8 @@ extern "C" {
  * Unlike the decoders, the stream encoder has many options that can
  * affect the speed and compression ratio.  When setting these parameters
  * you should have some basic knowledge of the format (see the
- * <A HREF="../documentation_format_overview.html">user-level documentation</A>
- * or the <A HREF="../format.html">formal description</A>).  The
+ * <A HREF="https://xiph.org/flac/documentation_format_overview.html">user-level documentation</A>
+ * or the <A HREF="https://xiph.org/flac/format.html">formal description</A>).  The
  * FLAC__stream_encoder_set_*() functions themselves do not validate the
  * values as many are interdependent.  The FLAC__stream_encoder_init_*()
  * functions will do this, so make sure to pay attention to the state
@@ -330,7 +330,7 @@ typedef enum {
 	/**< The specified block size is less than the maximum LPC order. */
 
 	FLAC__STREAM_ENCODER_INIT_STATUS_NOT_STREAMABLE,
-	/**< The encoder is bound to the <A HREF="../format.html#subset">Subset</A> but other settings violate it. */
+	/**< The encoder is bound to the <A HREF="https://xiph.org/flac/format.html#subset">Subset</A> but other settings violate it. */
 
 	FLAC__STREAM_ENCODER_INIT_STATUS_INVALID_METADATA,
 	/**< The metadata input to the encoder is invalid, in one of the following ways:
@@ -742,7 +742,7 @@ FLAC_API FLAC__bool FLAC__stream_encoder_set_ogg_serial_number(FLAC__StreamEncod
  */
 FLAC_API FLAC__bool FLAC__stream_encoder_set_verify(FLAC__StreamEncoder *encoder, FLAC__bool value);
 
-/** Set the <A HREF="../format.html#subset">Subset</A> flag.  If \c true,
+/** Set the <A HREF="https://xiph.org/flac/format.html#subset">Subset</A> flag.  If \c true,
  *  the encoder will comply with the Subset and will check the
  *  settings during FLAC__stream_encoder_init_*() to see if all settings
  *  comply.  If \c false, the settings may take advantage of the full
@@ -1295,7 +1295,7 @@ FLAC_API void FLAC__stream_encoder_get_verify_decoder_error_stats(const FLAC__St
  */
 FLAC_API FLAC__bool FLAC__stream_encoder_get_verify(const FLAC__StreamEncoder *encoder);
 
-/** Get the <A HREF="../format.html#subset">Subset</A> flag.
+/** Get the <A HREF="https://xiph.org/flac/format.html#subset">Subset</A> flag.
  *
  * \param  encoder  An encoder instance to query.
  * \assert
@@ -1781,7 +1781,7 @@ FLAC_API FLAC__bool FLAC__stream_encoder_finish(FLAC__StreamEncoder *encoder);
  *
  *  For applications where channel order is important, channels must
  *  follow the order as described in the
- *  <A HREF="../format.html#frame_header">frame header</A>.
+ *  <A HREF="https://xiph.org/flac/format.html#frame_header">frame header</A>.
  *
  * \param  encoder  An initialized encoder instance in the OK state.
  * \param  buffer   An array of pointers to each channel's signal.
@@ -1810,7 +1810,7 @@ FLAC_API FLAC__bool FLAC__stream_encoder_process(FLAC__StreamEncoder *encoder, c
  *
  *  For applications where channel order is important, channels must
  *  follow the order as described in the
- *  <A HREF="../format.html#frame_header">frame header</A>.
+ *  <A HREF="https://xiph.org/flac/format.html#frame_header">frame header</A>.
  *
  * \param  encoder  An initialized encoder instance in the OK state.
  * \param  buffer   An array of channel-interleaved data (see above).


### PR DESCRIPTION
fixes doxygen error:
include/FLAC/stream_encoder.h:1298: Error: Unexpected character `"'