### PR TITLE
build: Fix 32-bit Visual Studio builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,8 +161,8 @@ if(HAVE_WERROR_FLAG)
 endif()
 
 add_compile_options(
-    $<$<BOOL:${MSVC}>:/wd4267>
-    $<$<BOOL:${MSVC}>:/wd4996>
+    $<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:${MSVC}>>:/wd4267>
+    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<BOOL:${MSVC}>>:/wd4996>
     $<$<BOOL:${ENABLE_WERROR}>:-Werror>
     $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<BOOL:${HAVE_WEFFCXX_FLAG}>>:-Weffc++>
     $<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:${HAVE_DECL_AFTER_STMT_FLAG}>>:-Wdeclaration-after-statement>)


### PR DESCRIPTION
Hi,

This attempts to fix the CMake build files so that 32-bit Visual Studio builds can be done successfully when buliding the NASM bits, namely by restricting the application of `/wd4996` and `/wd4267` when building C and C++ files only.

With blessings, thank you.