### PR TITLE
Fix use-after-free warning in GCC 12

### DIFF
--- a/src/share/utf8/iconvert.c
+++ b/src/share/utf8/iconvert.c
@@ -62,7 +62,7 @@ int iconvert(const char *fromcode, const char *tocode,
   char *ib;
   char *ob;
   char *utfbuf = 0, *outbuf, *newbuf;
-  size_t utflen, outlen, ibl, obl, k;
+  size_t utflen, outlen, ibl, obl, obp, k;
   char tbuf[2048];
 
   cd1 = iconv_open("UTF-8", fromcode);
@@ -124,11 +124,12 @@ int iconvert(const char *fromcode, const char *tocode,
       if(utflen*2 < utflen) /* overflow check */
 	goto fail;
       utflen *= 2;
+      obp = ob - utfbuf; /* save position */
       newbuf = realloc(utfbuf, utflen);
       if (!newbuf)
 	goto fail;
-      ob = (ob - utfbuf) + newbuf;
-      obl = utflen - (ob - newbuf);
+      ob = newbuf + obp;
+      obl = utflen - obp;
       utfbuf = newbuf;
     }
     else {


### PR DESCRIPTION
A pointer was used for arithmatic after a realloc.