### PR TITLE
Retune compression levels

### DIFF
--- a/src/libFLAC/deduplication/lpc_compute_and_use_predictor_above_12.c
+++ b/src/libFLAC/deduplication/lpc_compute_and_use_predictor_above_12.c
@@ -1,0 +1,136 @@
+/* This code is ordered such that each loop is at least 2/3ths unrolled */
+
+if(order <= 22) {
+	if(order <= 16) {
+		for(i = 0; i < (int)data_len; i++) {
+			sum = 0;
+			switch(order) {
+				case 16: sum += qlp_coeff[15] * (FLAC__LPC_DATA_TYPE)data[i-16]; /* Falls through. */
+				case 15: sum += qlp_coeff[14] * (FLAC__LPC_DATA_TYPE)data[i-15]; /* Falls through. */
+				case 14: sum += qlp_coeff[13] * (FLAC__LPC_DATA_TYPE)data[i-14]; /* Falls through. */
+				case 13: sum += qlp_coeff[12] * (FLAC__LPC_DATA_TYPE)data[i-13];
+						 sum += qlp_coeff[11] * (FLAC__LPC_DATA_TYPE)data[i-12];
+						 sum += qlp_coeff[10] * (FLAC__LPC_DATA_TYPE)data[i-11];
+						 sum += qlp_coeff[ 9] * (FLAC__LPC_DATA_TYPE)data[i-10];
+						 sum += qlp_coeff[ 8] * (FLAC__LPC_DATA_TYPE)data[i- 9];
+						 sum += qlp_coeff[ 7] * (FLAC__LPC_DATA_TYPE)data[i- 8];
+						 sum += qlp_coeff[ 6] * (FLAC__LPC_DATA_TYPE)data[i- 7];
+						 sum += qlp_coeff[ 5] * (FLAC__LPC_DATA_TYPE)data[i- 6];
+						 sum += qlp_coeff[ 4] * (FLAC__LPC_DATA_TYPE)data[i- 5];
+						 sum += qlp_coeff[ 3] * (FLAC__LPC_DATA_TYPE)data[i- 4];
+						 sum += qlp_coeff[ 2] * (FLAC__LPC_DATA_TYPE)data[i- 3];
+						 sum += qlp_coeff[ 1] * (FLAC__LPC_DATA_TYPE)data[i- 2];
+						 sum += qlp_coeff[ 0] * (FLAC__LPC_DATA_TYPE)data[i- 1];
+			}
+			FLAC__LPC_ACTION;
+		}
+	}
+	else { /* 16 < order <= 20 */
+		for(i = 0; i < (int)data_len; i++) {
+			sum = 0;
+			switch(order) {
+				case 22: sum += qlp_coeff[21] * (FLAC__LPC_DATA_TYPE)data[i-22]; /* Falls through. */
+				case 21: sum += qlp_coeff[20] * (FLAC__LPC_DATA_TYPE)data[i-21]; /* Falls through. */
+				case 20: sum += qlp_coeff[19] * (FLAC__LPC_DATA_TYPE)data[i-20]; /* Falls through. */
+				case 19: sum += qlp_coeff[18] * (FLAC__LPC_DATA_TYPE)data[i-19]; /* Falls through. */
+				case 18: sum += qlp_coeff[17] * (FLAC__LPC_DATA_TYPE)data[i-18]; /* Falls through. */
+				case 17: sum += qlp_coeff[16] * (FLAC__LPC_DATA_TYPE)data[i-17];
+				         sum += qlp_coeff[15] * (FLAC__LPC_DATA_TYPE)data[i-16];
+						 sum += qlp_coeff[14] * (FLAC__LPC_DATA_TYPE)data[i-15];
+						 sum += qlp_coeff[13] * (FLAC__LPC_DATA_TYPE)data[i-14];
+						 sum += qlp_coeff[12] * (FLAC__LPC_DATA_TYPE)data[i-13];
+						 sum += qlp_coeff[11] * (FLAC__LPC_DATA_TYPE)data[i-12];
+						 sum += qlp_coeff[10] * (FLAC__LPC_DATA_TYPE)data[i-11];
+						 sum += qlp_coeff[ 9] * (FLAC__LPC_DATA_TYPE)data[i-10];
+						 sum += qlp_coeff[ 8] * (FLAC__LPC_DATA_TYPE)data[i- 9];
+						 sum += qlp_coeff[ 7] * (FLAC__LPC_DATA_TYPE)data[i- 8];
+						 sum += qlp_coeff[ 6] * (FLAC__LPC_DATA_TYPE)data[i- 7];
+						 sum += qlp_coeff[ 5] * (FLAC__LPC_DATA_TYPE)data[i- 6];
+						 sum += qlp_coeff[ 4] * (FLAC__LPC_DATA_TYPE)data[i- 5];
+						 sum += qlp_coeff[ 3] * (FLAC__LPC_DATA_TYPE)data[i- 4];
+						 sum += qlp_coeff[ 2] * (FLAC__LPC_DATA_TYPE)data[i- 3];
+						 sum += qlp_coeff[ 1] * (FLAC__LPC_DATA_TYPE)data[i- 2];
+						 sum += qlp_coeff[ 0] * (FLAC__LPC_DATA_TYPE)data[i- 1];
+			}
+			FLAC__LPC_ACTION;
+		}
+	}
+}
+else { /* order > 22 */
+	if(order <= 28) {
+		for(i = 0; i < (int)data_len; i++) {
+			sum = 0;
+			switch(order) {
+				case 28: sum += qlp_coeff[27] * (FLAC__LPC_DATA_TYPE)data[i-28]; /* Falls through. */
+				case 27: sum += qlp_coeff[26] * (FLAC__LPC_DATA_TYPE)data[i-27]; /* Falls through. */
+				case 26: sum += qlp_coeff[25] * (FLAC__LPC_DATA_TYPE)data[i-26]; /* Falls through. */
+				case 25: sum += qlp_coeff[24] * (FLAC__LPC_DATA_TYPE)data[i-25]; /* Falls through. */
+				case 24: sum += qlp_coeff[23] * (FLAC__LPC_DATA_TYPE)data[i-24]; /* Falls through. */
+				case 23: sum += qlp_coeff[22] * (FLAC__LPC_DATA_TYPE)data[i-23];
+						 sum += qlp_coeff[21] * (FLAC__LPC_DATA_TYPE)data[i-22];
+						 sum += qlp_coeff[20] * (FLAC__LPC_DATA_TYPE)data[i-21];
+						 sum += qlp_coeff[19] * (FLAC__LPC_DATA_TYPE)data[i-20];
+						 sum += qlp_coeff[18] * (FLAC__LPC_DATA_TYPE)data[i-19];
+						 sum += qlp_coeff[17] * (FLAC__LPC_DATA_TYPE)data[i-18];
+						 sum += qlp_coeff[16] * (FLAC__LPC_DATA_TYPE)data[i-17];
+						 sum += qlp_coeff[15] * (FLAC__LPC_DATA_TYPE)data[i-16];
+						 sum += qlp_coeff[14] * (FLAC__LPC_DATA_TYPE)data[i-15];
+						 sum += qlp_coeff[13] * (FLAC__LPC_DATA_TYPE)data[i-14];
+						 sum += qlp_coeff[12] * (FLAC__LPC_DATA_TYPE)data[i-13];
+						 sum += qlp_coeff[11] * (FLAC__LPC_DATA_TYPE)data[i-12];
+						 sum += qlp_coeff[10] * (FLAC__LPC_DATA_TYPE)data[i-11];
+						 sum += qlp_coeff[ 9] * (FLAC__LPC_DATA_TYPE)data[i-10];
+						 sum += qlp_coeff[ 8] * (FLAC__LPC_DATA_TYPE)data[i- 9];
+						 sum += qlp_coeff[ 7] * (FLAC__LPC_DATA_TYPE)data[i- 8];
+						 sum += qlp_coeff[ 6] * (FLAC__LPC_DATA_TYPE)data[i- 7];
+						 sum += qlp_coeff[ 5] * (FLAC__LPC_DATA_TYPE)data[i- 6];
+						 sum += qlp_coeff[ 4] * (FLAC__LPC_DATA_TYPE)data[i- 5];
+						 sum += qlp_coeff[ 3] * (FLAC__LPC_DATA_TYPE)data[i- 4];
+						 sum += qlp_coeff[ 2] * (FLAC__LPC_DATA_TYPE)data[i- 3];
+						 sum += qlp_coeff[ 1] * (FLAC__LPC_DATA_TYPE)data[i- 2];
+						 sum += qlp_coeff[ 0] * (FLAC__LPC_DATA_TYPE)data[i- 1];
+			}
+			FLAC__LPC_ACTION;
+		}
+	}
+	else { /* order > 28 */
+		for(i = 0; i < (int)data_len; i++) {
+			sum = 0;
+			switch(order) {
+				case 32: sum += qlp_coeff[31] * (FLAC__LPC_DATA_TYPE)data[i-32]; /* Falls through. */
+				case 31: sum += qlp_coeff[30] * (FLAC__LPC_DATA_TYPE)data[i-31]; /* Falls through. */
+				case 30: sum += qlp_coeff[29] * (FLAC__LPC_DATA_TYPE)data[i-30]; /* Falls through. */
+				case 29: sum += qlp_coeff[28] * (FLAC__LPC_DATA_TYPE)data[i-29];
+						 sum += qlp_coeff[27] * (FLAC__LPC_DATA_TYPE)data[i-28];
+						 sum += qlp_coeff[26] * (FLAC__LPC_DATA_TYPE)data[i-27];
+						 sum += qlp_coeff[25] * (FLAC__LPC_DATA_TYPE)data[i-26];
+						 sum += qlp_coeff[24] * (FLAC__LPC_DATA_TYPE)data[i-25];
+						 sum += qlp_coeff[23] * (FLAC__LPC_DATA_TYPE)data[i-24];
+						 sum += qlp_coeff[22] * (FLAC__LPC_DATA_TYPE)data[i-23];
+						 sum += qlp_coeff[21] * (FLAC__LPC_DATA_TYPE)data[i-22];
+						 sum += qlp_coeff[20] * (FLAC__LPC_DATA_TYPE)data[i-21];
+						 sum += qlp_coeff[19] * (FLAC__LPC_DATA_TYPE)data[i-20];
+						 sum += qlp_coeff[18] * (FLAC__LPC_DATA_TYPE)data[i-19];
+						 sum += qlp_coeff[17] * (FLAC__LPC_DATA_TYPE)data[i-18];
+						 sum += qlp_coeff[16] * (FLAC__LPC_DATA_TYPE)data[i-17];
+						 sum += qlp_coeff[15] * (FLAC__LPC_DATA_TYPE)data[i-16];
+						 sum += qlp_coeff[14] * (FLAC__LPC_DATA_TYPE)data[i-15];
+						 sum += qlp_coeff[13] * (FLAC__LPC_DATA_TYPE)data[i-14];
+						 sum += qlp_coeff[12] * (FLAC__LPC_DATA_TYPE)data[i-13];
+						 sum += qlp_coeff[11] * (FLAC__LPC_DATA_TYPE)data[i-12];
+						 sum += qlp_coeff[10] * (FLAC__LPC_DATA_TYPE)data[i-11];
+						 sum += qlp_coeff[ 9] * (FLAC__LPC_DATA_TYPE)data[i-10];
+						 sum += qlp_coeff[ 8] * (FLAC__LPC_DATA_TYPE)data[i- 9];
+						 sum += qlp_coeff[ 7] * (FLAC__LPC_DATA_TYPE)data[i- 8];
+						 sum += qlp_coeff[ 6] * (FLAC__LPC_DATA_TYPE)data[i- 7];
+						 sum += qlp_coeff[ 5] * (FLAC__LPC_DATA_TYPE)data[i- 6];
+						 sum += qlp_coeff[ 4] * (FLAC__LPC_DATA_TYPE)data[i- 5];
+						 sum += qlp_coeff[ 3] * (FLAC__LPC_DATA_TYPE)data[i- 4];
+						 sum += qlp_coeff[ 2] * (FLAC__LPC_DATA_TYPE)data[i- 3];
+						 sum += qlp_coeff[ 1] * (FLAC__LPC_DATA_TYPE)data[i- 2];
+						 sum += qlp_coeff[ 0] * (FLAC__LPC_DATA_TYPE)data[i- 1];
+			}
+			FLAC__LPC_ACTION;
+		}
+	}
+}

