### PR TITLE
flac: foreign_metadata: fix -Walloc-size

### DIFF
--- a/src/flac/foreign_metadata.c
+++ b/src/flac/foreign_metadata.c
@@ -800,7 +800,7 @@ static FLAC__bool compare_with_iff_(foreign_metadata_t *fm, FILE *fin, FILE *fou
 foreign_metadata_t *flac__foreign_metadata_new(foreign_block_type_t type)
 {
 	/* calloc() to zero all the member variables */
-	foreign_metadata_t *x = calloc(sizeof(foreign_metadata_t), 1);
+	foreign_metadata_t *x = calloc(1, sizeof(foreign_metadata_t));
 	if(x) {
 		x->type = type;
 		x->is_rf64 = false;


### PR DESCRIPTION
GCC 14 introduces a new -Walloc-size included in -Wextra which gives:
```
src/flac/foreign_metadata.c:803:33: warning: allocation of insufficient size ‘1’ for type ‘foreign_metadata_t’ with size ‘64’ [-Walloc-size]
```

The calloc prototype is:
```
void *calloc(size_t nmemb, size_t size);
```

So, just swap the number of members and size arguments to match the prototype, as we're initialising 1 struct of size `sizeof(foreign_metadata_t)`. GCC then sees we're not doing anything wrong.