### PR TITLE
Use correct argument type for _BitScanReverse and _BitScanReverse64.

### DIFF
--- a/src/libFLAC/include/private/bitmath.h
+++ b/src/libFLAC/include/private/bitmath.h
@@ -82,7 +82,7 @@ static inline uint32_t FLAC__clz_uint32(FLAC__uint32 v)
 	return __builtin_clz(v);
 #elif defined(_MSC_VER)
 	{
-		uint32_t idx;
+		unsigned long idx;
 		_BitScanReverse(&idx, v);
 		return idx ^ 31U;
 	}
@@ -106,7 +106,7 @@ static inline uint32_t FLAC__clz_uint64(FLAC__uint64 v)
 	return __builtin_clzll(v);
 #elif (defined(__INTEL_COMPILER) || defined(_MSC_VER)) && (defined(_M_IA64) || defined(_M_X64))
 	{
-		uint32_t idx;
+		unsigned long idx;
 		_BitScanReverse64(&idx, v);
 		return idx ^ 63U;
 	}
@@ -160,7 +160,7 @@ static inline uint32_t FLAC__bitmath_ilog2(FLAC__uint32 v)
 	return _bit_scan_reverse(v);
 #elif defined(_MSC_VER)
 	{
-		uint32_t idx;
+		unsigned long idx;
 		_BitScanReverse(&idx, v);
 		return idx;
 	}
@@ -177,7 +177,7 @@ static inline uint32_t FLAC__bitmath_ilog2_wide(FLAC__uint64 v)
 /* Sorry, only supported in x64/Itanium.. and both have fast FPU which makes integer-only encoder pointless */
 #elif (defined(__INTEL_COMPILER) || defined(_MSC_VER)) && (defined(_M_IA64) || defined(_M_X64))
 	{
-		uint32_t idx;
+		unsigned long idx;
 		_BitScanReverse64(&idx, v);
 		return idx;
 	}


### PR DESCRIPTION
_BitScanReverse and _BitScanReverse64 are documented to take an `unsigned long *` as the first argument (see <https://learn.microsoft.com/en-us/cpp/intrinsics/bitscanreverse-bitscanreverse64?view=msvc-170>), however libFLAC used `uint32_t` which happens to be `unsigned int`.

This silences Clang warning `incompatible pointer types passing 'uint32_t *' (aka 'unsigned int *') to parameter of type 'unsigned long *' [-Wincompatible-pointer-types]`.

Fixes https://github.com/xiph/flac/issues/637