### PR TITLE
Fix bug in CHECK_ORDER_IS_VALID macro in functions with intrinsics

### DIFF
--- a/src/libFLAC/fixed_intrin_avx2.c
+++ b/src/libFLAC/fixed_intrin_avx2.c
@@ -178,7 +178,7 @@ if(shadow_error_##macro_order <= INT32_MAX) { \
 		order = macro_order; \
 		smallest_error = total_error_##macro_order ; \
 	} \
-	residual_bits_per_sample[ macro_order ] = (float)((total_error_0 > 0) ? log(M_LN2 * (double)total_error_0 / (double)data_len) / M_LN2 : 0.0); \
+	residual_bits_per_sample[ macro_order ] = (float)((total_error_##macro_order > 0) ? log(M_LN2 * (double)total_error_##macro_order / (double)data_len) / M_LN2 : 0.0); \
 } \
 else \
 	residual_bits_per_sample[ macro_order ] = 34.0f;

--- a/src/libFLAC/fixed_intrin_sse42.c
+++ b/src/libFLAC/fixed_intrin_sse42.c
@@ -59,7 +59,7 @@ if(shadow_error_##macro_order <= INT32_MAX) { \
 		order = macro_order; \
 		smallest_error = total_error_##macro_order ; \
 	} \
-	residual_bits_per_sample[ macro_order ] = (float)((total_error_0 > 0) ? log(M_LN2 * (double)total_error_0 / (double)data_len) / M_LN2 : 0.0); \
+	residual_bits_per_sample[ macro_order ] = (float)((total_error_##macro_order > 0) ? log(M_LN2 * (double)total_error_##macro_order / (double)data_len) / M_LN2 : 0.0); \
 } \
 else \
 	residual_bits_per_sample[ macro_order ] = 34.0f;


### PR DESCRIPTION
This fixes a few things I missed with #694