### PR TITLE
Fix CMake Doxygen install (match Makefile builds)

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -22,5 +22,5 @@ add_custom_target(FLAC-doxygen ALL
         COMMENT "Generating API documentation with Doxygen"
         VERBATIM )
 
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/api/"
+install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/doxytmp/html/"
         DESTINATION "${CMAKE_INSTALL_DOCDIR}/api")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,26 +1,32 @@
 cmake_minimum_required(VERSION 3.9)
 
-find_package(Doxygen)
+option(BUILD_DOXYGEN "Enable API documentation building via Doxygen if not already present" ON)
 
-if (NOT DOXYGEN_FOUND)
-    return()
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/api")
+
+    find_package(Doxygen)
+
+    if (NOT DOXYGEN_FOUND)
+        return()
+    endif()
+
+    if (NOT BUILD_DOXYGEN)
+        return()
+    endif()
+
+    set(top_srcdir "${PROJECT_SOURCE_DIR}")
+    configure_file(Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+
+
+    add_custom_target(FLAC-doxygen ALL
+            COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            COMMENT "Generating API documentation with Doxygen"
+            VERBATIM )
+
+    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/doxytmp/html/"
+            DESTINATION "${CMAKE_INSTALL_DOCDIR}/api")
+else()
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/api/"
+            DESTINATION "${CMAKE_INSTALL_DOCDIR}/api")
 endif()
-
-option(BUILD_DOXYGEN "Enable API documentation building via Doxygen" ON)
-
-if (NOT BUILD_DOXYGEN)
-    return()
-endif()
-
-set(top_srcdir "${PROJECT_SOURCE_DIR}")
-configure_file(Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-
-
-add_custom_target(FLAC-doxygen ALL
-        COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        COMMENT "Generating API documentation with Doxygen"
-        VERBATIM )
-
-install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/doxytmp/html/"
-        DESTINATION "${CMAKE_INSTALL_DOCDIR}/api")


### PR DESCRIPTION
The CMake install was trying to install `<gitroot>/docs/api/` instead of `<buildroot>/docs/doxytemp/`. Matches Makefile behavior.