### PR TITLE
Improve calculation of when to use wide residual computation

### DIFF
--- a/src/libFLAC/bitmath.c
+++ b/src/libFLAC/bitmath.c
@@ -71,3 +71,45 @@ uint32_t FLAC__bitmath_silog2(FLAC__int64 v)
 	v = (v < 0) ? (-(v+1)) : v;
 	return FLAC__bitmath_ilog2_wide(v)+2;
 }
+
+/* An example of what FLAC__bitmath_extra_mulbits_unsigned() computes:
+ *
+ * extra_mulbits_unsigned( 0) = 0
+ * extra_mulbits_unsigned( 1) = 0
+ * extra_mulbits_unsigned( 2) = 1
+ * extra_mulbits_unsigned( 3) = 2
+ * extra_mulbits_unsigned( 4) = 2
+ * extra_mulbits_unsigned( 5) = 3
+ * extra_mulbits_unsigned( 6) = 3
+ * extra_mulbits_unsigned( 7) = 3
+ * extra_mulbits_unsigned( 8) = 3
+ * extra_mulbits_unsigned( 9) = 4
+ * extra_mulbits_unsigned(10) = 4
+ * extra_mulbits_unsigned(11) = 4
+ * extra_mulbits_unsigned(12) = 4
+ * extra_mulbits_unsigned(13) = 4
+ * extra_mulbits_unsigned(14) = 4
+ * extra_mulbits_unsigned(15) = 4
+ * extra_mulbits_unsigned(16) = 4
+ * extra_mulbits_unsigned(17) = 5
+ * extra_mulbits_unsigned(18) = 5
+ *
+ * The intent of this is to calculate how many extra bits multiplication
+ * by a certain number requires. So, if a signal fits in a certain number
+ * of bits (for example 16) than multiplying by a number (for example 1024)
+ * grows that storage requirement (to 26 in this example). In effect this is
+ * is the log2 rounded up.
+ */
+uint32_t FLAC__bitmath_extra_mulbits_unsigned(FLAC__uint32 v)
+{
+	uint32_t ilog2;
+	if(v == 0)
+		return 0;
+	ilog2 = FLAC__bitmath_ilog2(v);
+	if(((v >> ilog2) << ilog2) == v)
+		/* v is power of 2 */
+		return ilog2;
+	else
+		/* v is not a power of 2, return one higher */
+		return ilog2 + 1;
+}

--- a/src/libFLAC/include/private/bitmath.h
+++ b/src/libFLAC/include/private/bitmath.h
@@ -206,5 +206,6 @@ static inline uint32_t FLAC__bitmath_ilog2_wide(FLAC__uint64 v)
 }
 
 uint32_t FLAC__bitmath_silog2(FLAC__int64 v);
+uint32_t FLAC__bitmath_extra_mulbits_unsigned(FLAC__uint32 v);
 
 #endif

--- a/src/libFLAC/lpc.c
+++ b/src/libFLAC/lpc.c
@@ -945,13 +945,11 @@ uint32_t FLAC__lpc_max_prediction_before_shift_bps(uint32_t subframe_bps, const 
 	 * but that treats both the samples as well as the predictor as unknown. The
 	 * predictor is known however, so taking the log2 of the sum of the absolute values
 	 * of all coefficients is a more accurate representation of the predictor */
-	FLAC__int32 abs_sum_of_qlp_coeff = 0;
+	FLAC__uint32 abs_sum_of_qlp_coeff = 0;
 	uint32_t i;
 	for(i = 0; i < order; i++)
 		abs_sum_of_qlp_coeff += abs(qlp_coeff[i]);
-	if(abs_sum_of_qlp_coeff == 0)
-		abs_sum_of_qlp_coeff = 1;
-	return subframe_bps + FLAC__bitmath_silog2(abs_sum_of_qlp_coeff);
+	return subframe_bps + FLAC__bitmath_extra_mulbits_unsigned(abs_sum_of_qlp_coeff);
 }
 
 


### PR DESCRIPTION
This change should make 24-bit encoding faster, because the `limit_residual` variant of residual computation is used less often.