--- a/src/libFLAC/include/private/lpc.h
+++ b/src/libFLAC/include/private/lpc.h
@@ -82,9 +82,9 @@ void FLAC__lpc_compute_autocorrelation_intrin_sse2_lag_14(const FLAC__real data[
 #  endif
 #  if defined FLAC__CPU_X86_64 && FLAC__HAS_X86INTRIN
 #    ifdef FLAC__FMA_SUPPORTED
-void FLAC__lpc_compute_autocorrelation_intrin_fma_lag_8(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[]);
-void FLAC__lpc_compute_autocorrelation_intrin_fma_lag_12(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[]);
-void FLAC__lpc_compute_autocorrelation_intrin_fma_lag_16(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[]);
+void FLAC__lpc_compute_autocorrelation_intrin_fma_lag_9(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[]);
+void FLAC__lpc_compute_autocorrelation_intrin_fma_lag_13(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[]);
+void FLAC__lpc_compute_autocorrelation_intrin_fma_lag_33(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[]);
 #    endif
 #  endif
 #if defined FLAC__CPU_ARM64 && FLAC__HAS_NEONINTRIN && FLAC__HAS_A64NEONINTRIN

--- a/src/libFLAC/include/protected/stream_encoder.h
+++ b/src/libFLAC/include/protected/stream_encoder.h
@@ -104,6 +104,7 @@ typedef struct FLAC__StreamEncoderProtected {
 	FLAC__ApodizationSpecification apodizations[FLAC__MAX_APODIZATION_FUNCTIONS];
 #endif
 	uint32_t max_lpc_order;
+	FLAC__bool max_lpc_order_set_by_compression_level;
 	uint32_t qlp_coeff_precision;
 	FLAC__bool do_qlp_coeff_prec_search;
 	FLAC__bool do_exhaustive_model_search;

--- a/src/libFLAC/lpc.c
+++ b/src/libFLAC/lpc.c
@@ -130,7 +130,7 @@ void FLAC__lpc_compute_autocorrelation(const FLAC__real data[], uint32_t data_le
 		autoc[lag] = d;
 	}
 #endif
-	if (data_len < FLAC__MAX_LPC_ORDER || lag > 16) {
+	if (data_len < FLAC__MAX_LPC_ORDER) {
 		/*
 		 * this version tends to run faster because of better data locality
 		 * ('data_len' is usually much larger than 'lag')
@@ -155,19 +155,22 @@ void FLAC__lpc_compute_autocorrelation(const FLAC__real data[], uint32_t data_le
 				autoc[coeff] += d * data[sample+coeff];
 		}
 	}
-	else if(lag <= 8) {
+	else if(lag <= 9) {
+		/* Up to max_lpc_order 8 */
 		#undef MAX_LAG
-		#define MAX_LAG 8
+		#define MAX_LAG 9
 		#include "deduplication/lpc_compute_autocorrelation_intrin.c"
 	}
-	else if(lag <= 12) {
+	else if(lag <= 13) {
+		/* Up to max_lpc_order 12 */
 		#undef MAX_LAG
-		#define MAX_LAG 12
+		#define MAX_LAG 13
 		#include "deduplication/lpc_compute_autocorrelation_intrin.c"
 	}
-	else if(lag <= 16) {
+	else if(lag <= 33) {
+		/* Up to max_lpc_order 32 */
 		#undef MAX_LAG
-		#define MAX_LAG 16
+		#define MAX_LAG 33
 		#include "deduplication/lpc_compute_autocorrelation_intrin.c"
 	}
 
@@ -787,44 +790,11 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients_wide(const FLAC__int32 * f
 		}
 	}
 	else { /* order > 12 */
-		for(i = 0; i < (int)data_len; i++) {
-			sum = 0;
-			switch(order) {
-				case 32: sum += qlp_coeff[31] * (FLAC__int64)data[i-32]; /* Falls through. */
-				case 31: sum += qlp_coeff[30] * (FLAC__int64)data[i-31]; /* Falls through. */
-				case 30: sum += qlp_coeff[29] * (FLAC__int64)data[i-30]; /* Falls through. */
-				case 29: sum += qlp_coeff[28] * (FLAC__int64)data[i-29]; /* Falls through. */
-				case 28: sum += qlp_coeff[27] * (FLAC__int64)data[i-28]; /* Falls through. */
-				case 27: sum += qlp_coeff[26] * (FLAC__int64)data[i-27]; /* Falls through. */
-				case 26: sum += qlp_coeff[25] * (FLAC__int64)data[i-26]; /* Falls through. */
-				case 25: sum += qlp_coeff[24] * (FLAC__int64)data[i-25]; /* Falls through. */
-				case 24: sum += qlp_coeff[23] * (FLAC__int64)data[i-24]; /* Falls through. */
-				case 23: sum += qlp_coeff[22] * (FLAC__int64)data[i-23]; /* Falls through. */
-				case 22: sum += qlp_coeff[21] * (FLAC__int64)data[i-22]; /* Falls through. */
-				case 21: sum += qlp_coeff[20] * (FLAC__int64)data[i-21]; /* Falls through. */
-				case 20: sum += qlp_coeff[19] * (FLAC__int64)data[i-20]; /* Falls through. */
-				case 19: sum += qlp_coeff[18] * (FLAC__int64)data[i-19]; /* Falls through. */
-				case 18: sum += qlp_coeff[17] * (FLAC__int64)data[i-18]; /* Falls through. */
-				case 17: sum += qlp_coeff[16] * (FLAC__int64)data[i-17]; /* Falls through. */
-				case 16: sum += qlp_coeff[15] * (FLAC__int64)data[i-16]; /* Falls through. */
-				case 15: sum += qlp_coeff[14] * (FLAC__int64)data[i-15]; /* Falls through. */
-				case 14: sum += qlp_coeff[13] * (FLAC__int64)data[i-14]; /* Falls through. */
-				case 13: sum += qlp_coeff[12] * (FLAC__int64)data[i-13];
-				         sum += qlp_coeff[11] * (FLAC__int64)data[i-12];
-				         sum += qlp_coeff[10] * (FLAC__int64)data[i-11];
-				         sum += qlp_coeff[ 9] * (FLAC__int64)data[i-10];
-				         sum += qlp_coeff[ 8] * (FLAC__int64)data[i- 9];
-				         sum += qlp_coeff[ 7] * (FLAC__int64)data[i- 8];
-				         sum += qlp_coeff[ 6] * (FLAC__int64)data[i- 7];
-				         sum += qlp_coeff[ 5] * (FLAC__int64)data[i- 6];
-				         sum += qlp_coeff[ 4] * (FLAC__int64)data[i- 5];
-				         sum += qlp_coeff[ 3] * (FLAC__int64)data[i- 4];
-				         sum += qlp_coeff[ 2] * (FLAC__int64)data[i- 3];
-				         sum += qlp_coeff[ 1] * (FLAC__int64)data[i- 2];
-				         sum += qlp_coeff[ 0] * (FLAC__int64)data[i- 1];
-			}
-			residual[i] = data[i] - (sum >> lp_quantization);
-		}
+		#undef FLAC__LPC_DATA_TYPE
+		#undef FLAC__LPC_ACTION
+		#define FLAC__LPC_DATA_TYPE FLAC__int64
+		#define FLAC__LPC_ACTION residual[i] = data[i] - (sum >> lp_quantization);
+		#include "deduplication/lpc_compute_and_use_predictor_above_12.c"
 	}
 }
 #endif
@@ -1445,44 +1415,11 @@ void FLAC__lpc_restore_signal_wide(const FLAC__int32 * flac_restrict residual, u
 		}
 	}
 	else { /* order > 12 */
-		for(i = 0; i < (int)data_len; i++) {
-			sum = 0;
-			switch(order) {
-				case 32: sum += qlp_coeff[31] * (FLAC__int64)data[i-32]; /* Falls through. */
-				case 31: sum += qlp_coeff[30] * (FLAC__int64)data[i-31]; /* Falls through. */
-				case 30: sum += qlp_coeff[29] * (FLAC__int64)data[i-30]; /* Falls through. */
-				case 29: sum += qlp_coeff[28] * (FLAC__int64)data[i-29]; /* Falls through. */
-				case 28: sum += qlp_coeff[27] * (FLAC__int64)data[i-28]; /* Falls through. */
-				case 27: sum += qlp_coeff[26] * (FLAC__int64)data[i-27]; /* Falls through. */
-				case 26: sum += qlp_coeff[25] * (FLAC__int64)data[i-26]; /* Falls through. */
-				case 25: sum += qlp_coeff[24] * (FLAC__int64)data[i-25]; /* Falls through. */
-				case 24: sum += qlp_coeff[23] * (FLAC__int64)data[i-24]; /* Falls through. */
-				case 23: sum += qlp_coeff[22] * (FLAC__int64)data[i-23]; /* Falls through. */
-				case 22: sum += qlp_coeff[21] * (FLAC__int64)data[i-22]; /* Falls through. */
-				case 21: sum += qlp_coeff[20] * (FLAC__int64)data[i-21]; /* Falls through. */
-				case 20: sum += qlp_coeff[19] * (FLAC__int64)data[i-20]; /* Falls through. */
-				case 19: sum += qlp_coeff[18] * (FLAC__int64)data[i-19]; /* Falls through. */
-				case 18: sum += qlp_coeff[17] * (FLAC__int64)data[i-18]; /* Falls through. */
-				case 17: sum += qlp_coeff[16] * (FLAC__int64)data[i-17]; /* Falls through. */
-				case 16: sum += qlp_coeff[15] * (FLAC__int64)data[i-16]; /* Falls through. */
-				case 15: sum += qlp_coeff[14] * (FLAC__int64)data[i-15]; /* Falls through. */
-				case 14: sum += qlp_coeff[13] * (FLAC__int64)data[i-14]; /* Falls through. */
-				case 13: sum += qlp_coeff[12] * (FLAC__int64)data[i-13];
-				         sum += qlp_coeff[11] * (FLAC__int64)data[i-12];
-				         sum += qlp_coeff[10] * (FLAC__int64)data[i-11];
-				         sum += qlp_coeff[ 9] * (FLAC__int64)data[i-10];
-				         sum += qlp_coeff[ 8] * (FLAC__int64)data[i- 9];
-				         sum += qlp_coeff[ 7] * (FLAC__int64)data[i- 8];
-				         sum += qlp_coeff[ 6] * (FLAC__int64)data[i- 7];
-				         sum += qlp_coeff[ 5] * (FLAC__int64)data[i- 6];
-				         sum += qlp_coeff[ 4] * (FLAC__int64)data[i- 5];
-				         sum += qlp_coeff[ 3] * (FLAC__int64)data[i- 4];
-				         sum += qlp_coeff[ 2] * (FLAC__int64)data[i- 3];
-				         sum += qlp_coeff[ 1] * (FLAC__int64)data[i- 2];
-				         sum += qlp_coeff[ 0] * (FLAC__int64)data[i- 1];
-			}
-			data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
-		}
+		#undef FLAC__LPC_DATA_TYPE
+		#undef FLAC__LPC_ACTION
+		#define FLAC__LPC_DATA_TYPE FLAC__int64
+		#define FLAC__LPC_ACTION data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
+		#include "deduplication/lpc_compute_and_use_predictor_above_12.c"
 	}
 }
 #endif

--- a/src/libFLAC/lpc.c
+++ b/src/libFLAC/lpc.c
@@ -1517,7 +1517,7 @@ double FLAC__lpc_compute_expected_bits_per_residual_sample(double lpc_error, uin
 
 	FLAC__ASSERT(total_samples > 0);
 
-	error_scale = 0.5 / (double)total_samples;
+	error_scale = 0.5 * M_LN2 * M_LN2 / (double)total_samples;
 
 	return FLAC__lpc_compute_expected_bits_per_residual_sample_with_error_scale(lpc_error, error_scale);
 }
@@ -1547,7 +1547,7 @@ uint32_t FLAC__lpc_compute_best_order(const double lpc_error[], uint32_t max_ord
 	FLAC__ASSERT(max_order > 0);
 	FLAC__ASSERT(total_samples > 0);
 
-	error_scale = 0.5 / (double)total_samples;
+	error_scale = 0.5 * M_LN2 * M_LN2 / (double)total_samples;
 
 	best_index = 0;
 	best_bits = (uint32_t)(-1);

--- a/src/libFLAC/lpc_intrin_avx2.c
+++ b/src/libFLAC/lpc_intrin_avx2.c
@@ -1074,44 +1074,11 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients_wide_intrin_avx2(const FLA
 		}
 	}
 	else { /* order > 12 */
-		for(i = 0; i < (int)data_len; i++) {
-			sum = 0;
-			switch(order) {
-				case 32: sum += qlp_coeff[31] * (FLAC__int64)data[i-32]; /* Falls through. */
-				case 31: sum += qlp_coeff[30] * (FLAC__int64)data[i-31]; /* Falls through. */
-				case 30: sum += qlp_coeff[29] * (FLAC__int64)data[i-30]; /* Falls through. */
-				case 29: sum += qlp_coeff[28] * (FLAC__int64)data[i-29]; /* Falls through. */
-				case 28: sum += qlp_coeff[27] * (FLAC__int64)data[i-28]; /* Falls through. */
-				case 27: sum += qlp_coeff[26] * (FLAC__int64)data[i-27]; /* Falls through. */
-				case 26: sum += qlp_coeff[25] * (FLAC__int64)data[i-26]; /* Falls through. */
-				case 25: sum += qlp_coeff[24] * (FLAC__int64)data[i-25]; /* Falls through. */
-				case 24: sum += qlp_coeff[23] * (FLAC__int64)data[i-24]; /* Falls through. */
-				case 23: sum += qlp_coeff[22] * (FLAC__int64)data[i-23]; /* Falls through. */
-				case 22: sum += qlp_coeff[21] * (FLAC__int64)data[i-22]; /* Falls through. */
-				case 21: sum += qlp_coeff[20] * (FLAC__int64)data[i-21]; /* Falls through. */
-				case 20: sum += qlp_coeff[19] * (FLAC__int64)data[i-20]; /* Falls through. */
-				case 19: sum += qlp_coeff[18] * (FLAC__int64)data[i-19]; /* Falls through. */
-				case 18: sum += qlp_coeff[17] * (FLAC__int64)data[i-18]; /* Falls through. */
-				case 17: sum += qlp_coeff[16] * (FLAC__int64)data[i-17]; /* Falls through. */
-				case 16: sum += qlp_coeff[15] * (FLAC__int64)data[i-16]; /* Falls through. */
-				case 15: sum += qlp_coeff[14] * (FLAC__int64)data[i-15]; /* Falls through. */
-				case 14: sum += qlp_coeff[13] * (FLAC__int64)data[i-14]; /* Falls through. */
-				case 13: sum += qlp_coeff[12] * (FLAC__int64)data[i-13];
-				         sum += qlp_coeff[11] * (FLAC__int64)data[i-12];
-				         sum += qlp_coeff[10] * (FLAC__int64)data[i-11];
-				         sum += qlp_coeff[ 9] * (FLAC__int64)data[i-10];
-				         sum += qlp_coeff[ 8] * (FLAC__int64)data[i- 9];
-				         sum += qlp_coeff[ 7] * (FLAC__int64)data[i- 8];
-				         sum += qlp_coeff[ 6] * (FLAC__int64)data[i- 7];
-				         sum += qlp_coeff[ 5] * (FLAC__int64)data[i- 6];
-				         sum += qlp_coeff[ 4] * (FLAC__int64)data[i- 5];
-				         sum += qlp_coeff[ 3] * (FLAC__int64)data[i- 4];
-				         sum += qlp_coeff[ 2] * (FLAC__int64)data[i- 3];
-				         sum += qlp_coeff[ 1] * (FLAC__int64)data[i- 2];
-				         sum += qlp_coeff[ 0] * (FLAC__int64)data[i- 1];
-			}
-			residual[i] = data[i] - (FLAC__int32)(sum >> lp_quantization);
-		}
+		#undef FLAC__LPC_DATA_TYPE
+		#undef FLAC__LPC_ACTION
+		#define FLAC__LPC_DATA_TYPE FLAC__int64
+		#define FLAC__LPC_ACTION residual[i] = data[i] - (FLAC__int32)(sum >> lp_quantization);
+		#include "deduplication/lpc_compute_and_use_predictor_above_12.c"
 	}
 	_mm256_zeroupper();
 }

--- a/src/libFLAC/lpc_intrin_fma.c
+++ b/src/libFLAC/lpc_intrin_fma.c
@@ -44,27 +44,26 @@
 #include "FLAC/assert.h"
 
 FLAC__SSE_TARGET("fma")
-void FLAC__lpc_compute_autocorrelation_intrin_fma_lag_8(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[])
+void FLAC__lpc_compute_autocorrelation_intrin_fma_lag_9(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[])
 {
 #undef MAX_LAG
-#define MAX_LAG 8
+#define MAX_LAG 9
 #include "deduplication/lpc_compute_autocorrelation_intrin.c"
 }
 
 FLAC__SSE_TARGET("fma")
-void FLAC__lpc_compute_autocorrelation_intrin_fma_lag_12(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[])
+void FLAC__lpc_compute_autocorrelation_intrin_fma_lag_13(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[])
 {
 #undef MAX_LAG
-#define MAX_LAG 12
+#define MAX_LAG 13
 #include "deduplication/lpc_compute_autocorrelation_intrin.c"
 }
 FLAC__SSE_TARGET("fma")
-void FLAC__lpc_compute_autocorrelation_intrin_fma_lag_16(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[])
+void FLAC__lpc_compute_autocorrelation_intrin_fma_lag_33(const FLAC__real data[], uint32_t data_len, uint32_t lag, double autoc[])
 {
 #undef MAX_LAG
-#define MAX_LAG 16
+#define MAX_LAG 33
 #include "deduplication/lpc_compute_autocorrelation_intrin.c"
-
 }
 
 #endif /* FLAC__FMA_SUPPORTED */

--- a/src/libFLAC/lpc_intrin_neon.c
+++ b/src/libFLAC/lpc_intrin_neon.c
@@ -1203,66 +1203,11 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients_wide_intrin_neon(const FLA
     }
     else
     { /* order > 12 */
-        for (i = 0; i < (int)data_len; i++)
-        {
-            sum = 0;
-            switch (order)
-            {
-            case 32:
-                sum += qlp_coeff[31] * (FLAC__int64)data[i - 32]; /* Falls through. */
-            case 31:
-                sum += qlp_coeff[30] * (FLAC__int64)data[i - 31]; /* Falls through. */
-            case 30:
-                sum += qlp_coeff[29] * (FLAC__int64)data[i - 30]; /* Falls through. */
-            case 29:
-                sum += qlp_coeff[28] * (FLAC__int64)data[i - 29]; /* Falls through. */
-            case 28:
-                sum += qlp_coeff[27] * (FLAC__int64)data[i - 28]; /* Falls through. */
-            case 27:
-                sum += qlp_coeff[26] * (FLAC__int64)data[i - 27]; /* Falls through. */
-            case 26:
-                sum += qlp_coeff[25] * (FLAC__int64)data[i - 26]; /* Falls through. */
-            case 25:
-                sum += qlp_coeff[24] * (FLAC__int64)data[i - 25]; /* Falls through. */
-            case 24:
-                sum += qlp_coeff[23] * (FLAC__int64)data[i - 24]; /* Falls through. */
-            case 23:
-                sum += qlp_coeff[22] * (FLAC__int64)data[i - 23]; /* Falls through. */
-            case 22:
-                sum += qlp_coeff[21] * (FLAC__int64)data[i - 22]; /* Falls through. */
-            case 21:
-                sum += qlp_coeff[20] * (FLAC__int64)data[i - 21]; /* Falls through. */
-            case 20:
-                sum += qlp_coeff[19] * (FLAC__int64)data[i - 20]; /* Falls through. */
-            case 19:
-                sum += qlp_coeff[18] * (FLAC__int64)data[i - 19]; /* Falls through. */
-            case 18:
-                sum += qlp_coeff[17] * (FLAC__int64)data[i - 18]; /* Falls through. */
-            case 17:
-                sum += qlp_coeff[16] * (FLAC__int64)data[i - 17]; /* Falls through. */
-            case 16:
-                sum += qlp_coeff[15] * (FLAC__int64)data[i - 16]; /* Falls through. */
-            case 15:
-                sum += qlp_coeff[14] * (FLAC__int64)data[i - 15]; /* Falls through. */
-            case 14:
-                sum += qlp_coeff[13] * (FLAC__int64)data[i - 14]; /* Falls through. */
-            case 13:
-                sum += qlp_coeff[12] * (FLAC__int64)data[i - 13];
-                sum += qlp_coeff[11] * (FLAC__int64)data[i - 12];
-                sum += qlp_coeff[10] * (FLAC__int64)data[i - 11];
-                sum += qlp_coeff[9] * (FLAC__int64)data[i - 10];	
-                sum += qlp_coeff[8] * (FLAC__int64)data[i - 9];
-                sum += qlp_coeff[7] * (FLAC__int64)data[i - 8];
-                sum += qlp_coeff[6] * (FLAC__int64)data[i - 7];
-                sum += qlp_coeff[5] * (FLAC__int64)data[i - 6];
-                sum += qlp_coeff[4] * (FLAC__int64)data[i - 5];
-                sum += qlp_coeff[3] * (FLAC__int64)data[i - 4];
-                sum += qlp_coeff[2] * (FLAC__int64)data[i - 3];
-                sum += qlp_coeff[1] * (FLAC__int64)data[i - 2];
-                sum += qlp_coeff[0] * (FLAC__int64)data[i - 1];
-            }
-            residual[i] = data[i] - (sum >> lp_quantization);
-        }
+#undef FLAC__LPC_DATA_TYPE
+#undef FLAC__LPC_ACTION
+#define FLAC__LPC_DATA_TYPE FLAC__int64
+#define FLAC__LPC_ACTION residual[i] = data[i] - (FLAC__int32)(sum >> lp_quantization);
+#include "deduplication/lpc_compute_and_use_predictor_above_12.c"
     }
 
     return;

--- a/src/libFLAC/lpc_intrin_sse41.c
+++ b/src/libFLAC/lpc_intrin_sse41.c
@@ -547,44 +547,11 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients_wide_intrin_sse41(const FL
 	}
 	else { /* order > 12 */
 		FLAC__int64 sum;
-		for(i = 0; i < (int)data_len; i++) {
-			sum = 0;
-			switch(order) {
-				case 32: sum += qlp_coeff[31] * (FLAC__int64)data[i-32]; /* Falls through. */
-				case 31: sum += qlp_coeff[30] * (FLAC__int64)data[i-31]; /* Falls through. */
-				case 30: sum += qlp_coeff[29] * (FLAC__int64)data[i-30]; /* Falls through. */
-				case 29: sum += qlp_coeff[28] * (FLAC__int64)data[i-29]; /* Falls through. */
-				case 28: sum += qlp_coeff[27] * (FLAC__int64)data[i-28]; /* Falls through. */
-				case 27: sum += qlp_coeff[26] * (FLAC__int64)data[i-27]; /* Falls through. */
-				case 26: sum += qlp_coeff[25] * (FLAC__int64)data[i-26]; /* Falls through. */
-				case 25: sum += qlp_coeff[24] * (FLAC__int64)data[i-25]; /* Falls through. */
-				case 24: sum += qlp_coeff[23] * (FLAC__int64)data[i-24]; /* Falls through. */
-				case 23: sum += qlp_coeff[22] * (FLAC__int64)data[i-23]; /* Falls through. */
-				case 22: sum += qlp_coeff[21] * (FLAC__int64)data[i-22]; /* Falls through. */
-				case 21: sum += qlp_coeff[20] * (FLAC__int64)data[i-21]; /* Falls through. */
-				case 20: sum += qlp_coeff[19] * (FLAC__int64)data[i-20]; /* Falls through. */
-				case 19: sum += qlp_coeff[18] * (FLAC__int64)data[i-19]; /* Falls through. */
-				case 18: sum += qlp_coeff[17] * (FLAC__int64)data[i-18]; /* Falls through. */
-				case 17: sum += qlp_coeff[16] * (FLAC__int64)data[i-17]; /* Falls through. */
-				case 16: sum += qlp_coeff[15] * (FLAC__int64)data[i-16]; /* Falls through. */
-				case 15: sum += qlp_coeff[14] * (FLAC__int64)data[i-15]; /* Falls through. */
-				case 14: sum += qlp_coeff[13] * (FLAC__int64)data[i-14]; /* Falls through. */
-				case 13: sum += qlp_coeff[12] * (FLAC__int64)data[i-13];
-				         sum += qlp_coeff[11] * (FLAC__int64)data[i-12];
-				         sum += qlp_coeff[10] * (FLAC__int64)data[i-11];
-				         sum += qlp_coeff[ 9] * (FLAC__int64)data[i-10];
-				         sum += qlp_coeff[ 8] * (FLAC__int64)data[i- 9];
-				         sum += qlp_coeff[ 7] * (FLAC__int64)data[i- 8];
-				         sum += qlp_coeff[ 6] * (FLAC__int64)data[i- 7];
-				         sum += qlp_coeff[ 5] * (FLAC__int64)data[i- 6];
-				         sum += qlp_coeff[ 4] * (FLAC__int64)data[i- 5];
-				         sum += qlp_coeff[ 3] * (FLAC__int64)data[i- 4];
-				         sum += qlp_coeff[ 2] * (FLAC__int64)data[i- 3];
-				         sum += qlp_coeff[ 1] * (FLAC__int64)data[i- 2];
-				         sum += qlp_coeff[ 0] * (FLAC__int64)data[i- 1];
-			}
-			residual[i] = data[i] - (FLAC__int32)(sum >> lp_quantization);
-		}
+		#undef FLAC__LPC_DATA_TYPE
+		#undef FLAC__LPC_ACTION
+		#define FLAC__LPC_DATA_TYPE FLAC__int64
+		#define FLAC__LPC_ACTION residual[i] = data[i] - (FLAC__int32)(sum >> lp_quantization);
+		#include "deduplication/lpc_compute_and_use_predictor_above_12.c"
 	}
 }
 

