### PR TITLE
Try to fix flac tool fuzzer

### DIFF
--- a/oss-fuzz/tool_flac.c
+++ b/oss-fuzz/tool_flac.c
@@ -43,10 +43,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
 	size_t size_left = size;
 	size_t arglen;
-	char * argv[64];
+	char * argv[67];
 	char exename[] = "flac";
 	char filename[] = "/tmp/fuzzXXXXXX";
-	int numarg = 0, maxarg;
+	int numarg = 0, maxarg, pad;
 	int file_to_fuzz;
 
 	flac__utils_verbosity_ = 0;
@@ -57,7 +57,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	if(size < 2)
 		return 0;
 
-	maxarg = data[0] & 16;
+	maxarg = data[0] & 63;
+	pad = data[0] & 64;
 	size_left--;
 
 	argv[0] = exename;
@@ -74,6 +75,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	if (file_to_fuzz < 0)
 		abort();
 	write(file_to_fuzz,data+(size-size_left),size_left);
+	if(pad)
+		write(file_to_fuzz,"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",12);
 	close(file_to_fuzz);
 
 	argv[numarg++] = filename;

--- a/src/flac/decode.c
+++ b/src/flac/decode.c
@@ -1161,7 +1161,7 @@ FLAC__StreamDecoderWriteStatus write_callback(const FLAC__StreamDecoder *decoder
 	}
 
 	/* sanity-check the sample rate */
-	if(decoder_session->sample_rate) {
+	if(!decoder_session->got_stream_info) {
 		if(frame->header.sample_rate != decoder_session->sample_rate) {
 			if(decoder_session->got_stream_info)
 				flac__utils_printf(stderr, 1, "%s: ERROR, sample rate is %u in frame but %u in STREAMINFO\n", decoder_session->inbasefilename, frame->header.sample_rate, decoder_session->sample_rate);
@@ -1172,8 +1172,6 @@ FLAC__StreamDecoderWriteStatus write_callback(const FLAC__StreamDecoder *decoder
 		}
 	}
 	else {
-		/* must not have gotten STREAMINFO, save the sample rate from the frame header */
-		FLAC__ASSERT(!decoder_session->got_stream_info);
 		decoder_session->sample_rate = frame->header.sample_rate;
 	}
 


### PR DESCRIPTION
It seems the flac tool fuzzer doesn't make much progress. I think this might be due to the fuzzer focussing too much on the command line arguments instead of the file. Some changes are made that might alleviate this.

Also, fix an open oss-fuzz issue