### PR TITLE
Further improve calculation of when to use wide residual computation

### DIFF
--- a/src/libFLAC/include/private/lpc.h
+++ b/src/libFLAC/include/private/lpc.h
@@ -181,6 +181,7 @@ void FLAC__lpc_compute_residual_from_qlp_coefficients_wide_intrin_avx2(const FLA
 
 #endif /* !defined FLAC__INTEGER_ONLY_LIBRARY */
 
+FLAC__uint64 FLAC__lpc_max_prediction_value_before_shift(uint32_t subframe_bps, const FLAC__int32 qlp_coeff[], uint32_t order);
 uint32_t FLAC__lpc_max_prediction_before_shift_bps(uint32_t subframe_bps, const FLAC__int32 qlp_coeff[], uint32_t order);
 uint32_t FLAC__lpc_max_residual_bps(uint32_t subframe_bps, const FLAC__int32 qlp_coeff[], uint32_t order, int lp_quantization);
 

--- a/src/libFLAC/lpc.c
+++ b/src/libFLAC/lpc.c
@@ -961,7 +961,7 @@ uint32_t FLAC__lpc_max_prediction_before_shift_bps(uint32_t subframe_bps, const 
 
 uint32_t FLAC__lpc_max_residual_bps(uint32_t subframe_bps, const FLAC__int32 * flac_restrict qlp_coeff, uint32_t order, int lp_quantization)
 {
-	FLAC__uint64 max_abs_sample_value = 1 << (subframe_bps - 1);
+	FLAC__uint64 max_abs_sample_value = (FLAC__uint64)(1) << (subframe_bps - 1);
 	FLAC__uint64 max_prediction_value_after_shift = -1 * ((-1 * (FLAC__int64)FLAC__lpc_max_prediction_value_before_shift(subframe_bps, qlp_coeff, order)) >> lp_quantization);
 	FLAC__uint64 max_residual_value = max_abs_sample_value + max_prediction_value_after_shift;
 	return FLAC__bitmath_silog2(max_residual_value);

--- a/src/libFLAC/lpc.c
+++ b/src/libFLAC/lpc.c
@@ -941,7 +941,7 @@ FLAC__bool FLAC__lpc_compute_residual_from_qlp_coefficients_limit_residual_33bit
 
 FLAC__uint64 FLAC__lpc_max_prediction_value_before_shift(uint32_t subframe_bps, const FLAC__int32 * flac_restrict qlp_coeff, uint32_t order)
 {
-	FLAC__uint64 max_abs_sample_value = 1 << (subframe_bps - 1);
+	FLAC__uint64 max_abs_sample_value = (FLAC__uint64)(1) << (subframe_bps - 1);
 	FLAC__uint32 abs_sum_of_qlp_coeff = 0;
 	uint32_t i;
 	for(i = 0; i < order; i++)


### PR DESCRIPTION
This takes #700 one step further

In the following dataset, `./current` is a binary without this PR and #700, `./mulbits` is without this PR but with #700 and `./betterbps` is including this PR. Testdata is the same as for #700: an upsampled set of short samples. Results are most pronounced for `-5p` on 24-bit material, see emphasis.

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `./betterbps -5 -j2 -c ../Rarewares-16bit.flac` | 1.214 ± 0.014 | 1.197 | 1.238 | 1.00 |
| `./mulbits -5 -j2 -c ../Rarewares-16bit.flac` | 1.223 ± 0.010 | 1.207 | 1.237 | 1.01 ± 0.01 |
| `./current -5 -j2 -c ../Rarewares-16bit.flac` | 1.217 ± 0.024 | 1.177 | 1.256 | 1.00 ± 0.02 |
| `./betterbps -5p -j2 -c ../Rarewares-16bit.flac` | 1.504 ± 0.035 | 1.463 | 1.552 | 1.24 ± 0.03 |
| `./mulbits -5p -j2 -c ../Rarewares-16bit.flac` | 1.495 ± 0.030 | 1.457 | 1.538 | 1.23 ± 0.03 |
| `./current -5p -j2 -c ../Rarewares-16bit.flac` | 1.497 ± 0.033 | 1.457 | 1.557 | 1.23 ± 0.03 |
| `./betterbps -8 -j2 -c ../Rarewares-16bit.flac` | 2.025 ± 0.014 | 2.005 | 2.050 | 1.67 ± 0.02 |
| `./mulbits -8 -j2 -c ../Rarewares-16bit.flac` | 2.002 ± 0.015 | 1.979 | 2.023 | 1.65 ± 0.02 |
| `./current -8 -j2 -c ../Rarewares-16bit.flac` | 2.011 ± 0.033 | 1.961 | 2.056 | 1.66 ± 0.03 |
| `./betterbps -8p -j2 -c ../Rarewares-16bit.flac` | 6.172 ± 0.050 | 6.107 | 6.285 | 5.08 ± 0.07 |
| `./mulbits -8p -j2 -c ../Rarewares-16bit.flac` | 6.176 ± 0.098 | 6.087 | 6.356 | 5.09 ± 0.10 |
| `./current -8p -j2 -c ../Rarewares-16bit.flac` | 6.297 ± 0.076 | 6.194 | 6.401 | 5.19 ± 0.09 |
| `./betterbps -5 -j2 -c ../Rarewares-24bit.flac` | 2.414 ± 0.042 | 2.356 | 2.476 | 1.99 ± 0.04 |
| `./mulbits -5 -j2 -c ../Rarewares-24bit.flac` | 2.637 ± 0.036 | 2.574 | 2.685 | 2.17 ± 0.04 |
| `./current -5 -j2 -c ../Rarewares-24bit.flac` | 2.851 ± 0.055 | 2.766 | 2.921 | 2.35 ± 0.05 |
| `./betterbps -5p -j2 -c ../Rarewares-24bit.flac` | 4.289 ± 0.059 | 4.188 | 4.388 | **3.53 ± 0.06** |
| `./mulbits -5p -j2 -c ../Rarewares-24bit.flac` | 6.038 ± 0.114 | 5.936 | 6.308 | **4.97 ± 0.11** |
| `./current -5p -j2 -c ../Rarewares-24bit.flac` | 8.807 ± 0.098 | 8.678 | 8.992 | **7.25 ± 0.12** |
| `./betterbps -8 -j2 -c ../Rarewares-24bit.flac` | 10.126 ± 0.043 | 10.051 | 10.170 | 8.34 ± 0.10 |
| `./mulbits -8 -j2 -c ../Rarewares-24bit.flac` | 10.556 ± 0.076 | 10.481 | 10.718 | 8.69 ± 0.12 |
| `./current -8 -j2 -c ../Rarewares-24bit.flac` | 10.654 ± 0.044 | 10.623 | 10.762 | 8.77 ± 0.11 |
| `./betterbps -8p -j2 -c ../Rarewares-24bit.flac` | 66.274 ± 0.240 | 65.983 | 66.583 | 54.58 ± 0.66 |
| `./mulbits -8p -j2 -c ../Rarewares-24bit.flac` | 74.999 ± 0.077 | 74.884 | 75.150 | 61.76 ± 0.72 |
| `./current -8p -j2 -c ../Rarewares-24bit.flac` | 81.717 ± 0.122 | 81.525 | 81.929 | 67.30 ± 0.79 |
