### PR TITLE
Clarify replaygain requirements

### DIFF
--- a/man/flac.md
+++ b/man/flac.md
@@ -360,11 +360,13 @@ the HTML documentation.
 	and an album gain/peak will be computed for all files. All input
 	files must have the same resolution, sample rate, and number of
 	channels. Only mono and stereo files are allowed, and the sample
-	rate must be one of 8, 11.025, 12, 16, 22.05, 24, 32, 44.1, or 48
-	kHz. Also note that this option may leave a few extra bytes in a
-	PADDING block as the exact size of the tags is not known until all
-	files are processed. Note that this option cannot be used when
-	encoding to standard output (stdout).
+	rate must be 8, 11.025, 12, 16, 18.9, 22.05, 24, 28, 32, 36, 37.8,
+	44.1, 48, 56, 64, 72, 75.6, 88.2, 96, 112, 128, 144, 151.2, 176.4,
+	192, 224, 256, 288, 302.4, 352.8, 384, 448, 512, 576, or 604.8 kHz.
+	Also note that this option may leave a few extra bytes in a PADDING
+	block as the exact size of the tags is not known until all files
+	are processed. Note that this option cannot be used when encoding
+	to standard output (stdout).
 
 **\--cuesheet=***filename*  
 :	Import the given cuesheet file and store it in a CUESHEET metadata

--- a/man/metaflac.md
+++ b/man/metaflac.md
@@ -179,9 +179,10 @@ modification time is set to the current time):
 	requires two passes, it is always executed last, after all other
 	operations have been completed and written to disk. All FLAC files
 	specified must have the same resolution, sample rate, and number of
-	channels. The sample rate must be one of 8, 11.025, 12, 16, 18.9,
-	22.05, 24, 28, 32, 37.8, 44.1, 48, 56, 64, 88.2, 96, 112, 128, 144,
-	176.4, or 192kHz.
+	channels. Only mono and stereo files are allowed, and the sample
+	rate must be 8, 11.025, 12, 16, 18.9, 22.05, 24, 28, 32, 36, 37.8,
+	44.1, 48, 56, 64, 72, 75.6, 88.2, 96, 112, 128, 144, 151.2, 176.4,
+	192, 224, 256, 288, 302.4, 352.8, 384, 448, 512, 576, or 604.8 kHz.
 
 **\--scan-replay-gain**  
 :	Like \--add-replay-gain, but only analyzes the files rather than

--- a/src/flac/main.c
+++ b/src/flac/main.c
@@ -1494,10 +1494,14 @@ void show_explain(void)
 	printf("                               for each file, and an album gain/peak will be\n");
 	printf("                               computed for all files.  All input files must\n");
 	printf("                               have the same resolution, sample rate, and\n");
-	printf("                               number of channels.  The sample rate must be\n");
-	printf("                               one of 8, 11.025, 12, 16, 22.05, 24, 32, 44.1,\n");
-	printf("                               or 48 kHz.  NOTE: this option may also leave a\n");
-	printf("                               few extra bytes in the PADDING block.\n");
+	printf("                               number of channels.  Only mono and stereo files\n");
+	printf("                               are allowed, and the sample rate must be 8,\n");
+	printf("                               11.025, 12, 16, 18.9, 22.05, 24, 28, 32, 36,\n");
+	printf("                               37.8, 44.1, 48, 56, 64, 72, 75.6, 88.2, 96, 112,\n");
+	printf("                               128, 144, 151.2, 176.4, 192, 224, 256, 288,\n");
+	printf("                               302.4, 352.8, 384, 448, 512, 576, or 604.8 kHz.\n");
+	printf("                               NOTE: this option may also leave a few extra\n");
+	printf("                               bytes in the PADDING block.\n");
 	printf("      --cuesheet=FILENAME      Import the given cuesheet file and store it in\n");
 	printf("                               a CUESHEET metadata block.  This option may only\n");
 	printf("                               be used when encoding a single file.  A\n");

--- a/src/metaflac/usage.c
+++ b/src/metaflac/usage.c
@@ -216,8 +216,11 @@ int long_usage(const char *message, ...)
 	fprintf(out, "                      executed last, after all other operations have been\n");
 	fprintf(out, "                      completed and written to disk.  All FLAC files specified\n");
 	fprintf(out, "                      must have the same resolution, sample rate, and number\n");
-	fprintf(out, "                      of channels.  The sample rate must be one of 8, 11.025,\n");
-	fprintf(out, "                      12, 16, 22.05, 24, 32, 44.1, or 48 kHz.\n");
+	fprintf(out, "                      of channels.  Only mono and stereo files are allowed,\n");
+	fprintf(out, "                      and the sample rate must be 8, 11.025, 12, 16, 18.9,\n");
+	fprintf(out, "                      22.05, 24, 28, 32, 36, 37.8, 44.1, 48, 56, 64, 72, 75.6,\n");
+	fprintf(out, "                      88.2, 96, 112, 128, 144, 151.2, 176.4, 192, 224, 256,\n");
+	fprintf(out, "                      288, 302.4, 352.8, 384, 448, 512, 576, or 604.8 kHz.\n");
 	fprintf(out, "--scan-replay-gain    Like --add-replay-gain, but only analyzes the files\n");
 	fprintf(out, "                      rather than writing them to tags.\n");
 	fprintf(out, "--remove-replay-gain  Removes the ReplayGain tags.\n");


### PR DESCRIPTION
This PR closes #495. All ReplayGain help text now states channel number requirements and an exhaustive list of supported sample rates.

I also removed trailing whitespace from docs and code, in separate commits. Trailing whitespace still remains in .cue and .meta test files.