### PR TITLE
Fix compilation of getopt1.c on Intel Compiler with LLVM backend

### DIFF
--- a/src/share/getopt/getopt1.c
+++ b/src/share/getopt/getopt1.c
@@ -36,9 +36,6 @@
 #  include <config.h>
 #endif
 
-#include "share/getopt.h"
-/*[JEC] was:#include "getopt.h"*/
-
 #if !defined __STDC__ || !__STDC__
 /* This is a separate conditional since some stdc systems
    reject `defined (const)'.  */
@@ -48,6 +45,9 @@
 #endif
 
 #include <stdio.h>
+
+#include "share/getopt.h"
+/*[JEC] was:#include "getopt.h"*/
 
 /* Comment out all this code if we are using the GNU C Library, and are not
    actually compiling the library itself.  This code is part of the GNU C


### PR DESCRIPTION
This mirrors a change in 2005 to the GCC getopt1.c.