### PR TITLE
Add fuzzer for flac command-line tool, attempt 2

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -25,7 +25,7 @@ jobs:
      with:
        oss-fuzz-project-name: 'flac'
        language: c++
-       fuzz-seconds: 3600
+       fuzz-seconds: 7200
        sanitizer: ${{ matrix.sanitizer }}
    - name: Upload Crash
      uses: actions/upload-artifact@v1

--- a/oss-fuzz/Makefile.am
+++ b/oss-fuzz/Makefile.am
@@ -17,6 +17,7 @@
 
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/oss-fuzz
 
+AM_CFLAGS = ${LIB_FUZZING_ENGINE}
 AM_CXXFLAGS = -std=c++11 $(LIB_FUZZING_ENGINE)
 LDADD = $(flac_libs)
 
@@ -34,7 +35,7 @@ EXTRA_DIST = \
 noinst_PROGRAMS =
 
 if USE_OSSFUZZERS
-noinst_PROGRAMS += fuzzer_encoder fuzzer_encoder_v2 fuzzer_decoder fuzzer_seek fuzzer_metadata fuzzer_reencoder
+noinst_PROGRAMS += fuzzer_encoder fuzzer_encoder_v2 fuzzer_decoder fuzzer_seek fuzzer_metadata fuzzer_reencoder fuzzer_tool_flac
 endif
 
 fuzzer_encoder_SOURCES = encoder.cc
@@ -43,6 +44,16 @@ fuzzer_decoder_SOURCES = decoder.cc
 fuzzer_seek_SOURCES = seek.cc
 fuzzer_metadata_SOURCES = metadata.cc
 fuzzer_reencoder_SOURCES = reencoder.cc
+fuzzer_tool_flac_SOURCES = ${flac_SOURCES} tool_flac.c
+fuzzer_tool_flac_LDADD =  \
+        $(top_builddir)/src/share/utf8/libutf8.la \
+        $(top_builddir)/src/share/grabbag/libgrabbag.la \
+        $(top_builddir)/src/share/getopt/libgetopt.la \
+        $(top_builddir)/src/share/replaygain_analysis/libreplaygain_analysis.la \
+        $(top_builddir)/src/share/replaygain_synthesis/libreplaygain_synthesis.la \
+        $(top_builddir)/src/libFLAC/libFLAC.la \
+        @LTLIBICONV@ \
+        -lm
 
 flac_libs = \
 	$(top_builddir)/src/libFLAC/libFLAC-static.la \
@@ -50,3 +61,18 @@ flac_libs = \
 	@OGG_LIBS@ \
 	-lm
 
+flac_SOURCES = \
+        ${top_builddir}/src/flac/analyze.c \
+        ${top_builddir}/src/flac/decode.c \
+        ${top_builddir}/src/flac/encode.c \
+        ${top_builddir}/src/flac/foreign_metadata.c \
+        ${top_builddir}/src/flac/local_string_utils.c \
+        ${top_builddir}/src/flac/utils.c \
+        ${top_builddir}/src/flac/vorbiscomment.c \
+        ${top_builddir}/src/flac/analyze.h \
+        ${top_builddir}/src/flac/decode.h \
+        ${top_builddir}/src/flac/encode.h \
+        ${top_builddir}/src/flac/foreign_metadata.h \
+        ${top_builddir}/src/flac/local_string_utils.h \
+        ${top_builddir}/src/flac/utils.h \
+        ${top_builddir}/src/flac/vorbiscomment.h

--- a/oss-fuzz/tool_flac.c
+++ b/oss-fuzz/tool_flac.c
@@ -1,0 +1,87 @@
+/* fuzzer_tool_flac
+ * Copyright (C) 2023  Xiph.Org Foundation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the Xiph.org Foundation nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include <string.h> /* for memcpy */
+#define FUZZ_TOOL_FLAC
+#define fprintf(...)
+#define printf(...)
+#include "../src/flac/main.c"
+#include "common.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	size_t size_left = size;
+	size_t arglen;
+	char * argv[64];
+	char exename[] = "flac";
+	char filename[] = "/tmp/fuzzXXXXXX";
+	int numarg = 0, maxarg;
+	int file_to_fuzz;
+
+	flac__utils_verbosity_ = 0;
+	share__opterr = 0;
+	share__optind = 0;
+
+
+	if(size < 2)
+		return 0;
+
+	maxarg = data[0] & 16;
+	size_left--;
+
+	argv[0] = exename;
+	numarg++;
+
+	/* Check whether input is zero delimited */
+	while((arglen = strnlen((char *)data+(size-size_left),size_left)) < size_left && numarg < maxarg) {
+		argv[numarg++] = (char *)data+(size-size_left);
+		size_left -= arglen + 1;
+	}
+
+	file_to_fuzz = mkstemp(filename);
+
+	if (file_to_fuzz < 0)
+		abort();
+	write(file_to_fuzz,data+(size-size_left),size_left);
+	close(file_to_fuzz);
+
+	argv[numarg++] = filename;
+
+	main_to_fuzz(numarg,argv);
+
+	unlink(filename);
+
+	return 0;
+}
+

--- a/src/flac/main.c
+++ b/src/flac/main.c
@@ -2360,7 +2360,7 @@ int decode_file(const char *infilename)
 	decode_options.channel_map_none = option_values.channel_map_none;
 	decode_options.format = output_format;
 
-#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 	/* Can't fuzz from stdin */
 	if(0 == strcmp(infilename, "-") || 0 == strcmp(outfilename, "-"))
 		return 1;


### PR DESCRIPTION
Try #551 again

> As the flac tool has quite some code of its own, add a fuzzer for that. Of course, this also indirectly fuzzes libFLAC, though coverage is limited compared to the existing fuzzers