### PR TITLE
Throw error on too large foreign metadata directly

### DIFF
--- a/src/flac/foreign_metadata.c
+++ b/src/flac/foreign_metadata.c
@@ -99,7 +99,12 @@ static FLAC__bool compare_data_(FILE *fin, FILE *fout, size_t size, const char *
 
 static FLAC__bool append_block_(foreign_metadata_t *fm, FLAC__off_t offset, FLAC__uint32 size, const char **error)
 {
-	foreign_block_t *fb = safe_realloc_nofree_muladd2_(fm->blocks, sizeof(foreign_block_t), /*times (*/fm->num_blocks, /*+*/1/*)*/);
+	foreign_block_t *fb;
+	if(size >= (1u << FLAC__STREAM_METADATA_LENGTH_LEN)) {
+		if(error) *error = "found foreign metadata chunk is too large (max is 16MiB per chunk)";
+		return false;
+	}
+	fb = safe_realloc_nofree_muladd2_(fm->blocks, sizeof(foreign_block_t), /*times (*/fm->num_blocks, /*+*/1/*)*/);
 	if(fb) {
 		fb[fm->num_blocks].offset = offset;
 		fb[fm->num_blocks].size = size;


### PR DESCRIPTION
Previously, too large chunks of foreign metadata (> 16MiB) were signalled by libFLAC, throwing an error upon adding the metadata, so flac gave a rather vague error back to the user. This commit adds detection to the foreign metadata handling, so the user gets a much clearer error.

Credit: Oss-Fuzz
Issue: N/A