### PR TITLE
Let libFLAC not write a seektable in Ogg, even when asked for

### DIFF
--- a/src/test_libFLAC++/decoders.cpp
+++ b/src/test_libFLAC++/decoders.cpp
@@ -745,11 +745,10 @@ static bool test_stream_decoder(Layer layer, bool is_ogg)
 	printf("OK\n");
 
 	num_expected_ = 0;
-	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping */
+	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping. Also removes the seektable */
 		expected_metadata_sequence_[num_expected_++] = &streaminfo_;
 		expected_metadata_sequence_[num_expected_++] = &vorbiscomment_;
 		expected_metadata_sequence_[num_expected_++] = &padding_;
-		expected_metadata_sequence_[num_expected_++] = &seektable_;
 		expected_metadata_sequence_[num_expected_++] = &application1_;
 		expected_metadata_sequence_[num_expected_++] = &application2_;
 		expected_metadata_sequence_[num_expected_++] = &cuesheet_;
@@ -808,7 +807,8 @@ static bool test_stream_decoder(Layer layer, bool is_ogg)
 	num_expected_ = 0;
 	expected_metadata_sequence_[num_expected_++] = &streaminfo_;
 	expected_metadata_sequence_[num_expected_++] = &padding_;
-	expected_metadata_sequence_[num_expected_++] = &seektable_;
+	if(!is_ogg) /* encoder removes seektable for ogg */
+		expected_metadata_sequence_[num_expected_++] = &seektable_;
 	expected_metadata_sequence_[num_expected_++] = &application1_;
 	expected_metadata_sequence_[num_expected_++] = &application2_;
 	expected_metadata_sequence_[num_expected_++] = &cuesheet_;
@@ -837,11 +837,10 @@ static bool test_stream_decoder(Layer layer, bool is_ogg)
 	printf("OK\n");
 
 	num_expected_ = 0;
-	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping */
+	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping. Also removes the seektable */
 		expected_metadata_sequence_[num_expected_++] = &streaminfo_;
 		expected_metadata_sequence_[num_expected_++] = &vorbiscomment_;
 		expected_metadata_sequence_[num_expected_++] = &padding_;
-		expected_metadata_sequence_[num_expected_++] = &seektable_;
 		expected_metadata_sequence_[num_expected_++] = &cuesheet_;
 		expected_metadata_sequence_[num_expected_++] = &picture_;
 		expected_metadata_sequence_[num_expected_++] = &unknown_;
@@ -878,11 +877,10 @@ static bool test_stream_decoder(Layer layer, bool is_ogg)
 	printf("OK\n");
 
 	num_expected_ = 0;
-	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping */
+	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping. Also removes the seektable */
 		expected_metadata_sequence_[num_expected_++] = &streaminfo_;
 		expected_metadata_sequence_[num_expected_++] = &vorbiscomment_;
 		expected_metadata_sequence_[num_expected_++] = &padding_;
-		expected_metadata_sequence_[num_expected_++] = &seektable_;
 		expected_metadata_sequence_[num_expected_++] = &application2_;
 		expected_metadata_sequence_[num_expected_++] = &cuesheet_;
 		expected_metadata_sequence_[num_expected_++] = &picture_;
@@ -928,11 +926,10 @@ static bool test_stream_decoder(Layer layer, bool is_ogg)
 	printf("OK\n");
 
 	num_expected_ = 0;
-	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping */
+	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping. Also removes seektable */
 		expected_metadata_sequence_[num_expected_++] = &streaminfo_;
 		expected_metadata_sequence_[num_expected_++] = &vorbiscomment_;
 		expected_metadata_sequence_[num_expected_++] = &padding_;
-		expected_metadata_sequence_[num_expected_++] = &seektable_;
 		expected_metadata_sequence_[num_expected_++] = &cuesheet_;
 		expected_metadata_sequence_[num_expected_++] = &picture_;
 		expected_metadata_sequence_[num_expected_++] = &unknown_;
@@ -1081,11 +1078,10 @@ static bool test_stream_decoder(Layer layer, bool is_ogg)
 	printf("OK\n");
 
 	num_expected_ = 0;
-	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping */
+	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping. Also removes the seektable */
 		expected_metadata_sequence_[num_expected_++] = &streaminfo_;
 		expected_metadata_sequence_[num_expected_++] = &vorbiscomment_;
 		expected_metadata_sequence_[num_expected_++] = &padding_;
-		expected_metadata_sequence_[num_expected_++] = &seektable_;
 		expected_metadata_sequence_[num_expected_++] = &application1_;
 		expected_metadata_sequence_[num_expected_++] = &cuesheet_;
 		expected_metadata_sequence_[num_expected_++] = &picture_;

--- a/src/test_libFLAC/decoders.c
+++ b/src/test_libFLAC/decoders.c
@@ -670,11 +670,10 @@ static FLAC__bool test_stream_decoder(Layer layer, FLAC__bool is_ogg)
 	printf("OK\n");
 
 	num_expected_ = 0;
