### PR TITLE
Update github action dependencies to latest versions

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -57,9 +57,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: startsWith(matrix.build-system,'cmake')
         with:
           repository: xiph/ogg
@@ -125,7 +125,7 @@ jobs:
         run: ctest -V -C Release
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -28,7 +28,7 @@ jobs:
        fuzz-seconds: 7200
        sanitizer: ${{ matrix.sanitizer }}
    - name: Upload Crash
-     uses: actions/upload-artifact@v1
+     uses: actions/upload-artifact@v4
      if: failure() && steps.build.outcome == 'success'
      with:
        name: ${{ matrix.sanitizer }}-artifacts

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -11,9 +11,9 @@ jobs:
   distcheck:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ietf-wg-cellar/flac-test-files
           path: ./test-files
@@ -43,14 +43,14 @@ jobs:
         run: ./src/flac/flac -t test-files/subset/*.flac test-files/uncommon/0[5-9]*.flac test-files/uncommon/10*.flac
 
       - name: Upload ABI compliance reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-compat
           path: |
             ./compat_reports
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs

--- a/.github/workflows/options.yml
+++ b/.github/workflows/options.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
@@ -41,7 +41,7 @@ jobs:
           make check
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs


### PR DESCRIPTION
As described here: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/