--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -3623,7 +3623,7 @@ FLAC__bool process_subframe_(
 							min_lpc_order = max_lpc_order_this_apodization = guess_lpc_order;
 						}
 						for(lpc_order = min_lpc_order; lpc_order <= max_lpc_order_this_apodization; lpc_order++) {
-							lpc_residual_bits_per_sample = FLAC__lpc_compute_expected_bits_per_residual_sample(lpc_error[lpc_order-1], frame_header->blocksize-lpc_order);
+							lpc_residual_bits_per_sample = FLAC__lpc_compute_expected_bits_per_residual_sample(lpc_error[lpc_order-1], frame_header->blocksize/apply_apodization_state.b-lpc_order);
 							if(lpc_residual_bits_per_sample >= (double)subframe_bps)
 								continue; /* don't even try */
 							if(encoder->protected_->do_qlp_coeff_prec_search) {
@@ -3778,7 +3778,7 @@ FLAC__bool apply_apodization_(FLAC__StreamEncoder *encoder,
 	FLAC__lpc_compute_best_order(
 		lpc_error,
 		*max_lpc_order_this_apodization,
-		blocksize,
+		blocksize/apply_apodization_state->b,
 		subframe_bps + (
 			encoder->protected_->do_qlp_coeff_prec_search?
 				FLAC__MIN_QLP_COEFF_PRECISION : /* have to guess; use the min possible size to avoid accidentally favoring lower orders */

--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -1043,12 +1043,12 @@ static FLAC__StreamEncoderInitStatus init_stream_internal_(
 #    endif
 #    ifdef FLAC__FMA_SUPPORTED
 		if(encoder->private_->cpuinfo.x86.fma) {
-			if(encoder->protected_->max_lpc_order < 8)
-				encoder->private_->local_lpc_compute_autocorrelation = FLAC__lpc_compute_autocorrelation_intrin_fma_lag_8;
-			else if(encoder->protected_->max_lpc_order < 12)
-				encoder->private_->local_lpc_compute_autocorrelation = FLAC__lpc_compute_autocorrelation_intrin_fma_lag_12;
-			else if(encoder->protected_->max_lpc_order < 16)
-				encoder->private_->local_lpc_compute_autocorrelation = FLAC__lpc_compute_autocorrelation_intrin_fma_lag_16;
+			if(encoder->protected_->max_lpc_order <= 8)
+				encoder->private_->local_lpc_compute_autocorrelation = FLAC__lpc_compute_autocorrelation_intrin_fma_lag_9;
+			else if(encoder->protected_->max_lpc_order <= 12)
+				encoder->private_->local_lpc_compute_autocorrelation = FLAC__lpc_compute_autocorrelation_intrin_fma_lag_13;
+			else
+				encoder->private_->local_lpc_compute_autocorrelation = FLAC__lpc_compute_autocorrelation_intrin_fma_lag_33;
 		}
 #    endif
 


### PR DESCRIPTION
The compression levels in FLAC have been kept the same for a long time, only preset 6, 7 and 8 got a retune 10 years ago. However, as some parts of FLAC got much faster, I felt it was time to retune the presets.

The presets as they currently are mostly add complexity as the level goes up, increasing encoding time and improving compression more or less monotonically.

The presets as this PR proposes them are more like the approach TAK (Tom's lossless Audio Kompressor) has to presets: grouping them based on decoding speed. Preset 0, 1 and 2 are the fastest decoding, presets 3, 4 and 5 are a little less fast and presets 6, 7 and 8 are the slowest (but still pretty fast!).

Within those groups, the first of the presets (0, 3 and 6) encode the fastest, the second of the presets (1, 4 and 7) compress a little better, and the last of the presets (2, 5 and 8) encode the best/slowest.

The advantage of this approach is that presets are more clearly differentiated. Currently, I find it kind of hard justifying the use of presets 0 (because 1 is almost as fast but compressed much better), 3 (same reason) and 6 (same reason).

All changes
- presets 0, 1 and 2 go from blocksize 1152 to blocksize 4096
- preset 0 switches from no stereo decorrelation to 'loose mid-side'
- preset 1 increases its max rice partition order from 3 to 5
- preset 2 increases its max rice partition order from 3 to 6, and does exhaustive predictor order search
- preset 3 switches from no stereo decorrelation to 'loose mid-side', increases its max predictor order to 8 and lowers its max rice partition order to 3
- preset 4 takes on the options from former preset 5
- preset 5 takes on the options from former preset 6
- preset 6 increases its max predictor order from 8 to 32, lowers its max rice partition order from 6 to 3 and switches apodization from subdivide_tukey(2) to tukey(5e-1)
- preset 7 increases its max predictor order from 12 to 32, lowers its max rice partition order from 6 to 5 and switches apodization from subdivide_tukey(2) to tukey(5e-1)
- preset 8 increases its max predictor order from 12 to 32. increases its max rice partition order from 6 to 8 and switches apodization from subdivide_tukey(3) to subdivide_tukey(2)
- for presets 6, 7 and 8, the max predictor order (32) is limited to 12 when encoding material with a sample rate of 48kHz or lower, to stay within subset limits

This probably seems rather confusing. Hopefully some graphs help. 

Here is data for 24-bit tracks. Presets 0 through 8 go from top left to bottom right.
[set of 24bit tracks.pdf](https://github.com/xiph/flac/files/11089432/set.of.24bit.tracks.pdf)

Compression seems to increase monotonically, however, this is not always the case. Here are the results split by track. Page 4 shows a very clear case where preset 6 gives a file larger than preset 4 and preset 7 gives a file larger than preset 5. On average, this retune improves compression however.
[set of 24bit tracks-per-track.pdf](https://github.com/xiph/flac/files/11089443/set.of.24bit.tracks-per-track.pdf)

Here is data for 16-bit tracks. 
[very large set of tracks.pdf](https://github.com/xiph/flac/files/11089490/very.large.set.of.tracks.pdf)

Also per track:
[very large set of tracks-per-track.pdf](https://github.com/xiph/flac/files/11089540/very.large.set.of.tracks-per-track.pdf)

At the time of writing this, the PR doesn't yet update the documentation.