### PR TITLE
Speed up format input

### DIFF
--- a/src/flac/encode.c
+++ b/src/flac/encode.c
@@ -2365,50 +2365,58 @@ FLAC__bool format_input(FLAC__int32 *dest[], uint32_t wide_samples, FLAC__bool i
 	else if(bps == 24) {
 		if(!is_big_endian) {
 			if(is_unsigned_samples) {
-				uint32_t b;
-				for(b = sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-					for(channel = 0; channel < channels; channel++, sample++) {
+				for(channel = 0; channel < channels; channel++) {
+					uint32_t b = 3*channel;
+					for(wide_sample = 0; wide_sample < wide_samples; wide_sample++) {
 						uint32_t t;
-						t  = ubuffer.u8[b++];
-						t |= (uint32_t)(ubuffer.u8[b++]) << 8;
-						t |= (uint32_t)(ubuffer.u8[b++]) << 16;
+						t  = ubuffer.u8[b];
+						t |= (uint32_t)(ubuffer.u8[b+1]) << 8;
+						t |= (uint32_t)(ubuffer.u8[b+2]) << 16;
 						out[channel][wide_sample] = (FLAC__int32)t - 0x800000;
+						b += 3*channels;
 					}
+				}
 			}
 			else {
-				uint32_t b;
-				for(b = sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-					for(channel = 0; channel < channels; channel++, sample++) {
+				for(channel = 0; channel < channels; channel++) {
+					uint32_t b = 3*channel;
+					for(wide_sample = 0; wide_sample < wide_samples; wide_sample++) {
 						uint32_t t;
-						t  = ubuffer.u8[b++];
-						t |= (uint32_t)(ubuffer.u8[b++]) << 8;
-						t |= (int32_t)(ubuffer.s8[b++]) << 16;
+						t  = ubuffer.u8[b];
+						t |= (uint32_t)(ubuffer.u8[b+1]) << 8;
+						t |= (int32_t)(ubuffer.s8[b+2]) << 16;
 						out[channel][wide_sample] = t;
+						b += 3*channels;
 					}
+				}
 			}
 		}
 		else {
 			if(is_unsigned_samples) {
-				uint32_t b;
-				for(b = sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-					for(channel = 0; channel < channels; channel++, sample++) {
+				for(channel = 0; channel < channels; channel++) {
+					uint32_t b = 3*channel;
+					for(wide_sample = 0; wide_sample < wide_samples; wide_sample++) {
 						uint32_t t;
-						t  = ubuffer.u8[b++]; t <<= 8;
-						t |= ubuffer.u8[b++]; t <<= 8;
-						t |= ubuffer.u8[b++];
+						t  = ubuffer.u8[b]; t <<= 8;
+						t |= ubuffer.u8[b+1]; t <<= 8;
+						t |= ubuffer.u8[b+2];
 						out[channel][wide_sample] = (FLAC__int32)t - 0x800000;
+						b += 3*channels;
 					}
+				}
 			}
 			else {
-				uint32_t b;
-				for(b = sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-					for(channel = 0; channel < channels; channel++, sample++) {
+				for(channel = 0; channel < channels; channel++) {
+					uint32_t b = 3*channel;
+					for(wide_sample = 0; wide_sample < wide_samples; wide_sample++) {
 						uint32_t t;
-						t  = ubuffer.s8[b++]; t <<= 8;
-						t |= ubuffer.u8[b++]; t <<= 8;
-						t |= ubuffer.u8[b++];
+						t  = ubuffer.s8[b]; t <<= 8;
+						t |= ubuffer.u8[b+1]; t <<= 8;
+						t |= ubuffer.u8[b+2];
 						out[channel][wide_sample] = t;
+						b += 3*channels;
 					}
+				}
 			}
 		}
 	}

--- a/src/flac/encode.c
+++ b/src/flac/encode.c
@@ -2364,36 +2364,52 @@ FLAC__bool format_input(FLAC__int32 *dest[], uint32_t wide_samples, FLAC__bool i
 	}
 	else if(bps == 24) {
 		if(!is_big_endian) {
-			uint8_t tmp;
-			const uint32_t bytes = wide_samples * channels * (bps >> 3);
-			uint32_t b;
-			for(b = 0; b < bytes; b += 3) {
-				tmp = ubuffer.u8[b];
-				ubuffer.u8[b] = ubuffer.u8[b+2];
-				ubuffer.u8[b+2] = tmp;
+			if(is_unsigned_samples) {
+				uint32_t b;
+				for(b = sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
+					for(channel = 0; channel < channels; channel++, sample++) {
+						uint32_t t;
+						t  = ubuffer.u8[b++];
+						t |= (uint32_t)(ubuffer.u8[b++]) << 8;
+						t |= (uint32_t)(ubuffer.u8[b++]) << 16;
+						out[channel][wide_sample] = (FLAC__int32)t - 0x800000;
+					}
+			}
+			else {
+				uint32_t b;
+				for(b = sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
+					for(channel = 0; channel < channels; channel++, sample++) {
+						uint32_t t;
+						t  = ubuffer.u8[b++];
+						t |= (uint32_t)(ubuffer.u8[b++]) << 8;
+						t |= (int32_t)(ubuffer.s8[b++]) << 16;
+						out[channel][wide_sample] = t;
+					}
 			}
 		}
-		if(is_unsigned_samples) {
-			uint32_t b;
-			for(b = sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-				for(channel = 0; channel < channels; channel++, sample++) {
-					uint32_t t;
-					t  = ubuffer.u8[b++]; t <<= 8;
-					t |= ubuffer.u8[b++]; t <<= 8;
-					t |= ubuffer.u8[b++];
-					out[channel][wide_sample] = (FLAC__int32)t - 0x800000;
-				}
-		}
 		else {
-			uint32_t b;
-			for(b = sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-				for(channel = 0; channel < channels; channel++, sample++) {
-					uint32_t t;
-					t  = ubuffer.s8[b++]; t <<= 8;
-					t |= ubuffer.u8[b++]; t <<= 8;
-					t |= ubuffer.u8[b++];
-					out[channel][wide_sample] = t;
-				}
+			if(is_unsigned_samples) {
+				uint32_t b;
+				for(b = sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
+					for(channel = 0; channel < channels; channel++, sample++) {
+						uint32_t t;
+						t  = ubuffer.u8[b++]; t <<= 8;
+						t |= ubuffer.u8[b++]; t <<= 8;
+						t |= ubuffer.u8[b++];
+						out[channel][wide_sample] = (FLAC__int32)t - 0x800000;
+					}
+			}
+			else {
+				uint32_t b;
+				for(b = sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
+					for(channel = 0; channel < channels; channel++, sample++) {
+						uint32_t t;
+						t  = ubuffer.s8[b++]; t <<= 8;
+						t |= ubuffer.u8[b++]; t <<= 8;
+						t |= ubuffer.u8[b++];
+						out[channel][wide_sample] = t;
+					}
+			}
 		}
 	}
 	else if(bps == 32) {

--- a/src/flac/encode.c
+++ b/src/flac/encode.c
@@ -2330,36 +2330,41 @@ FLAC__bool format_input(FLAC__int32 *dest[], uint32_t wide_samples, FLAC__bool i
 
 	if(bps == 8) {
 		if(is_unsigned_samples) {
-			for(sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-				for(channel = 0; channel < channels; channel++, sample++)
+			for(channel = 0; channel < channels; channel++)
+				for(sample = channel, wide_sample = 0; wide_sample < wide_samples; wide_sample++, sample+=channels)
 					out[channel][wide_sample] = (FLAC__int32)ubuffer.u8[sample] - 0x80;
 		}
 		else {
-			for(sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-				for(channel = 0; channel < channels; channel++, sample++)
+			for(channel = 0; channel < channels; channel++)
+				for(sample = channel, wide_sample = 0; wide_sample < wide_samples; wide_sample++, sample+=channels)
 					out[channel][wide_sample] = (FLAC__int32)ubuffer.s8[sample];
 		}
 	}
 	else if(bps == 16) {
-		if(is_big_endian != is_big_endian_host_) {
-			uint8_t tmp;
-			const uint32_t bytes = wide_samples * channels * (bps >> 3);
-			uint32_t b;
-			for(b = 0; b < bytes; b += 2) {
-				tmp = ubuffer.u8[b];
-				ubuffer.u8[b] = ubuffer.u8[b+1];
-				ubuffer.u8[b+1] = tmp;
+		if(is_unsigned_samples) {
+			if(is_big_endian != is_big_endian_host_) {
+				for(channel = 0; channel < channels; channel++)
+					for(sample = channel, wide_sample = 0; wide_sample < wide_samples; wide_sample++, sample+=channels)
+						out[channel][wide_sample] = (FLAC__int32)(ENDSWAP_16(ubuffer.u16[sample])) - 0x8000;
+			}
+			else {
+				for(channel = 0; channel < channels; channel++)
+					for(sample = channel, wide_sample = 0; wide_sample < wide_samples; wide_sample++, sample+=channels)
+						out[channel][wide_sample] = (FLAC__int32)ubuffer.u16[sample] - 0x8000;
 			}
 		}
-		if(is_unsigned_samples) {
-			for(sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-				for(channel = 0; channel < channels; channel++, sample++)
-					out[channel][wide_sample] = ubuffer.u16[sample] - 0x8000;
-		}
 		else {
-			for(sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-				for(channel = 0; channel < channels; channel++, sample++)
-					out[channel][wide_sample] = ubuffer.s16[sample];
+			if(is_big_endian != is_big_endian_host_) {
+				for(channel = 0; channel < channels; channel++)
+					for(sample = channel, wide_sample = 0; wide_sample < wide_samples; wide_sample++, sample+=channels)
+						out[channel][wide_sample] = (int16_t)(ENDSWAP_16(ubuffer.s16[sample]));
+
+			}
+			else {
+				for(channel = 0; channel < channels; channel++)
+					for(sample = channel, wide_sample = 0; wide_sample < wide_samples; wide_sample++, sample+=channels)
+						out[channel][wide_sample] = ubuffer.s16[sample];
+			}
 		}
 	}
 	else if(bps == 24) {
@@ -2423,26 +2428,26 @@ FLAC__bool format_input(FLAC__int32 *dest[], uint32_t wide_samples, FLAC__bool i
 	else if(bps == 32) {
 		if(is_unsigned_samples) {
 			if(is_big_endian != is_big_endian_host_) {
-				for(sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-					for(channel = 0; channel < channels; channel++, sample++)
+				for(channel = 0; channel < channels; channel++)
+					for(sample = channel, wide_sample = 0; wide_sample < wide_samples; wide_sample++, sample+=channels)
 						out[channel][wide_sample] = ENDSWAP_32(ubuffer.u32[sample]) - 0x80000000;
 			}
 			else {
-				for(sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-					for(channel = 0; channel < channels; channel++, sample++)
+				for(channel = 0; channel < channels; channel++)
+					for(sample = channel, wide_sample = 0; wide_sample < wide_samples; wide_sample++, sample+=channels)
 						out[channel][wide_sample] = ubuffer.u32[sample] - 0x80000000;
 			}
 		}
 		else {
 			if(is_big_endian != is_big_endian_host_) {
-				for(sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-					for(channel = 0; channel < channels; channel++, sample++)
+				for(channel = 0; channel < channels; channel++)
+					for(sample = channel, wide_sample = 0; wide_sample < wide_samples; wide_sample++, sample+=channels)
 						out[channel][wide_sample] = ENDSWAP_32(ubuffer.s32[sample]);
 			}
 			else {
-				for(sample = wide_sample = 0; wide_sample < wide_samples; wide_sample++)
-					for(channel = 0; channel < channels; channel++, sample++)
-						out[channel][wide_sample] = ubuffer.u32[sample];
+				for(channel = 0; channel < channels; channel++)
+					for(sample = channel, wide_sample = 0; wide_sample < wide_samples; wide_sample++, sample+=channels)
+						out[channel][wide_sample] = ubuffer.s32[sample];
 			}
 		}
 	}
@@ -2911,3 +2916,4 @@ uint32_t count_channel_mask_bits(FLAC__uint32 mask)
 	}
 	return count;
 }
+


### PR DESCRIPTION
While profiling the faster presets of libFLAC with `flac`, it seemed the function format_input was taking a disproportionate amount of time. With a few changes, this function became much faster, especially for 24-bit and 32-bit inputs.

The most extreme case I've seen was a 26x speedup for mono 32-bit PCM files. For stereo 24-bit files, this function became twice as fast.