### PR TITLE
Enable better vectorization for generic convolution

### DIFF
--- a/src/libFLAC/lpc.c
+++ b/src/libFLAC/lpc.c
@@ -359,7 +359,7 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients(const FLAC__int32 * flac_r
 #else /* fully unrolled version for normal use */
 {
 	int i;
-	FLAC__int32 sum;
+	FLAC__int32 sum0, sum1;
 
 	FLAC__ASSERT(order > 0);
 	FLAC__ASSERT(order <= 32);
@@ -374,70 +374,74 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients(const FLAC__int32 * flac_r
 			if(order > 10) {
 				if(order == 12) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[11] * data[i-12];
-						sum += qlp_coeff[10] * data[i-11];
-						sum += qlp_coeff[9] * data[i-10];
-						sum += qlp_coeff[8] * data[i-9];
-						sum += qlp_coeff[7] * data[i-8];
-						sum += qlp_coeff[6] * data[i-7];
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[11] * data[i-12];
+						sum1 += qlp_coeff[10] * data[i-11];
+						sum0 += qlp_coeff[9] * data[i-10];
+						sum1 += qlp_coeff[8] * data[i-9];
+						sum0 += qlp_coeff[7] * data[i-8];
+						sum1 += qlp_coeff[6] * data[i-7];
+						sum0 += qlp_coeff[5] * data[i-6];
+						sum1 += qlp_coeff[4] * data[i-5];
+						sum0 += qlp_coeff[3] * data[i-4];
+						sum1 += qlp_coeff[2] * data[i-3];
+						sum0 += qlp_coeff[1] * data[i-2];
+						sum1 += qlp_coeff[0] * data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 11 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[10] * data[i-11];
-						sum += qlp_coeff[9] * data[i-10];
-						sum += qlp_coeff[8] * data[i-9];
-						sum += qlp_coeff[7] * data[i-8];
-						sum += qlp_coeff[6] * data[i-7];
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[10] * data[i-11];
+						sum1 += qlp_coeff[9] * data[i-10];
+						sum0 += qlp_coeff[8] * data[i-9];
+						sum1 += qlp_coeff[7] * data[i-8];
+						sum0 += qlp_coeff[6] * data[i-7];
+						sum1 += qlp_coeff[5] * data[i-6];
+						sum0 += qlp_coeff[4] * data[i-5];
+						sum1 += qlp_coeff[3] * data[i-4];
+						sum0 += qlp_coeff[2] * data[i-3];
+						sum1 += qlp_coeff[1] * data[i-2];
+						sum0 += qlp_coeff[0] * data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
 			else {
 				if(order == 10) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[9] * data[i-10];
-						sum += qlp_coeff[8] * data[i-9];
-						sum += qlp_coeff[7] * data[i-8];
-						sum += qlp_coeff[6] * data[i-7];
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[9] * data[i-10];
+						sum1 += qlp_coeff[8] * data[i-9];
+						sum0 += qlp_coeff[7] * data[i-8];
+						sum1 += qlp_coeff[6] * data[i-7];
+						sum0 += qlp_coeff[5] * data[i-6];
+						sum1 += qlp_coeff[4] * data[i-5];
+						sum0 += qlp_coeff[3] * data[i-4];
+						sum1 += qlp_coeff[2] * data[i-3];
+						sum0 += qlp_coeff[1] * data[i-2];
+						sum1 += qlp_coeff[0] * data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 9 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[8] * data[i-9];
-						sum += qlp_coeff[7] * data[i-8];
-						sum += qlp_coeff[6] * data[i-7];
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[8] * data[i-9];
+						sum1 += qlp_coeff[7] * data[i-8];
+						sum0 += qlp_coeff[6] * data[i-7];
+						sum1 += qlp_coeff[5] * data[i-6];
+						sum0 += qlp_coeff[4] * data[i-5];
+						sum1 += qlp_coeff[3] * data[i-4];
+						sum0 += qlp_coeff[2] * data[i-3];
+						sum1 += qlp_coeff[1] * data[i-2];
+						sum0 += qlp_coeff[0] * data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
@@ -446,54 +450,58 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients(const FLAC__int32 * flac_r
 			if(order > 6) {
 				if(order == 8) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[7] * data[i-8];
-						sum += qlp_coeff[6] * data[i-7];
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[7] * data[i-8];
+						sum1 += qlp_coeff[6] * data[i-7];
+						sum0 += qlp_coeff[5] * data[i-6];
+						sum1 += qlp_coeff[4] * data[i-5];
+						sum0 += qlp_coeff[3] * data[i-4];
+						sum1 += qlp_coeff[2] * data[i-3];
+						sum0 += qlp_coeff[1] * data[i-2];
+						sum1 += qlp_coeff[0] * data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 7 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[6] * data[i-7];
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[6] * data[i-7];
+						sum1 += qlp_coeff[5] * data[i-6];
+						sum0 += qlp_coeff[4] * data[i-5];
+						sum1 += qlp_coeff[3] * data[i-4];
+						sum0 += qlp_coeff[2] * data[i-3];
+						sum1 += qlp_coeff[1] * data[i-2];
+						sum0 += qlp_coeff[0] * data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
 			else {
 				if(order == 6) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[5] * data[i-6];
+						sum1 += qlp_coeff[4] * data[i-5];
+						sum0 += qlp_coeff[3] * data[i-4];
+						sum1 += qlp_coeff[2] * data[i-3];
+						sum0 += qlp_coeff[1] * data[i-2];
+						sum1 += qlp_coeff[0] * data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 5 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[4] * data[i-5];
+						sum1 += qlp_coeff[3] * data[i-4];
+						sum0 += qlp_coeff[2] * data[i-3];
+						sum1 += qlp_coeff[1] * data[i-2];
+						sum0 += qlp_coeff[0] * data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
@@ -502,31 +510,34 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients(const FLAC__int32 * flac_r
 			if(order > 2) {
 				if(order == 4) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[3] * data[i-4];
+						sum1 += qlp_coeff[2] * data[i-3];
+						sum0 += qlp_coeff[1] * data[i-2];
+						sum1 += qlp_coeff[0] * data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 3 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[2] * data[i-3];
+						sum1 += qlp_coeff[1] * data[i-2];
+						sum0 += qlp_coeff[0] * data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
 			else {
 				if(order == 2) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[1] * data[i-2];
+						sum1 += qlp_coeff[0] * data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 1 */
@@ -538,42 +549,43 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients(const FLAC__int32 * flac_r
 	}
 	else { /* order > 12 */
 		for(i = 0; i < (int)data_len; i++) {
-			sum = 0;
+			sum0 = 0;
+			sum1 = 0;
 			switch(order) {
-				case 32: sum += qlp_coeff[31] * data[i-32]; /* Falls through. */
-				case 31: sum += qlp_coeff[30] * data[i-31]; /* Falls through. */
-				case 30: sum += qlp_coeff[29] * data[i-30]; /* Falls through. */
-				case 29: sum += qlp_coeff[28] * data[i-29]; /* Falls through. */
-				case 28: sum += qlp_coeff[27] * data[i-28]; /* Falls through. */
-				case 27: sum += qlp_coeff[26] * data[i-27]; /* Falls through. */
-				case 26: sum += qlp_coeff[25] * data[i-26]; /* Falls through. */
-				case 25: sum += qlp_coeff[24] * data[i-25]; /* Falls through. */
-				case 24: sum += qlp_coeff[23] * data[i-24]; /* Falls through. */
-				case 23: sum += qlp_coeff[22] * data[i-23]; /* Falls through. */
-				case 22: sum += qlp_coeff[21] * data[i-22]; /* Falls through. */
-				case 21: sum += qlp_coeff[20] * data[i-21]; /* Falls through. */
-				case 20: sum += qlp_coeff[19] * data[i-20]; /* Falls through. */
-				case 19: sum += qlp_coeff[18] * data[i-19]; /* Falls through. */
-				case 18: sum += qlp_coeff[17] * data[i-18]; /* Falls through. */
-				case 17: sum += qlp_coeff[16] * data[i-17]; /* Falls through. */
-				case 16: sum += qlp_coeff[15] * data[i-16]; /* Falls through. */
-				case 15: sum += qlp_coeff[14] * data[i-15]; /* Falls through. */
-				case 14: sum += qlp_coeff[13] * data[i-14]; /* Falls through. */
-				case 13: sum += qlp_coeff[12] * data[i-13];
-				         sum += qlp_coeff[11] * data[i-12];
-				         sum += qlp_coeff[10] * data[i-11];
-				         sum += qlp_coeff[ 9] * data[i-10];
-				         sum += qlp_coeff[ 8] * data[i- 9];
-				         sum += qlp_coeff[ 7] * data[i- 8];
-				         sum += qlp_coeff[ 6] * data[i- 7];
-				         sum += qlp_coeff[ 5] * data[i- 6];
-				         sum += qlp_coeff[ 4] * data[i- 5];
-				         sum += qlp_coeff[ 3] * data[i- 4];
-				         sum += qlp_coeff[ 2] * data[i- 3];
-				         sum += qlp_coeff[ 1] * data[i- 2];
-				         sum += qlp_coeff[ 0] * data[i- 1];
+				case 32: sum0 += qlp_coeff[31] * data[i-32]; /* Falls through. */
+				case 31: sum1 += qlp_coeff[30] * data[i-31]; /* Falls through. */
+				case 30: sum0 += qlp_coeff[29] * data[i-30]; /* Falls through. */
+				case 29: sum1 += qlp_coeff[28] * data[i-29]; /* Falls through. */
+				case 28: sum0 += qlp_coeff[27] * data[i-28]; /* Falls through. */
+				case 27: sum1 += qlp_coeff[26] * data[i-27]; /* Falls through. */
+				case 26: sum0 += qlp_coeff[25] * data[i-26]; /* Falls through. */
+				case 25: sum1 += qlp_coeff[24] * data[i-25]; /* Falls through. */
+				case 24: sum0 += qlp_coeff[23] * data[i-24]; /* Falls through. */
+				case 23: sum1 += qlp_coeff[22] * data[i-23]; /* Falls through. */
+				case 22: sum0 += qlp_coeff[21] * data[i-22]; /* Falls through. */
+				case 21: sum1 += qlp_coeff[20] * data[i-21]; /* Falls through. */
+				case 20: sum0 += qlp_coeff[19] * data[i-20]; /* Falls through. */
+				case 19: sum1 += qlp_coeff[18] * data[i-19]; /* Falls through. */
+				case 18: sum0 += qlp_coeff[17] * data[i-18]; /* Falls through. */
+				case 17: sum1 += qlp_coeff[16] * data[i-17]; /* Falls through. */
+				case 16: sum0 += qlp_coeff[15] * data[i-16]; /* Falls through. */
+				case 15: sum1 += qlp_coeff[14] * data[i-15]; /* Falls through. */
+				case 14: sum0 += qlp_coeff[13] * data[i-14]; /* Falls through. */
+				case 13: sum1 += qlp_coeff[12] * data[i-13];
+				         sum0 += qlp_coeff[11] * data[i-12];
+				         sum1 += qlp_coeff[10] * data[i-11];
+				         sum0 += qlp_coeff[ 9] * data[i-10];
+				         sum1 += qlp_coeff[ 8] * data[i- 9];
+				         sum0 += qlp_coeff[ 7] * data[i- 8];
+				         sum1 += qlp_coeff[ 6] * data[i- 7];
+				         sum0 += qlp_coeff[ 5] * data[i- 6];
+				         sum1 += qlp_coeff[ 4] * data[i- 5];
+				         sum0 += qlp_coeff[ 3] * data[i- 4];
+				         sum1 += qlp_coeff[ 2] * data[i- 3];
+				         sum0 += qlp_coeff[ 1] * data[i- 2];
+				         sum1 += qlp_coeff[ 0] * data[i- 1];
 			}
-			residual[i] = data[i] - (sum >> lp_quantization);
+			residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 		}
 	}
 }
@@ -609,7 +621,7 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients_wide(const FLAC__int32 * f
 #else /* fully unrolled version for normal use */
 {
 	int i;
-	FLAC__int64 sum;
+	FLAC__int64 sum0, sum1;
 
 	FLAC__ASSERT(order > 0);
 	FLAC__ASSERT(order <= 32);
@@ -624,70 +636,74 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients_wide(const FLAC__int32 * f
 			if(order > 10) {
 				if(order == 12) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[11] * (FLAC__int64)data[i-12];
-						sum += qlp_coeff[10] * (FLAC__int64)data[i-11];
-						sum += qlp_coeff[9] * (FLAC__int64)data[i-10];
-						sum += qlp_coeff[8] * (FLAC__int64)data[i-9];
-						sum += qlp_coeff[7] * (FLAC__int64)data[i-8];
-						sum += qlp_coeff[6] * (FLAC__int64)data[i-7];
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[11] * (FLAC__int64)data[i-12];
+						sum1 += qlp_coeff[10] * (FLAC__int64)data[i-11];
+						sum0 += qlp_coeff[9] * (FLAC__int64)data[i-10];
+						sum1 += qlp_coeff[8] * (FLAC__int64)data[i-9];
+						sum0 += qlp_coeff[7] * (FLAC__int64)data[i-8];
+						sum1 += qlp_coeff[6] * (FLAC__int64)data[i-7];
+						sum0 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum1 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum0 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum1 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum0 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum1 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 11 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[10] * (FLAC__int64)data[i-11];
-						sum += qlp_coeff[9] * (FLAC__int64)data[i-10];
-						sum += qlp_coeff[8] * (FLAC__int64)data[i-9];
-						sum += qlp_coeff[7] * (FLAC__int64)data[i-8];
-						sum += qlp_coeff[6] * (FLAC__int64)data[i-7];
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[10] * (FLAC__int64)data[i-11];
+						sum1 += qlp_coeff[9] * (FLAC__int64)data[i-10];
+						sum0 += qlp_coeff[8] * (FLAC__int64)data[i-9];
+						sum1 += qlp_coeff[7] * (FLAC__int64)data[i-8];
+						sum0 += qlp_coeff[6] * (FLAC__int64)data[i-7];
+						sum1 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum0 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum1 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum0 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum1 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum0 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
 			else {
 				if(order == 10) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[9] * (FLAC__int64)data[i-10];
-						sum += qlp_coeff[8] * (FLAC__int64)data[i-9];
-						sum += qlp_coeff[7] * (FLAC__int64)data[i-8];
-						sum += qlp_coeff[6] * (FLAC__int64)data[i-7];
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[9] * (FLAC__int64)data[i-10];
+						sum1 += qlp_coeff[8] * (FLAC__int64)data[i-9];
+						sum0 += qlp_coeff[7] * (FLAC__int64)data[i-8];
+						sum1 += qlp_coeff[6] * (FLAC__int64)data[i-7];
+						sum0 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum1 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum0 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum1 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum0 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum1 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 9 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[8] * (FLAC__int64)data[i-9];
-						sum += qlp_coeff[7] * (FLAC__int64)data[i-8];
-						sum += qlp_coeff[6] * (FLAC__int64)data[i-7];
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[8] * (FLAC__int64)data[i-9];
+						sum1 += qlp_coeff[7] * (FLAC__int64)data[i-8];
+						sum0 += qlp_coeff[6] * (FLAC__int64)data[i-7];
+						sum1 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum0 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum1 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum0 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum1 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum0 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
@@ -696,54 +712,58 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients_wide(const FLAC__int32 * f
 			if(order > 6) {
 				if(order == 8) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[7] * (FLAC__int64)data[i-8];
-						sum += qlp_coeff[6] * (FLAC__int64)data[i-7];
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[7] * (FLAC__int64)data[i-8];
+						sum1 += qlp_coeff[6] * (FLAC__int64)data[i-7];
+						sum0 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum1 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum0 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum1 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum0 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum1 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 7 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[6] * (FLAC__int64)data[i-7];
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[6] * (FLAC__int64)data[i-7];
+						sum1 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum0 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum1 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum0 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum1 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum0 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
 			else {
 				if(order == 6) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum1 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum0 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum1 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum0 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum1 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 5 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum1 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum0 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum1 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum0 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
@@ -752,31 +772,34 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients_wide(const FLAC__int32 * f
 			if(order > 2) {
 				if(order == 4) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum1 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum0 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum1 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 3 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum1 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum0 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
 			else {
 				if(order == 2) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						residual[i] = data[i] - (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum1 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 1 */
@@ -788,42 +811,43 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients_wide(const FLAC__int32 * f
 	}
 	else { /* order > 12 */
 		for(i = 0; i < (int)data_len; i++) {
-			sum = 0;
+			sum0 = 0;
+			sum1 = 0;
 			switch(order) {
-				case 32: sum += qlp_coeff[31] * (FLAC__int64)data[i-32]; /* Falls through. */
-				case 31: sum += qlp_coeff[30] * (FLAC__int64)data[i-31]; /* Falls through. */
-				case 30: sum += qlp_coeff[29] * (FLAC__int64)data[i-30]; /* Falls through. */
-				case 29: sum += qlp_coeff[28] * (FLAC__int64)data[i-29]; /* Falls through. */
-				case 28: sum += qlp_coeff[27] * (FLAC__int64)data[i-28]; /* Falls through. */
-				case 27: sum += qlp_coeff[26] * (FLAC__int64)data[i-27]; /* Falls through. */
-				case 26: sum += qlp_coeff[25] * (FLAC__int64)data[i-26]; /* Falls through. */
-				case 25: sum += qlp_coeff[24] * (FLAC__int64)data[i-25]; /* Falls through. */
-				case 24: sum += qlp_coeff[23] * (FLAC__int64)data[i-24]; /* Falls through. */
-				case 23: sum += qlp_coeff[22] * (FLAC__int64)data[i-23]; /* Falls through. */
-				case 22: sum += qlp_coeff[21] * (FLAC__int64)data[i-22]; /* Falls through. */
-				case 21: sum += qlp_coeff[20] * (FLAC__int64)data[i-21]; /* Falls through. */
-				case 20: sum += qlp_coeff[19] * (FLAC__int64)data[i-20]; /* Falls through. */
-				case 19: sum += qlp_coeff[18] * (FLAC__int64)data[i-19]; /* Falls through. */
-				case 18: sum += qlp_coeff[17] * (FLAC__int64)data[i-18]; /* Falls through. */
-				case 17: sum += qlp_coeff[16] * (FLAC__int64)data[i-17]; /* Falls through. */
-				case 16: sum += qlp_coeff[15] * (FLAC__int64)data[i-16]; /* Falls through. */
-				case 15: sum += qlp_coeff[14] * (FLAC__int64)data[i-15]; /* Falls through. */
-				case 14: sum += qlp_coeff[13] * (FLAC__int64)data[i-14]; /* Falls through. */
-				case 13: sum += qlp_coeff[12] * (FLAC__int64)data[i-13];
-				         sum += qlp_coeff[11] * (FLAC__int64)data[i-12];
-				         sum += qlp_coeff[10] * (FLAC__int64)data[i-11];
-				         sum += qlp_coeff[ 9] * (FLAC__int64)data[i-10];
-				         sum += qlp_coeff[ 8] * (FLAC__int64)data[i- 9];
-				         sum += qlp_coeff[ 7] * (FLAC__int64)data[i- 8];
-				         sum += qlp_coeff[ 6] * (FLAC__int64)data[i- 7];
-				         sum += qlp_coeff[ 5] * (FLAC__int64)data[i- 6];
-				         sum += qlp_coeff[ 4] * (FLAC__int64)data[i- 5];
-				         sum += qlp_coeff[ 3] * (FLAC__int64)data[i- 4];
-				         sum += qlp_coeff[ 2] * (FLAC__int64)data[i- 3];
-				         sum += qlp_coeff[ 1] * (FLAC__int64)data[i- 2];
-				         sum += qlp_coeff[ 0] * (FLAC__int64)data[i- 1];
+				case 32: sum0 += qlp_coeff[31] * (FLAC__int64)data[i-32]; /* Falls through. */
+				case 31: sum1 += qlp_coeff[30] * (FLAC__int64)data[i-31]; /* Falls through. */
+				case 30: sum0 += qlp_coeff[29] * (FLAC__int64)data[i-30]; /* Falls through. */
+				case 29: sum1 += qlp_coeff[28] * (FLAC__int64)data[i-29]; /* Falls through. */
+				case 28: sum0 += qlp_coeff[27] * (FLAC__int64)data[i-28]; /* Falls through. */
+				case 27: sum1 += qlp_coeff[26] * (FLAC__int64)data[i-27]; /* Falls through. */
+				case 26: sum0 += qlp_coeff[25] * (FLAC__int64)data[i-26]; /* Falls through. */
+				case 25: sum1 += qlp_coeff[24] * (FLAC__int64)data[i-25]; /* Falls through. */
+				case 24: sum0 += qlp_coeff[23] * (FLAC__int64)data[i-24]; /* Falls through. */
+				case 23: sum1 += qlp_coeff[22] * (FLAC__int64)data[i-23]; /* Falls through. */
+				case 22: sum0 += qlp_coeff[21] * (FLAC__int64)data[i-22]; /* Falls through. */
+				case 21: sum1 += qlp_coeff[20] * (FLAC__int64)data[i-21]; /* Falls through. */
+				case 20: sum0 += qlp_coeff[19] * (FLAC__int64)data[i-20]; /* Falls through. */
+				case 19: sum1 += qlp_coeff[18] * (FLAC__int64)data[i-19]; /* Falls through. */
+				case 18: sum0 += qlp_coeff[17] * (FLAC__int64)data[i-18]; /* Falls through. */
+				case 17: sum1 += qlp_coeff[16] * (FLAC__int64)data[i-17]; /* Falls through. */
+				case 16: sum0 += qlp_coeff[15] * (FLAC__int64)data[i-16]; /* Falls through. */
+				case 15: sum1 += qlp_coeff[14] * (FLAC__int64)data[i-15]; /* Falls through. */
+				case 14: sum0 += qlp_coeff[13] * (FLAC__int64)data[i-14]; /* Falls through. */
+				case 13: sum1 += qlp_coeff[12] * (FLAC__int64)data[i-13];
+				         sum0 += qlp_coeff[11] * (FLAC__int64)data[i-12];
+				         sum1 += qlp_coeff[10] * (FLAC__int64)data[i-11];
+				         sum0 += qlp_coeff[ 9] * (FLAC__int64)data[i-10];
+				         sum1 += qlp_coeff[ 8] * (FLAC__int64)data[i- 9];
+				         sum0 += qlp_coeff[ 7] * (FLAC__int64)data[i- 8];
+				         sum1 += qlp_coeff[ 6] * (FLAC__int64)data[i- 7];
+				         sum0 += qlp_coeff[ 5] * (FLAC__int64)data[i- 6];
+				         sum1 += qlp_coeff[ 4] * (FLAC__int64)data[i- 5];
+				         sum0 += qlp_coeff[ 3] * (FLAC__int64)data[i- 4];
+				         sum1 += qlp_coeff[ 2] * (FLAC__int64)data[i- 3];
+				         sum0 += qlp_coeff[ 1] * (FLAC__int64)data[i- 2];
+				         sum1 += qlp_coeff[ 0] * (FLAC__int64)data[i- 1];
 			}
-			residual[i] = data[i] - (sum >> lp_quantization);
+			residual[i] = data[i] - ((sum0 + sum1) >> lp_quantization);
 		}
 	}
 }
@@ -832,48 +856,49 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients_wide(const FLAC__int32 * f
 FLAC__bool FLAC__lpc_compute_residual_from_qlp_coefficients_limit_residual(const FLAC__int32 * flac_restrict data, uint32_t data_len, const FLAC__int32 * flac_restrict qlp_coeff, uint32_t order, int lp_quantization, FLAC__int32 * flac_restrict residual)
 {
 	int i;
-	FLAC__int64 sum, residual_to_check;
+	FLAC__int64 sum0, sum1, residual_to_check;
 
 	FLAC__ASSERT(order > 0);
 	FLAC__ASSERT(order <= 32);
 
 	for(i = 0; i < (int)data_len; i++) {
-		sum = 0;
+		sum0 = 0;
+		sum1 = 0;
 		switch(order) {
-			case 32: sum += qlp_coeff[31] * (FLAC__int64)data[i-32]; /* Falls through. */
-			case 31: sum += qlp_coeff[30] * (FLAC__int64)data[i-31]; /* Falls through. */
-			case 30: sum += qlp_coeff[29] * (FLAC__int64)data[i-30]; /* Falls through. */
-			case 29: sum += qlp_coeff[28] * (FLAC__int64)data[i-29]; /* Falls through. */
-			case 28: sum += qlp_coeff[27] * (FLAC__int64)data[i-28]; /* Falls through. */
-			case 27: sum += qlp_coeff[26] * (FLAC__int64)data[i-27]; /* Falls through. */
-			case 26: sum += qlp_coeff[25] * (FLAC__int64)data[i-26]; /* Falls through. */
-			case 25: sum += qlp_coeff[24] * (FLAC__int64)data[i-25]; /* Falls through. */
-			case 24: sum += qlp_coeff[23] * (FLAC__int64)data[i-24]; /* Falls through. */
-			case 23: sum += qlp_coeff[22] * (FLAC__int64)data[i-23]; /* Falls through. */
-			case 22: sum += qlp_coeff[21] * (FLAC__int64)data[i-22]; /* Falls through. */
-			case 21: sum += qlp_coeff[20] * (FLAC__int64)data[i-21]; /* Falls through. */
-			case 20: sum += qlp_coeff[19] * (FLAC__int64)data[i-20]; /* Falls through. */
-			case 19: sum += qlp_coeff[18] * (FLAC__int64)data[i-19]; /* Falls through. */
-			case 18: sum += qlp_coeff[17] * (FLAC__int64)data[i-18]; /* Falls through. */
-			case 17: sum += qlp_coeff[16] * (FLAC__int64)data[i-17]; /* Falls through. */
-			case 16: sum += qlp_coeff[15] * (FLAC__int64)data[i-16]; /* Falls through. */
-			case 15: sum += qlp_coeff[14] * (FLAC__int64)data[i-15]; /* Falls through. */
-			case 14: sum += qlp_coeff[13] * (FLAC__int64)data[i-14]; /* Falls through. */
-			case 13: sum += qlp_coeff[12] * (FLAC__int64)data[i-13]; /* Falls through. */
-			case 12: sum += qlp_coeff[11] * (FLAC__int64)data[i-12]; /* Falls through. */
-			case 11: sum += qlp_coeff[10] * (FLAC__int64)data[i-11]; /* Falls through. */
-			case 10: sum += qlp_coeff[ 9] * (FLAC__int64)data[i-10]; /* Falls through. */
-			case  9: sum += qlp_coeff[ 8] * (FLAC__int64)data[i- 9]; /* Falls through. */
-			case  8: sum += qlp_coeff[ 7] * (FLAC__int64)data[i- 8]; /* Falls through. */
-			case  7: sum += qlp_coeff[ 6] * (FLAC__int64)data[i- 7]; /* Falls through. */
-			case  6: sum += qlp_coeff[ 5] * (FLAC__int64)data[i- 6]; /* Falls through. */
-			case  5: sum += qlp_coeff[ 4] * (FLAC__int64)data[i- 5]; /* Falls through. */
-			case  4: sum += qlp_coeff[ 3] * (FLAC__int64)data[i- 4]; /* Falls through. */
-			case  3: sum += qlp_coeff[ 2] * (FLAC__int64)data[i- 3]; /* Falls through. */
-			case  2: sum += qlp_coeff[ 1] * (FLAC__int64)data[i- 2]; /* Falls through. */
-			case  1: sum += qlp_coeff[ 0] * (FLAC__int64)data[i- 1];
+			case 32: sum0 += qlp_coeff[31] * (FLAC__int64)data[i-32]; /* Falls through. */
+			case 31: sum1 += qlp_coeff[30] * (FLAC__int64)data[i-31]; /* Falls through. */
+			case 30: sum0 += qlp_coeff[29] * (FLAC__int64)data[i-30]; /* Falls through. */
+			case 29: sum1 += qlp_coeff[28] * (FLAC__int64)data[i-29]; /* Falls through. */
+			case 28: sum0 += qlp_coeff[27] * (FLAC__int64)data[i-28]; /* Falls through. */
+			case 27: sum1 += qlp_coeff[26] * (FLAC__int64)data[i-27]; /* Falls through. */
+			case 26: sum0 += qlp_coeff[25] * (FLAC__int64)data[i-26]; /* Falls through. */
+			case 25: sum1 += qlp_coeff[24] * (FLAC__int64)data[i-25]; /* Falls through. */
+			case 24: sum0 += qlp_coeff[23] * (FLAC__int64)data[i-24]; /* Falls through. */
+			case 23: sum1 += qlp_coeff[22] * (FLAC__int64)data[i-23]; /* Falls through. */
+			case 22: sum0 += qlp_coeff[21] * (FLAC__int64)data[i-22]; /* Falls through. */
+			case 21: sum1 += qlp_coeff[20] * (FLAC__int64)data[i-21]; /* Falls through. */
+			case 20: sum0 += qlp_coeff[19] * (FLAC__int64)data[i-20]; /* Falls through. */
+			case 19: sum1 += qlp_coeff[18] * (FLAC__int64)data[i-19]; /* Falls through. */
+			case 18: sum0 += qlp_coeff[17] * (FLAC__int64)data[i-18]; /* Falls through. */
+			case 17: sum1 += qlp_coeff[16] * (FLAC__int64)data[i-17]; /* Falls through. */
+			case 16: sum0 += qlp_coeff[15] * (FLAC__int64)data[i-16]; /* Falls through. */
+			case 15: sum1 += qlp_coeff[14] * (FLAC__int64)data[i-15]; /* Falls through. */
+			case 14: sum0 += qlp_coeff[13] * (FLAC__int64)data[i-14]; /* Falls through. */
+			case 13: sum1 += qlp_coeff[12] * (FLAC__int64)data[i-13]; /* Falls through. */
+			case 12: sum0 += qlp_coeff[11] * (FLAC__int64)data[i-12]; /* Falls through. */
+			case 11: sum1 += qlp_coeff[10] * (FLAC__int64)data[i-11]; /* Falls through. */
+			case 10: sum0 += qlp_coeff[ 9] * (FLAC__int64)data[i-10]; /* Falls through. */
+			case  9: sum1 += qlp_coeff[ 8] * (FLAC__int64)data[i- 9]; /* Falls through. */
+			case  8: sum0 += qlp_coeff[ 7] * (FLAC__int64)data[i- 8]; /* Falls through. */
+			case  7: sum1 += qlp_coeff[ 6] * (FLAC__int64)data[i- 7]; /* Falls through. */
+			case  6: sum0 += qlp_coeff[ 5] * (FLAC__int64)data[i- 6]; /* Falls through. */
+			case  5: sum1 += qlp_coeff[ 4] * (FLAC__int64)data[i- 5]; /* Falls through. */
+			case  4: sum0 += qlp_coeff[ 3] * (FLAC__int64)data[i- 4]; /* Falls through. */
+			case  3: sum1 += qlp_coeff[ 2] * (FLAC__int64)data[i- 3]; /* Falls through. */
+			case  2: sum0 += qlp_coeff[ 1] * (FLAC__int64)data[i- 2]; /* Falls through. */
+			case  1: sum1 += qlp_coeff[ 0] * (FLAC__int64)data[i- 1];
 		}
-		residual_to_check = data[i] - (sum >> lp_quantization);
+		residual_to_check = data[i] - ((sum0 + sum1) >> lp_quantization);
 		 /* residual must not be INT32_MIN because abs(INT32_MIN) is undefined */
 		if(residual_to_check <= INT32_MIN || residual_to_check > INT32_MAX)
 			return false;
@@ -886,48 +911,49 @@ FLAC__bool FLAC__lpc_compute_residual_from_qlp_coefficients_limit_residual(const
 FLAC__bool FLAC__lpc_compute_residual_from_qlp_coefficients_limit_residual_33bit(const FLAC__int64 * flac_restrict data, uint32_t data_len, const FLAC__int32 * flac_restrict qlp_coeff, uint32_t order, int lp_quantization, FLAC__int32 * flac_restrict residual)
 {
 	int i;
-	FLAC__int64 sum, residual_to_check;
+	FLAC__int64 sum0, sum1, residual_to_check;
 
 	FLAC__ASSERT(order > 0);
 	FLAC__ASSERT(order <= 32);
 
 	for(i = 0; i < (int)data_len; i++) {
-		sum = 0;
+		sum0 = 0;
+		sum1 = 0;
 		switch(order) {
-			case 32: sum += qlp_coeff[31] * data[i-32]; /* Falls through. */
-			case 31: sum += qlp_coeff[30] * data[i-31]; /* Falls through. */
-			case 30: sum += qlp_coeff[29] * data[i-30]; /* Falls through. */
-			case 29: sum += qlp_coeff[28] * data[i-29]; /* Falls through. */
-			case 28: sum += qlp_coeff[27] * data[i-28]; /* Falls through. */
-			case 27: sum += qlp_coeff[26] * data[i-27]; /* Falls through. */
-			case 26: sum += qlp_coeff[25] * data[i-26]; /* Falls through. */
-			case 25: sum += qlp_coeff[24] * data[i-25]; /* Falls through. */
-			case 24: sum += qlp_coeff[23] * data[i-24]; /* Falls through. */
-			case 23: sum += qlp_coeff[22] * data[i-23]; /* Falls through. */
-			case 22: sum += qlp_coeff[21] * data[i-22]; /* Falls through. */
-			case 21: sum += qlp_coeff[20] * data[i-21]; /* Falls through. */
-			case 20: sum += qlp_coeff[19] * data[i-20]; /* Falls through. */
-			case 19: sum += qlp_coeff[18] * data[i-19]; /* Falls through. */
-			case 18: sum += qlp_coeff[17] * data[i-18]; /* Falls through. */
-			case 17: sum += qlp_coeff[16] * data[i-17]; /* Falls through. */
-			case 16: sum += qlp_coeff[15] * data[i-16]; /* Falls through. */
-			case 15: sum += qlp_coeff[14] * data[i-15]; /* Falls through. */
-			case 14: sum += qlp_coeff[13] * data[i-14]; /* Falls through. */
-			case 13: sum += qlp_coeff[12] * data[i-13]; /* Falls through. */
-			case 12: sum += qlp_coeff[11] * data[i-12]; /* Falls through. */
-			case 11: sum += qlp_coeff[10] * data[i-11]; /* Falls through. */
-			case 10: sum += qlp_coeff[ 9] * data[i-10]; /* Falls through. */
-			case  9: sum += qlp_coeff[ 8] * data[i- 9]; /* Falls through. */
-			case  8: sum += qlp_coeff[ 7] * data[i- 8]; /* Falls through. */
-			case  7: sum += qlp_coeff[ 6] * data[i- 7]; /* Falls through. */
-			case  6: sum += qlp_coeff[ 5] * data[i- 6]; /* Falls through. */
-			case  5: sum += qlp_coeff[ 4] * data[i- 5]; /* Falls through. */
-			case  4: sum += qlp_coeff[ 3] * data[i- 4]; /* Falls through. */
-			case  3: sum += qlp_coeff[ 2] * data[i- 3]; /* Falls through. */
-			case  2: sum += qlp_coeff[ 1] * data[i- 2]; /* Falls through. */
-			case  1: sum += qlp_coeff[ 0] * data[i- 1];
+			case 32: sum0 += qlp_coeff[31] * data[i-32]; /* Falls through. */
+			case 31: sum1 += qlp_coeff[30] * data[i-31]; /* Falls through. */
+			case 30: sum0 += qlp_coeff[29] * data[i-30]; /* Falls through. */
+			case 29: sum1 += qlp_coeff[28] * data[i-29]; /* Falls through. */
+			case 28: sum0 += qlp_coeff[27] * data[i-28]; /* Falls through. */
+			case 27: sum1 += qlp_coeff[26] * data[i-27]; /* Falls through. */
+			case 26: sum0 += qlp_coeff[25] * data[i-26]; /* Falls through. */
+			case 25: sum1 += qlp_coeff[24] * data[i-25]; /* Falls through. */
+			case 24: sum0 += qlp_coeff[23] * data[i-24]; /* Falls through. */
+			case 23: sum1 += qlp_coeff[22] * data[i-23]; /* Falls through. */
+			case 22: sum0 += qlp_coeff[21] * data[i-22]; /* Falls through. */
+			case 21: sum1 += qlp_coeff[20] * data[i-21]; /* Falls through. */
+			case 20: sum0 += qlp_coeff[19] * data[i-20]; /* Falls through. */
+			case 19: sum1 += qlp_coeff[18] * data[i-19]; /* Falls through. */
+			case 18: sum0 += qlp_coeff[17] * data[i-18]; /* Falls through. */
+			case 17: sum1 += qlp_coeff[16] * data[i-17]; /* Falls through. */
+			case 16: sum0 += qlp_coeff[15] * data[i-16]; /* Falls through. */
+			case 15: sum1 += qlp_coeff[14] * data[i-15]; /* Falls through. */
+			case 14: sum0 += qlp_coeff[13] * data[i-14]; /* Falls through. */
+			case 13: sum1 += qlp_coeff[12] * data[i-13]; /* Falls through. */
+			case 12: sum0 += qlp_coeff[11] * data[i-12]; /* Falls through. */
+			case 11: sum1 += qlp_coeff[10] * data[i-11]; /* Falls through. */
+			case 10: sum0 += qlp_coeff[ 9] * data[i-10]; /* Falls through. */
+			case  9: sum1 += qlp_coeff[ 8] * data[i- 9]; /* Falls through. */
+			case  8: sum0 += qlp_coeff[ 7] * data[i- 8]; /* Falls through. */
+			case  7: sum1 += qlp_coeff[ 6] * data[i- 7]; /* Falls through. */
+			case  6: sum0 += qlp_coeff[ 5] * data[i- 6]; /* Falls through. */
+			case  5: sum1 += qlp_coeff[ 4] * data[i- 5]; /* Falls through. */
+			case  4: sum0 += qlp_coeff[ 3] * data[i- 4]; /* Falls through. */
+			case  3: sum1 += qlp_coeff[ 2] * data[i- 3]; /* Falls through. */
+			case  2: sum0 += qlp_coeff[ 1] * data[i- 2]; /* Falls through. */
+			case  1: sum1 += qlp_coeff[ 0] * data[i- 1];
 		}
-		residual_to_check = data[i] - (sum >> lp_quantization);
+		residual_to_check = data[i] - ((sum0 + sum1) >> lp_quantization);
 		/* residual must not be INT32_MIN because abs(INT32_MIN) is undefined */
 		if(residual_to_check <= INT32_MIN || residual_to_check > INT32_MAX)
 			return false;
@@ -1015,7 +1041,7 @@ void FLAC__lpc_restore_signal(const FLAC__int32 * flac_restrict residual, uint32
 #else /* fully unrolled version for normal use */
 {
 	int i;
-	FLAC__int32 sum;
+	FLAC__int32 sum0, sum1;
 
 	FLAC__ASSERT(order > 0);
 	FLAC__ASSERT(order <= 32);
@@ -1030,70 +1056,74 @@ void FLAC__lpc_restore_signal(const FLAC__int32 * flac_restrict residual, uint32
 			if(order > 10) {
 				if(order == 12) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[11] * data[i-12];
-						sum += qlp_coeff[10] * data[i-11];
-						sum += qlp_coeff[9] * data[i-10];
-						sum += qlp_coeff[8] * data[i-9];
-						sum += qlp_coeff[7] * data[i-8];
-						sum += qlp_coeff[6] * data[i-7];
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						data[i] = residual[i] + (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[11] * data[i-12];
+						sum1 += qlp_coeff[10] * data[i-11];
+						sum0 += qlp_coeff[9] * data[i-10];
+						sum1 += qlp_coeff[8] * data[i-9];
+						sum0 += qlp_coeff[7] * data[i-8];
+						sum1 += qlp_coeff[6] * data[i-7];
+						sum0 += qlp_coeff[5] * data[i-6];
+						sum1 += qlp_coeff[4] * data[i-5];
+						sum0 += qlp_coeff[3] * data[i-4];
+						sum1 += qlp_coeff[2] * data[i-3];
+						sum0 += qlp_coeff[1] * data[i-2];
+						sum1 += qlp_coeff[0] * data[i-1];
+						data[i] = residual[i] + ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 11 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[10] * data[i-11];
-						sum += qlp_coeff[9] * data[i-10];
-						sum += qlp_coeff[8] * data[i-9];
-						sum += qlp_coeff[7] * data[i-8];
-						sum += qlp_coeff[6] * data[i-7];
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						data[i] = residual[i] + (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[10] * data[i-11];
+						sum1 += qlp_coeff[9] * data[i-10];
+						sum0 += qlp_coeff[8] * data[i-9];
+						sum1 += qlp_coeff[7] * data[i-8];
+						sum0 += qlp_coeff[6] * data[i-7];
+						sum1 += qlp_coeff[5] * data[i-6];
+						sum0 += qlp_coeff[4] * data[i-5];
+						sum1 += qlp_coeff[3] * data[i-4];
+						sum0 += qlp_coeff[2] * data[i-3];
+						sum1 += qlp_coeff[1] * data[i-2];
+						sum0 += qlp_coeff[0] * data[i-1];
+						data[i] = residual[i] + ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
 			else {
 				if(order == 10) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[9] * data[i-10];
-						sum += qlp_coeff[8] * data[i-9];
-						sum += qlp_coeff[7] * data[i-8];
-						sum += qlp_coeff[6] * data[i-7];
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						data[i] = residual[i] + (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[9] * data[i-10];
+						sum1 += qlp_coeff[8] * data[i-9];
+						sum0 += qlp_coeff[7] * data[i-8];
+						sum1 += qlp_coeff[6] * data[i-7];
+						sum0 += qlp_coeff[5] * data[i-6];
+						sum1 += qlp_coeff[4] * data[i-5];
+						sum0 += qlp_coeff[3] * data[i-4];
+						sum1 += qlp_coeff[2] * data[i-3];
+						sum0 += qlp_coeff[1] * data[i-2];
+						sum1 += qlp_coeff[0] * data[i-1];
+						data[i] = residual[i] + ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 9 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[8] * data[i-9];
-						sum += qlp_coeff[7] * data[i-8];
-						sum += qlp_coeff[6] * data[i-7];
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						data[i] = residual[i] + (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[8] * data[i-9];
+						sum1 += qlp_coeff[7] * data[i-8];
+						sum0 += qlp_coeff[6] * data[i-7];
+						sum1 += qlp_coeff[5] * data[i-6];
+						sum0 += qlp_coeff[4] * data[i-5];
+						sum1 += qlp_coeff[3] * data[i-4];
+						sum0 += qlp_coeff[2] * data[i-3];
+						sum1 += qlp_coeff[1] * data[i-2];
+						sum0 += qlp_coeff[0] * data[i-1];
+						data[i] = residual[i] + ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
@@ -1102,54 +1132,58 @@ void FLAC__lpc_restore_signal(const FLAC__int32 * flac_restrict residual, uint32
 			if(order > 6) {
 				if(order == 8) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[7] * data[i-8];
-						sum += qlp_coeff[6] * data[i-7];
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						data[i] = residual[i] + (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[7] * data[i-8];
+						sum1 += qlp_coeff[6] * data[i-7];
+						sum0 += qlp_coeff[5] * data[i-6];
+						sum1 += qlp_coeff[4] * data[i-5];
+						sum0 += qlp_coeff[3] * data[i-4];
+						sum1 += qlp_coeff[2] * data[i-3];
+						sum0 += qlp_coeff[1] * data[i-2];
+						sum1 += qlp_coeff[0] * data[i-1];
+						data[i] = residual[i] + ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 7 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[6] * data[i-7];
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						data[i] = residual[i] + (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[6] * data[i-7];
+						sum1 += qlp_coeff[5] * data[i-6];
+						sum0 += qlp_coeff[4] * data[i-5];
+						sum1 += qlp_coeff[3] * data[i-4];
+						sum0 += qlp_coeff[2] * data[i-3];
+						sum1 += qlp_coeff[1] * data[i-2];
+						sum0 += qlp_coeff[0] * data[i-1];
+						data[i] = residual[i] + ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
 			else {
 				if(order == 6) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[5] * data[i-6];
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						data[i] = residual[i] + (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[5] * data[i-6];
+						sum1 += qlp_coeff[4] * data[i-5];
+						sum0 += qlp_coeff[3] * data[i-4];
+						sum1 += qlp_coeff[2] * data[i-3];
+						sum0 += qlp_coeff[1] * data[i-2];
+						sum1 += qlp_coeff[0] * data[i-1];
+						data[i] = residual[i] + ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 5 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[4] * data[i-5];
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						data[i] = residual[i] + (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[4] * data[i-5];
+						sum1 += qlp_coeff[3] * data[i-4];
+						sum0 += qlp_coeff[2] * data[i-3];
+						sum1 += qlp_coeff[1] * data[i-2];
+						sum0 += qlp_coeff[0] * data[i-1];
+						data[i] = residual[i] + ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
@@ -1158,31 +1192,34 @@ void FLAC__lpc_restore_signal(const FLAC__int32 * flac_restrict residual, uint32
 			if(order > 2) {
 				if(order == 4) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[3] * data[i-4];
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						data[i] = residual[i] + (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[3] * data[i-4];
+						sum1 += qlp_coeff[2] * data[i-3];
+						sum0 += qlp_coeff[1] * data[i-2];
+						sum1 += qlp_coeff[0] * data[i-1];
+						data[i] = residual[i] + ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 3 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[2] * data[i-3];
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						data[i] = residual[i] + (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[2] * data[i-3];
+						sum1 += qlp_coeff[1] * data[i-2];
+						sum0 += qlp_coeff[0] * data[i-1];
+						data[i] = residual[i] + ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 			}
 			else {
 				if(order == 2) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[1] * data[i-2];
-						sum += qlp_coeff[0] * data[i-1];
-						data[i] = residual[i] + (sum >> lp_quantization);
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[1] * data[i-2];
+						sum1 += qlp_coeff[0] * data[i-1];
+						data[i] = residual[i] + ((sum0 + sum1) >> lp_quantization);
 					}
 				}
 				else { /* order == 1 */
@@ -1194,42 +1231,43 @@ void FLAC__lpc_restore_signal(const FLAC__int32 * flac_restrict residual, uint32
 	}
 	else { /* order > 12 */
 		for(i = 0; i < (int)data_len; i++) {
-			sum = 0;
+			sum0 = 0;
+			sum1 = 0;
 			switch(order) {
-				case 32: sum += qlp_coeff[31] * data[i-32]; /* Falls through. */
-				case 31: sum += qlp_coeff[30] * data[i-31]; /* Falls through. */
-				case 30: sum += qlp_coeff[29] * data[i-30]; /* Falls through. */
-				case 29: sum += qlp_coeff[28] * data[i-29]; /* Falls through. */
-				case 28: sum += qlp_coeff[27] * data[i-28]; /* Falls through. */
-				case 27: sum += qlp_coeff[26] * data[i-27]; /* Falls through. */
-				case 26: sum += qlp_coeff[25] * data[i-26]; /* Falls through. */
-				case 25: sum += qlp_coeff[24] * data[i-25]; /* Falls through. */
-				case 24: sum += qlp_coeff[23] * data[i-24]; /* Falls through. */
-				case 23: sum += qlp_coeff[22] * data[i-23]; /* Falls through. */
-				case 22: sum += qlp_coeff[21] * data[i-22]; /* Falls through. */
-				case 21: sum += qlp_coeff[20] * data[i-21]; /* Falls through. */
-				case 20: sum += qlp_coeff[19] * data[i-20]; /* Falls through. */
-				case 19: sum += qlp_coeff[18] * data[i-19]; /* Falls through. */
-				case 18: sum += qlp_coeff[17] * data[i-18]; /* Falls through. */
-				case 17: sum += qlp_coeff[16] * data[i-17]; /* Falls through. */
-				case 16: sum += qlp_coeff[15] * data[i-16]; /* Falls through. */
-				case 15: sum += qlp_coeff[14] * data[i-15]; /* Falls through. */
-				case 14: sum += qlp_coeff[13] * data[i-14]; /* Falls through. */
-				case 13: sum += qlp_coeff[12] * data[i-13];
-				         sum += qlp_coeff[11] * data[i-12];
-				         sum += qlp_coeff[10] * data[i-11];
-				         sum += qlp_coeff[ 9] * data[i-10];
-				         sum += qlp_coeff[ 8] * data[i- 9];
-				         sum += qlp_coeff[ 7] * data[i- 8];
-				         sum += qlp_coeff[ 6] * data[i- 7];
-				         sum += qlp_coeff[ 5] * data[i- 6];
-				         sum += qlp_coeff[ 4] * data[i- 5];
-				         sum += qlp_coeff[ 3] * data[i- 4];
-				         sum += qlp_coeff[ 2] * data[i- 3];
-				         sum += qlp_coeff[ 1] * data[i- 2];
-				         sum += qlp_coeff[ 0] * data[i- 1];
+				case 32: sum0 += qlp_coeff[31] * data[i-32]; /* Falls through. */
+				case 31: sum1 += qlp_coeff[30] * data[i-31]; /* Falls through. */
+				case 30: sum0 += qlp_coeff[29] * data[i-30]; /* Falls through. */
+				case 29: sum1 += qlp_coeff[28] * data[i-29]; /* Falls through. */
+				case 28: sum0 += qlp_coeff[27] * data[i-28]; /* Falls through. */
+				case 27: sum1 += qlp_coeff[26] * data[i-27]; /* Falls through. */
+				case 26: sum0 += qlp_coeff[25] * data[i-26]; /* Falls through. */
+				case 25: sum1 += qlp_coeff[24] * data[i-25]; /* Falls through. */
+				case 24: sum0 += qlp_coeff[23] * data[i-24]; /* Falls through. */
+				case 23: sum1 += qlp_coeff[22] * data[i-23]; /* Falls through. */
+				case 22: sum0 += qlp_coeff[21] * data[i-22]; /* Falls through. */
+				case 21: sum1 += qlp_coeff[20] * data[i-21]; /* Falls through. */
+				case 20: sum0 += qlp_coeff[19] * data[i-20]; /* Falls through. */
+				case 19: sum1 += qlp_coeff[18] * data[i-19]; /* Falls through. */
+				case 18: sum0 += qlp_coeff[17] * data[i-18]; /* Falls through. */
+				case 17: sum1 += qlp_coeff[16] * data[i-17]; /* Falls through. */
+				case 16: sum0 += qlp_coeff[15] * data[i-16]; /* Falls through. */
+				case 15: sum1 += qlp_coeff[14] * data[i-15]; /* Falls through. */
+				case 14: sum0 += qlp_coeff[13] * data[i-14]; /* Falls through. */
+				case 13: sum1 += qlp_coeff[12] * data[i-13];
+				         sum0 += qlp_coeff[11] * data[i-12];
+				         sum1 += qlp_coeff[10] * data[i-11];
+				         sum0 += qlp_coeff[ 9] * data[i-10];
+				         sum1 += qlp_coeff[ 8] * data[i- 9];
+				         sum0 += qlp_coeff[ 7] * data[i- 8];
+				         sum1 += qlp_coeff[ 6] * data[i- 7];
+				         sum0 += qlp_coeff[ 5] * data[i- 6];
+				         sum1 += qlp_coeff[ 4] * data[i- 5];
+				         sum0 += qlp_coeff[ 3] * data[i- 4];
+				         sum1 += qlp_coeff[ 2] * data[i- 3];
+				         sum0 += qlp_coeff[ 1] * data[i- 2];
+				         sum1 += qlp_coeff[ 0] * data[i- 1];
 			}
-			data[i] = residual[i] + (sum >> lp_quantization);
+			data[i] = residual[i] + ((sum0 + sum1) >> lp_quantization);
 		}
 	}
 }
@@ -1267,7 +1305,7 @@ void FLAC__lpc_restore_signal_wide(const FLAC__int32 * flac_restrict residual, u
 #else /* fully unrolled version for normal use */
 {
 	int i;
-	FLAC__int64 sum;
+	FLAC__int64 sum0, sum1;
 
 	FLAC__ASSERT(order > 0);
 	FLAC__ASSERT(order <= 32);
@@ -1282,70 +1320,74 @@ void FLAC__lpc_restore_signal_wide(const FLAC__int32 * flac_restrict residual, u
 			if(order > 10) {
 				if(order == 12) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[11] * (FLAC__int64)data[i-12];
-						sum += qlp_coeff[10] * (FLAC__int64)data[i-11];
-						sum += qlp_coeff[9] * (FLAC__int64)data[i-10];
-						sum += qlp_coeff[8] * (FLAC__int64)data[i-9];
-						sum += qlp_coeff[7] * (FLAC__int64)data[i-8];
-						sum += qlp_coeff[6] * (FLAC__int64)data[i-7];
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[11] * (FLAC__int64)data[i-12];
+						sum1 += qlp_coeff[10] * (FLAC__int64)data[i-11];
+						sum0 += qlp_coeff[9] * (FLAC__int64)data[i-10];
+						sum1 += qlp_coeff[8] * (FLAC__int64)data[i-9];
+						sum0 += qlp_coeff[7] * (FLAC__int64)data[i-8];
+						sum1 += qlp_coeff[6] * (FLAC__int64)data[i-7];
+						sum0 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum1 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum0 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum1 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum0 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum1 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						data[i] = (FLAC__int32) (residual[i] + ((sum0 + sum1) >> lp_quantization));
 					}
 				}
 				else { /* order == 11 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[10] * (FLAC__int64)data[i-11];
-						sum += qlp_coeff[9] * (FLAC__int64)data[i-10];
-						sum += qlp_coeff[8] * (FLAC__int64)data[i-9];
-						sum += qlp_coeff[7] * (FLAC__int64)data[i-8];
-						sum += qlp_coeff[6] * (FLAC__int64)data[i-7];
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[10] * (FLAC__int64)data[i-11];
+						sum1 += qlp_coeff[9] * (FLAC__int64)data[i-10];
+						sum0 += qlp_coeff[8] * (FLAC__int64)data[i-9];
+						sum1 += qlp_coeff[7] * (FLAC__int64)data[i-8];
+						sum0 += qlp_coeff[6] * (FLAC__int64)data[i-7];
+						sum1 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum0 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum1 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum0 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum1 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum0 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						data[i] = (FLAC__int32) (residual[i] + ((sum0 + sum1) >> lp_quantization));
 					}
 				}
 			}
 			else {
 				if(order == 10) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[9] * (FLAC__int64)data[i-10];
-						sum += qlp_coeff[8] * (FLAC__int64)data[i-9];
-						sum += qlp_coeff[7] * (FLAC__int64)data[i-8];
-						sum += qlp_coeff[6] * (FLAC__int64)data[i-7];
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[9] * (FLAC__int64)data[i-10];
+						sum1 += qlp_coeff[8] * (FLAC__int64)data[i-9];
+						sum0 += qlp_coeff[7] * (FLAC__int64)data[i-8];
+						sum1 += qlp_coeff[6] * (FLAC__int64)data[i-7];
+						sum0 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum1 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum0 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum1 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum0 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum1 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						data[i] = (FLAC__int32) (residual[i] + ((sum0 + sum1) >> lp_quantization));
 					}
 				}
 				else { /* order == 9 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[8] * (FLAC__int64)data[i-9];
-						sum += qlp_coeff[7] * (FLAC__int64)data[i-8];
-						sum += qlp_coeff[6] * (FLAC__int64)data[i-7];
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[8] * (FLAC__int64)data[i-9];
+						sum1 += qlp_coeff[7] * (FLAC__int64)data[i-8];
+						sum0 += qlp_coeff[6] * (FLAC__int64)data[i-7];
+						sum1 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum0 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum1 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum0 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum1 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum0 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						data[i] = (FLAC__int32) (residual[i] + ((sum0 + sum1) >> lp_quantization));
 					}
 				}
 			}
@@ -1354,54 +1396,58 @@ void FLAC__lpc_restore_signal_wide(const FLAC__int32 * flac_restrict residual, u
 			if(order > 6) {
 				if(order == 8) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[7] * (FLAC__int64)data[i-8];
-						sum += qlp_coeff[6] * (FLAC__int64)data[i-7];
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[7] * (FLAC__int64)data[i-8];
+						sum1 += qlp_coeff[6] * (FLAC__int64)data[i-7];
+						sum0 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum1 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum0 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum1 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum0 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum1 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						data[i] = (FLAC__int32) (residual[i] + ((sum0 + sum1) >> lp_quantization));
 					}
 				}
 				else { /* order == 7 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[6] * (FLAC__int64)data[i-7];
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[6] * (FLAC__int64)data[i-7];
+						sum1 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum0 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum1 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum0 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum1 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum0 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						data[i] = (FLAC__int32) (residual[i] + ((sum0 + sum1) >> lp_quantization));
 					}
 				}
 			}
 			else {
 				if(order == 6) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[5] * (FLAC__int64)data[i-6];
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[5] * (FLAC__int64)data[i-6];
+						sum1 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum0 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum1 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum0 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum1 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						data[i] = (FLAC__int32) (residual[i] + ((sum0 + sum1) >> lp_quantization));
 					}
 				}
 				else { /* order == 5 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[4] * (FLAC__int64)data[i-5];
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[4] * (FLAC__int64)data[i-5];
+						sum1 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum0 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum1 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum0 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						data[i] = (FLAC__int32) (residual[i] + ((sum0 + sum1) >> lp_quantization));
 					}
 				}
 			}
@@ -1410,31 +1456,34 @@ void FLAC__lpc_restore_signal_wide(const FLAC__int32 * flac_restrict residual, u
 			if(order > 2) {
 				if(order == 4) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[3] * (FLAC__int64)data[i-4];
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[3] * (FLAC__int64)data[i-4];
+						sum1 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum0 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum1 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						data[i] = (FLAC__int32) (residual[i] + ((sum0 + sum1) >> lp_quantization));
 					}
 				}
 				else { /* order == 3 */
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[2] * (FLAC__int64)data[i-3];
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[2] * (FLAC__int64)data[i-3];
+						sum1 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum0 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						data[i] = (FLAC__int32) (residual[i] + ((sum0 + sum1) >> lp_quantization));
 					}
 				}
 			}
 			else {
 				if(order == 2) {
 					for(i = 0; i < (int)data_len; i++) {
-						sum = 0;
-						sum += qlp_coeff[1] * (FLAC__int64)data[i-2];
-						sum += qlp_coeff[0] * (FLAC__int64)data[i-1];
-						data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
+						sum0 = 0;
+						sum1 = 0;
+						sum0 += qlp_coeff[1] * (FLAC__int64)data[i-2];
+						sum1 += qlp_coeff[0] * (FLAC__int64)data[i-1];
+						data[i] = (FLAC__int32) (residual[i] + ((sum0 + sum1) >> lp_quantization));
 					}
 				}
 				else { /* order == 1 */
@@ -1446,42 +1495,43 @@ void FLAC__lpc_restore_signal_wide(const FLAC__int32 * flac_restrict residual, u
 	}
 	else { /* order > 12 */
 		for(i = 0; i < (int)data_len; i++) {
-			sum = 0;
+			sum0 = 0;
+			sum1 = 0;
 			switch(order) {
-				case 32: sum += qlp_coeff[31] * (FLAC__int64)data[i-32]; /* Falls through. */
-				case 31: sum += qlp_coeff[30] * (FLAC__int64)data[i-31]; /* Falls through. */
-				case 30: sum += qlp_coeff[29] * (FLAC__int64)data[i-30]; /* Falls through. */
-				case 29: sum += qlp_coeff[28] * (FLAC__int64)data[i-29]; /* Falls through. */
-				case 28: sum += qlp_coeff[27] * (FLAC__int64)data[i-28]; /* Falls through. */
-				case 27: sum += qlp_coeff[26] * (FLAC__int64)data[i-27]; /* Falls through. */
-				case 26: sum += qlp_coeff[25] * (FLAC__int64)data[i-26]; /* Falls through. */
-				case 25: sum += qlp_coeff[24] * (FLAC__int64)data[i-25]; /* Falls through. */
-				case 24: sum += qlp_coeff[23] * (FLAC__int64)data[i-24]; /* Falls through. */
-				case 23: sum += qlp_coeff[22] * (FLAC__int64)data[i-23]; /* Falls through. */
-				case 22: sum += qlp_coeff[21] * (FLAC__int64)data[i-22]; /* Falls through. */
-				case 21: sum += qlp_coeff[20] * (FLAC__int64)data[i-21]; /* Falls through. */
-				case 20: sum += qlp_coeff[19] * (FLAC__int64)data[i-20]; /* Falls through. */
-				case 19: sum += qlp_coeff[18] * (FLAC__int64)data[i-19]; /* Falls through. */
-				case 18: sum += qlp_coeff[17] * (FLAC__int64)data[i-18]; /* Falls through. */
-				case 17: sum += qlp_coeff[16] * (FLAC__int64)data[i-17]; /* Falls through. */
-				case 16: sum += qlp_coeff[15] * (FLAC__int64)data[i-16]; /* Falls through. */
-				case 15: sum += qlp_coeff[14] * (FLAC__int64)data[i-15]; /* Falls through. */
-				case 14: sum += qlp_coeff[13] * (FLAC__int64)data[i-14]; /* Falls through. */
-				case 13: sum += qlp_coeff[12] * (FLAC__int64)data[i-13];
-				         sum += qlp_coeff[11] * (FLAC__int64)data[i-12];
-				         sum += qlp_coeff[10] * (FLAC__int64)data[i-11];
-				         sum += qlp_coeff[ 9] * (FLAC__int64)data[i-10];
-				         sum += qlp_coeff[ 8] * (FLAC__int64)data[i- 9];
-				         sum += qlp_coeff[ 7] * (FLAC__int64)data[i- 8];
-				         sum += qlp_coeff[ 6] * (FLAC__int64)data[i- 7];
-				         sum += qlp_coeff[ 5] * (FLAC__int64)data[i- 6];
-				         sum += qlp_coeff[ 4] * (FLAC__int64)data[i- 5];
-				         sum += qlp_coeff[ 3] * (FLAC__int64)data[i- 4];
-				         sum += qlp_coeff[ 2] * (FLAC__int64)data[i- 3];
-				         sum += qlp_coeff[ 1] * (FLAC__int64)data[i- 2];
-				         sum += qlp_coeff[ 0] * (FLAC__int64)data[i- 1];
+				case 32: sum0 += qlp_coeff[31] * (FLAC__int64)data[i-32]; /* Falls through. */
+				case 31: sum1 += qlp_coeff[30] * (FLAC__int64)data[i-31]; /* Falls through. */
+				case 30: sum0 += qlp_coeff[29] * (FLAC__int64)data[i-30]; /* Falls through. */
+				case 29: sum1 += qlp_coeff[28] * (FLAC__int64)data[i-29]; /* Falls through. */
+				case 28: sum0 += qlp_coeff[27] * (FLAC__int64)data[i-28]; /* Falls through. */
+				case 27: sum1 += qlp_coeff[26] * (FLAC__int64)data[i-27]; /* Falls through. */
+				case 26: sum0 += qlp_coeff[25] * (FLAC__int64)data[i-26]; /* Falls through. */
+				case 25: sum1 += qlp_coeff[24] * (FLAC__int64)data[i-25]; /* Falls through. */
+				case 24: sum0 += qlp_coeff[23] * (FLAC__int64)data[i-24]; /* Falls through. */
+				case 23: sum1 += qlp_coeff[22] * (FLAC__int64)data[i-23]; /* Falls through. */
+				case 22: sum0 += qlp_coeff[21] * (FLAC__int64)data[i-22]; /* Falls through. */
+				case 21: sum1 += qlp_coeff[20] * (FLAC__int64)data[i-21]; /* Falls through. */
+				case 20: sum0 += qlp_coeff[19] * (FLAC__int64)data[i-20]; /* Falls through. */
+				case 19: sum1 += qlp_coeff[18] * (FLAC__int64)data[i-19]; /* Falls through. */
+				case 18: sum0 += qlp_coeff[17] * (FLAC__int64)data[i-18]; /* Falls through. */
+				case 17: sum1 += qlp_coeff[16] * (FLAC__int64)data[i-17]; /* Falls through. */
+				case 16: sum0 += qlp_coeff[15] * (FLAC__int64)data[i-16]; /* Falls through. */
+				case 15: sum1 += qlp_coeff[14] * (FLAC__int64)data[i-15]; /* Falls through. */
+				case 14: sum0 += qlp_coeff[13] * (FLAC__int64)data[i-14]; /* Falls through. */
+				case 13: sum1 += qlp_coeff[12] * (FLAC__int64)data[i-13];
+				         sum0 += qlp_coeff[11] * (FLAC__int64)data[i-12];
+				         sum1 += qlp_coeff[10] * (FLAC__int64)data[i-11];
+				         sum0 += qlp_coeff[ 9] * (FLAC__int64)data[i-10];
+				         sum1 += qlp_coeff[ 8] * (FLAC__int64)data[i- 9];
+				         sum0 += qlp_coeff[ 7] * (FLAC__int64)data[i- 8];
+				         sum1 += qlp_coeff[ 6] * (FLAC__int64)data[i- 7];
+				         sum0 += qlp_coeff[ 5] * (FLAC__int64)data[i- 6];
+				         sum1 += qlp_coeff[ 4] * (FLAC__int64)data[i- 5];
+				         sum0 += qlp_coeff[ 3] * (FLAC__int64)data[i- 4];
+				         sum1 += qlp_coeff[ 2] * (FLAC__int64)data[i- 3];
+				         sum0 += qlp_coeff[ 1] * (FLAC__int64)data[i- 2];
+				         sum1 += qlp_coeff[ 0] * (FLAC__int64)data[i- 1];
 			}
-			data[i] = (FLAC__int32) (residual[i] + (sum >> lp_quantization));
+			data[i] = (FLAC__int32) (residual[i] + ((sum0 + sum1) >> lp_quantization));
 		}
 	}
 }
@@ -1522,48 +1572,49 @@ void FLAC__lpc_restore_signal_wide_33bit(const FLAC__int32 * flac_restrict resid
 #else /* unrolled version for normal use */
 {
 	int i;
-	FLAC__int64 sum;
+	FLAC__int64 sum0, sum1;
 
 	FLAC__ASSERT(order > 0);
 	FLAC__ASSERT(order <= 32);
 
 	for(i = 0; i < (int)data_len; i++) {
-		sum = 0;
+		sum0 = 0;
+		sum1 = 0;
 		switch(order) {
-			case 32: sum += qlp_coeff[31] * data[i-32]; /* Falls through. */
-			case 31: sum += qlp_coeff[30] * data[i-31]; /* Falls through. */
-			case 30: sum += qlp_coeff[29] * data[i-30]; /* Falls through. */
-			case 29: sum += qlp_coeff[28] * data[i-29]; /* Falls through. */
-			case 28: sum += qlp_coeff[27] * data[i-28]; /* Falls through. */
-			case 27: sum += qlp_coeff[26] * data[i-27]; /* Falls through. */
-			case 26: sum += qlp_coeff[25] * data[i-26]; /* Falls through. */
-			case 25: sum += qlp_coeff[24] * data[i-25]; /* Falls through. */
-			case 24: sum += qlp_coeff[23] * data[i-24]; /* Falls through. */
-			case 23: sum += qlp_coeff[22] * data[i-23]; /* Falls through. */
-			case 22: sum += qlp_coeff[21] * data[i-22]; /* Falls through. */
-			case 21: sum += qlp_coeff[20] * data[i-21]; /* Falls through. */
-			case 20: sum += qlp_coeff[19] * data[i-20]; /* Falls through. */
-			case 19: sum += qlp_coeff[18] * data[i-19]; /* Falls through. */
-			case 18: sum += qlp_coeff[17] * data[i-18]; /* Falls through. */
-			case 17: sum += qlp_coeff[16] * data[i-17]; /* Falls through. */
-			case 16: sum += qlp_coeff[15] * data[i-16]; /* Falls through. */
-			case 15: sum += qlp_coeff[14] * data[i-15]; /* Falls through. */
-			case 14: sum += qlp_coeff[13] * data[i-14]; /* Falls through. */
-			case 13: sum += qlp_coeff[12] * data[i-13]; /* Falls through. */
-			case 12: sum += qlp_coeff[11] * data[i-12]; /* Falls through. */
-			case 11: sum += qlp_coeff[10] * data[i-11]; /* Falls through. */
-			case 10: sum += qlp_coeff[ 9] * data[i-10]; /* Falls through. */
-			case  9: sum += qlp_coeff[ 8] * data[i- 9]; /* Falls through. */
-			case  8: sum += qlp_coeff[ 7] * data[i- 8]; /* Falls through. */
-			case  7: sum += qlp_coeff[ 6] * data[i- 7]; /* Falls through. */
-			case  6: sum += qlp_coeff[ 5] * data[i- 6]; /* Falls through. */
-			case  5: sum += qlp_coeff[ 4] * data[i- 5]; /* Falls through. */
-			case  4: sum += qlp_coeff[ 3] * data[i- 4]; /* Falls through. */
-			case  3: sum += qlp_coeff[ 2] * data[i- 3]; /* Falls through. */
-			case  2: sum += qlp_coeff[ 1] * data[i- 2]; /* Falls through. */
-			case  1: sum += qlp_coeff[ 0] * data[i- 1];
+			case 32: sum0 += qlp_coeff[31] * data[i-32]; /* Falls through. */
+			case 31: sum1 += qlp_coeff[30] * data[i-31]; /* Falls through. */
+			case 30: sum0 += qlp_coeff[29] * data[i-30]; /* Falls through. */
+			case 29: sum1 += qlp_coeff[28] * data[i-29]; /* Falls through. */
+			case 28: sum0 += qlp_coeff[27] * data[i-28]; /* Falls through. */
+			case 27: sum1 += qlp_coeff[26] * data[i-27]; /* Falls through. */
+			case 26: sum0 += qlp_coeff[25] * data[i-26]; /* Falls through. */
+			case 25: sum1 += qlp_coeff[24] * data[i-25]; /* Falls through. */
+			case 24: sum0 += qlp_coeff[23] * data[i-24]; /* Falls through. */
+			case 23: sum1 += qlp_coeff[22] * data[i-23]; /* Falls through. */
+			case 22: sum0 += qlp_coeff[21] * data[i-22]; /* Falls through. */
+			case 21: sum1 += qlp_coeff[20] * data[i-21]; /* Falls through. */
+			case 20: sum0 += qlp_coeff[19] * data[i-20]; /* Falls through. */
+			case 19: sum1 += qlp_coeff[18] * data[i-19]; /* Falls through. */
+			case 18: sum0 += qlp_coeff[17] * data[i-18]; /* Falls through. */
+			case 17: sum1 += qlp_coeff[16] * data[i-17]; /* Falls through. */
+			case 16: sum0 += qlp_coeff[15] * data[i-16]; /* Falls through. */
+			case 15: sum1 += qlp_coeff[14] * data[i-15]; /* Falls through. */
+			case 14: sum0 += qlp_coeff[13] * data[i-14]; /* Falls through. */
+			case 13: sum1 += qlp_coeff[12] * data[i-13]; /* Falls through. */
+			case 12: sum0 += qlp_coeff[11] * data[i-12]; /* Falls through. */
+			case 11: sum1 += qlp_coeff[10] * data[i-11]; /* Falls through. */
+			case 10: sum0 += qlp_coeff[ 9] * data[i-10]; /* Falls through. */
+			case  9: sum1 += qlp_coeff[ 8] * data[i- 9]; /* Falls through. */
+			case  8: sum0 += qlp_coeff[ 7] * data[i- 8]; /* Falls through. */
+			case  7: sum1 += qlp_coeff[ 6] * data[i- 7]; /* Falls through. */
+			case  6: sum0 += qlp_coeff[ 5] * data[i- 6]; /* Falls through. */
+			case  5: sum1 += qlp_coeff[ 4] * data[i- 5]; /* Falls through. */
+			case  4: sum0 += qlp_coeff[ 3] * data[i- 4]; /* Falls through. */
+			case  3: sum1 += qlp_coeff[ 2] * data[i- 3]; /* Falls through. */
+			case  2: sum0 += qlp_coeff[ 1] * data[i- 2]; /* Falls through. */
+			case  1: sum1 += qlp_coeff[ 0] * data[i- 1];
 		}
-		data[i] = residual[i] + (sum >> lp_quantization);
+		data[i] = residual[i] + ((sum0 + sum1) >> lp_quantization);
 	}
 }
 #endif


### PR DESCRIPTION
flac is being considered for the next version of the SPEC CPU benchmark suite, currently dubbed [CPUv8](https://spec.org/cpuv8/). As such, we are interested in the generic (non-intrinsic) code paths that can run on all current and future architectures. And as part of the intense scrutiny that benchmarks undergo, we saw a performance improvement opportunity in the generic code path in `libFLAC/lpc.c` and would like to share it with the community.

In the loop for computing residual from qlp coefficients, if we break the single dependence chain into two parallel sub-chains, we allow vectorization instructions to be interleaved during program execution. This provides 2-4% performance uplift as measured on modern ARM systems due to increased instruction level parallelism. Our two benchmark workloads are encoding podcasts using `-7ep --replay-gain` and `-8p`. We did try breaking the chain down further into four sub-chains, but didn't see any additional gains.