-	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping */
+	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping. Also removes the seektable */
 		expected_metadata_sequence_[num_expected_++] = &streaminfo_;
 		expected_metadata_sequence_[num_expected_++] = &vorbiscomment_;
 		expected_metadata_sequence_[num_expected_++] = &padding_;
-		expected_metadata_sequence_[num_expected_++] = &seektable_;
 		expected_metadata_sequence_[num_expected_++] = &application1_;
 		expected_metadata_sequence_[num_expected_++] = &application2_;
 		expected_metadata_sequence_[num_expected_++] = &cuesheet_;
@@ -727,7 +726,8 @@ static FLAC__bool test_stream_decoder(Layer layer, FLAC__bool is_ogg)
 	num_expected_ = 0;
 	expected_metadata_sequence_[num_expected_++] = &streaminfo_;
 	expected_metadata_sequence_[num_expected_++] = &padding_;
-	expected_metadata_sequence_[num_expected_++] = &seektable_;
+	if(!is_ogg) /* encoder removes seektable for ogg */
+		expected_metadata_sequence_[num_expected_++] = &seektable_;
 	expected_metadata_sequence_[num_expected_++] = &application1_;
 	expected_metadata_sequence_[num_expected_++] = &application2_;
 	expected_metadata_sequence_[num_expected_++] = &cuesheet_;
@@ -752,11 +752,10 @@ static FLAC__bool test_stream_decoder(Layer layer, FLAC__bool is_ogg)
 	printf("OK\n");
 
 	num_expected_ = 0;
-	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping */
+	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping. Also removes the seektable */
 		expected_metadata_sequence_[num_expected_++] = &streaminfo_;
 		expected_metadata_sequence_[num_expected_++] = &vorbiscomment_;
 		expected_metadata_sequence_[num_expected_++] = &padding_;
-		expected_metadata_sequence_[num_expected_++] = &seektable_;
 		expected_metadata_sequence_[num_expected_++] = &cuesheet_;
 		expected_metadata_sequence_[num_expected_++] = &picture_;
 		expected_metadata_sequence_[num_expected_++] = &unknown_;
@@ -789,11 +788,10 @@ static FLAC__bool test_stream_decoder(Layer layer, FLAC__bool is_ogg)
 	printf("OK\n");
 
 	num_expected_ = 0;
-	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping */
+	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping. Also removes the seektable */
 		expected_metadata_sequence_[num_expected_++] = &streaminfo_;
 		expected_metadata_sequence_[num_expected_++] = &vorbiscomment_;
 		expected_metadata_sequence_[num_expected_++] = &padding_;
-		expected_metadata_sequence_[num_expected_++] = &seektable_;
 		expected_metadata_sequence_[num_expected_++] = &application2_;
 		expected_metadata_sequence_[num_expected_++] = &cuesheet_;
 		expected_metadata_sequence_[num_expected_++] = &picture_;
@@ -833,11 +831,10 @@ static FLAC__bool test_stream_decoder(Layer layer, FLAC__bool is_ogg)
 	printf("OK\n");
 
 	num_expected_ = 0;
-	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping */
+	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping. Also removes the seektable */
 		expected_metadata_sequence_[num_expected_++] = &streaminfo_;
 		expected_metadata_sequence_[num_expected_++] = &vorbiscomment_;
 		expected_metadata_sequence_[num_expected_++] = &padding_;
-		expected_metadata_sequence_[num_expected_++] = &seektable_;
 		expected_metadata_sequence_[num_expected_++] = &cuesheet_;
 		expected_metadata_sequence_[num_expected_++] = &picture_;
 		expected_metadata_sequence_[num_expected_++] = &unknown_;
@@ -962,11 +959,10 @@ static FLAC__bool test_stream_decoder(Layer layer, FLAC__bool is_ogg)
 	printf("OK\n");
 
 	num_expected_ = 0;
-	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping */
+	if(is_ogg) { /* encoder moves vorbis comment after streaminfo according to ogg mapping. Also removes the seektable */
 		expected_metadata_sequence_[num_expected_++] = &streaminfo_;
 		expected_metadata_sequence_[num_expected_++] = &vorbiscomment_;
 		expected_metadata_sequence_[num_expected_++] = &padding_;
-		expected_metadata_sequence_[num_expected_++] = &seektable_;
 		expected_metadata_sequence_[num_expected_++] = &application1_;
 		expected_metadata_sequence_[num_expected_++] = &cuesheet_;
 		expected_metadata_sequence_[num_expected_++] = &picture_;


### PR DESCRIPTION
The seektable libFLAC currently writes does not conform to https://datatracker.ietf.org/doc/draft-ietf-cellar-flac/07/ and it probably isn't used anywhere, so the code writing it is removed