### PR TITLE
Optimize NEON encoding for high dynamic range blocks

### DIFF
--- a/src/libFLAC/include/private/lpc.h
+++ b/src/libFLAC/include/private/lpc.h
@@ -160,6 +160,7 @@ FLAC__bool FLAC__lpc_compute_residual_from_qlp_coefficients_limit_residual_33bit
 #   ifdef FLAC__CPU_ARM64
 void FLAC__lpc_compute_residual_from_qlp_coefficients_intrin_neon(const FLAC__int32 *data, uint32_t data_len, const FLAC__int32 qlp_coeff[], uint32_t order, int lp_quantization, FLAC__int32 residual[]);
 void FLAC__lpc_compute_residual_from_qlp_coefficients_wide_intrin_neon(const FLAC__int32 *data, uint32_t data_len, const FLAC__int32 qlp_coeff[], uint32_t order, int lp_quantization, FLAC__int32 residual[]);
+FLAC__bool FLAC__lpc_compute_residual_from_qlp_coefficients_limit_residual_neon(const FLAC__int32 *  data, uint32_t data_len, const FLAC__int32  qlp_coeff[], uint32_t order, int lp_quantization, FLAC__int32 residual[]);
 #   endif
 
 #  if (defined FLAC__CPU_IA32 || defined FLAC__CPU_X86_64) && FLAC__HAS_X86INTRIN

--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -448,6 +448,7 @@ typedef struct FLAC__StreamEncoderPrivate {
 	void (*local_lpc_compute_residual_from_qlp_coefficients)(const FLAC__int32 *data, uint32_t data_len, const FLAC__int32 qlp_coeff[], uint32_t order, int lp_quantization, FLAC__int32 residual[]);
 	void (*local_lpc_compute_residual_from_qlp_coefficients_64bit)(const FLAC__int32 *data, uint32_t data_len, const FLAC__int32 qlp_coeff[], uint32_t order, int lp_quantization, FLAC__int32 residual[]);
 	void (*local_lpc_compute_residual_from_qlp_coefficients_16bit)(const FLAC__int32 *data, uint32_t data_len, const FLAC__int32 qlp_coeff[], uint32_t order, int lp_quantization, FLAC__int32 residual[]);
+	FLAC__bool (*local_lpc_compute_residual_from_qlp_coefficients_limit_residual)(const FLAC__int32 * flac_restrict data, uint32_t data_len, const FLAC__int32 * flac_restrict qlp_coeff, uint32_t order, int lp_quantization, FLAC__int32 * flac_restrict residual);
 #endif
 	FLAC__bool disable_mmx;
 	FLAC__bool disable_sse2;
@@ -981,6 +982,7 @@ static FLAC__StreamEncoderInitStatus init_stream_internal_(
 	encoder->private_->local_lpc_compute_residual_from_qlp_coefficients = FLAC__lpc_compute_residual_from_qlp_coefficients;
 	encoder->private_->local_lpc_compute_residual_from_qlp_coefficients_64bit = FLAC__lpc_compute_residual_from_qlp_coefficients_wide;
 	encoder->private_->local_lpc_compute_residual_from_qlp_coefficients_16bit = FLAC__lpc_compute_residual_from_qlp_coefficients;
+	encoder->private_->local_lpc_compute_residual_from_qlp_coefficients_limit_residual = FLAC__lpc_compute_residual_from_qlp_coefficients_limit_residual;
 #endif
 	/* now override with asm where appropriate */
 #ifndef FLAC__INTEGER_ONLY_LIBRARY
@@ -996,9 +998,10 @@ static FLAC__StreamEncoderInitStatus init_stream_internal_(
 	else
 		encoder->private_->local_lpc_compute_autocorrelation = FLAC__lpc_compute_autocorrelation;
 #endif
-    encoder->private_->local_lpc_compute_residual_from_qlp_coefficients_16bit = FLAC__lpc_compute_residual_from_qlp_coefficients_intrin_neon;
-    encoder->private_->local_lpc_compute_residual_from_qlp_coefficients       = FLAC__lpc_compute_residual_from_qlp_coefficients_intrin_neon;
-    encoder->private_->local_lpc_compute_residual_from_qlp_coefficients_64bit = FLAC__lpc_compute_residual_from_qlp_coefficients_wide_intrin_neon;
+    encoder->private_->local_lpc_compute_residual_from_qlp_coefficients_16bit 			= FLAC__lpc_compute_residual_from_qlp_coefficients_intrin_neon;
+    encoder->private_->local_lpc_compute_residual_from_qlp_coefficients       			= FLAC__lpc_compute_residual_from_qlp_coefficients_intrin_neon;
+    encoder->private_->local_lpc_compute_residual_from_qlp_coefficients_64bit 			= FLAC__lpc_compute_residual_from_qlp_coefficients_wide_intrin_neon;
+	encoder->private_->local_lpc_compute_residual_from_qlp_coefficients_limit_residual	= FLAC__lpc_compute_residual_from_qlp_coefficients_limit_residual_neon;
 #endif /* defined FLAC__CPU_ARM64 && FLAC__HAS_NEONINTRIN */
 
 	if(encoder->private_->cpuinfo.use_asm) {
@@ -4511,7 +4514,7 @@ uint32_t evaluate_lpc_subframe_(
 
 	if(FLAC__lpc_max_residual_bps(subframe_bps, qlp_coeff, order, quantization) > 32) {
 		if(subframe_bps <= 32){
-			if(!FLAC__lpc_compute_residual_from_qlp_coefficients_limit_residual(((FLAC__int32 *)signal)+order, residual_samples, qlp_coeff, order, quantization, residual))
+			if(!encoder->private_->local_lpc_compute_residual_from_qlp_coefficients_limit_residual(((FLAC__int32 *)signal)+order, residual_samples, qlp_coeff, order, quantization, residual))
 				return 0;
 		}
 		else


### PR DESCRIPTION
We can improve the encoding performance on Apple silicon configurations with the following enhancements

- Replace the switch with a for loop
- Invert qlp_factors & remove else conditions as branches not taken are returned out

13% - 17% improvement depending on compiler, configuration and .wav

Clang 16 or GCC 13 necessary

| Platform | MBP18,2 | Mac14,12 | AMD Ryzen 9 7900X x 24 |
| Compiler | GCC 13 | Clang 16 | GCC 13 | Clang 16 | GNU 13.2.1 | 
| Original | 6.554 | 6.176 | 5.725 | 5.377 | 5.018 |
| Optimized | 5.642 | 5.131 | 4.803 | 4.672 | 5 |
| Overall | 14% | 17% | 16% | 13% | 0