### PR TITLE
Stop processing subframes when invalid data is found

### DIFF
--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -2095,6 +2095,8 @@ FLAC__bool read_frame_(FLAC__StreamDecoder *decoder, FLAC__bool *got_a_frame, FL
 			else
 				return false;
 		}
+		if(decoder->protected_->state != FLAC__STREAM_DECODER_READ_FRAME)
+			break;
 	}
 
 	if(decoder->protected_->state != FLAC__STREAM_DECODER_END_OF_STREAM)


### PR DESCRIPTION
This fixes https://github.com/xiph/flac/issues/580

The problem was that after encountering a problem in a first subframe, the state was changed from READ_FRAME to SEARCH_FOR_FRAME_SYNC, which meant a problem in the second subframe was interpreted as a read error instead of invalid data.

With this patch, processing of subframes is stopped after setting SEARCH_FOR_FRAME_SYNC