### PR TITLE
disable fseeko in android before API 24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,15 @@ else()
     check_include_file("x86intrin.h" FLAC__HAS_X86INTRIN)
 endif()
 
-check_function_exists(fseeko HAVE_FSEEKO)
+
+if(ANDROID AND CMAKE_SYSTEM_VERSION VERSION_LESS 24 AND (CMAKE_SYSTEM_PROCESSOR MATCHES "i686" OR CMAKE_SYSTEM_PROCESSOR MATCHES "armv7-a"))
+    # fseeko/ftello may link, but it's not usable before Android API 24 on 32-bit Android
+    # https://android.googlesource.com/platform/bionic/+/main/docs/32-bit-abi.md
+    message(STATUS "Disabling fseeko/ftello for 32-bit Android before API 24")
+    set(HAVE_FSEEKO 0 CACHE INTERNAL "")
+else()
+    check_function_exists(fseeko HAVE_FSEEKO)
+endif()
 
 check_c_source_compiles("int main() { return __builtin_bswap16 (0) ; }" HAVE_BSWAP16)
 check_c_source_compiles("int main() { return __builtin_bswap32 (0) ; }" HAVE_BSWAP32)

--- a/include/share/compat.h
+++ b/include/share/compat.h
@@ -63,8 +63,15 @@
 #endif
 #endif
 #else
+#ifndef HAVE_FSEEKO
+#define fseeko fseek
+#define ftello ftell
+#define FLAC__off_t long
+#define FLAC__OFF_T_MAX LONG_MAX
+#else
 #define FLAC__off_t off_t
 #define FLAC__OFF_T_MAX OFF_T_MAX
+#endif
 #endif
 
 


### PR DESCRIPTION
It can be linked in the NDK so `check_function_exists()` detects it. But it's only supporting `_FILE_OFFSET_BITS=64`
[since Android API 24](https://android.googlesource.com/platform/bionic/+/main/docs/32-bit-abi.md).

With NDK 26 it's no longer possible to build assuming the API is always available.

Fallback to 32-bit fseek/ftell whenever `HAVE_FSEEKO` is not set.