### PR TITLE
Fix encoder not deleting output after error on Windows

### DIFF
--- a/src/flac/encode.c
+++ b/src/flac/encode.c
@@ -1699,13 +1699,18 @@ int EncoderSession_finish_error(EncoderSession *e)
 	if(e->total_samples_to_encode > 0)
 		flac__utils_printf(stderr, 2, "\n");
 
-	if(FLAC__stream_encoder_get_state(e->encoder) == FLAC__STREAM_ENCODER_VERIFY_MISMATCH_IN_AUDIO_DATA)
+	if(FLAC__stream_encoder_get_state(e->encoder) == FLAC__STREAM_ENCODER_VERIFY_MISMATCH_IN_AUDIO_DATA) {
 		print_verify_error(e);
-	else if(e->outputfile_opened)
+		EncoderSession_destroy(e);
+	}
+	else if(e->outputfile_opened) {
 		/* only want to delete the file if we opened it; otherwise it could be an existing file and our overwrite failed */
+		/* Windows cannot unlink an open file, so close it first */
+		EncoderSession_destroy(e);
 		flac_unlink(e->outfilename);
-
-	EncoderSession_destroy(e);
+	}
+	else
+		EncoderSession_destroy(e);
 
 	return 1;
 }


### PR DESCRIPTION
When `flac` was invoked as an encoder and stumbled on an error, it would first try to unlink the file and only then finish encoding. This works fine on *nix but fails on Windows. With this commit, the encoder session is first destroyed and only then the file is 'unlinked'.