### PR TITLE
Fix potential dead store

### DIFF
--- a/src/libFLAC/metadata_iterators.c
+++ b/src/libFLAC/metadata_iterators.c
@@ -2337,7 +2337,7 @@ FLAC__Metadata_SimpleIteratorStatus read_metadata_block_data_vorbis_comment_entr
 	if(max_length < entry->length) {
 		entry->length = 0;
 		return FLAC__METADATA_SIMPLE_ITERATOR_STATUS_BAD_METADATA;
-	} else max_length -= entry->length;
+	}
 
 	if(0 != entry->entry)
 		free(entry->entry);


### PR DESCRIPTION
**Description**
Fix the dead store warning detected by static analyse tool infer@facebook

**Warning Type**
Dead Store

**Component Name**
flac/src/libFLAC/metadata_iterators.c(line:2340)

**Additional Information**
The value written to &max_length (type unsigned int) is never used.