### PR TITLE
Fix warning in test suite, introduced in a87e6b

### DIFF
--- a/src/test_streams/main.c
+++ b/src/test_streams/main.c
@@ -992,7 +992,7 @@ static FLAC__bool write_simple_wavex_header (FILE * f, unsigned samplerate, unsi
 
 	if (fwrite("RIFF", 1, 4, f) != 4)
 		return false;
-	if (!write_little_endian_uint32(f, 40 + 4 + 4 + datalen))
+	if (!write_little_endian_uint32(f, 60 + datalen))
 		return false;
 
 	if (fwrite("WAVEfmt ", 8, 1, f) != 1)


### PR DESCRIPTION
Recently a warning was added to libFLAC when RIFF header doesn't match the filesize. It turns out that warning is triggered by a very old (harmless) bug in the test suite file generator