### PR TITLE
Add the needed Android API check for fseeko and ftello.

### DIFF
--- a/include/share/compat.h
+++ b/include/share/compat.h
@@ -213,6 +213,10 @@
 
 #ifdef ANDROID
 #include <limits.h>
+#if __ANDROID_API__ < 24
+#define fseeko fseek
+#define ftello ftell
+#endif
 #endif
 
 #ifndef M_LN2


### PR DESCRIPTION
fseeko and ftello are available on Android API 24 or later. 

See for the libc src. https://android.googlesource.com/platform/bionic/+/master/libc/include/stdio.h#211

![image](https://github.com/xiph/flac/assets/152442088/e5f1f29e-c66b-4d18-a6e8-88c0269bf449)
