### PR TITLE
export -lssp for static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,9 @@ if(MINGW AND (WITH_FORTIFY_SOURCE OR WITH_STACK_PROTECTOR))
     message(WARNING "Could not find libssp in MinGW, stack protection and/or FORTIFY_SOURCE are unavailable")
   else()
     link_libraries("ssp.a")
+    # static libraries don't carry over other static libraries in mingw
+    # we need to export it in the pkg-config
+    set(FLAC_STATIC_LIBS "-lssp")
   endif()
 elseif(NOT MSVC)
   set(HAVE_LIBSSP 1)

--- a/src/libFLAC/flac.pc.in
+++ b/src/libFLAC/flac.pc.in
@@ -8,5 +8,5 @@ Description: Free Lossless Audio Codec Library
 Version: @VERSION@
 Requires.private: @OGG_PACKAGE@
 Libs: -L${libdir} -lFLAC
-Libs.private: -lm
+Libs.private: -lm @FLAC_STATIC_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
`.a` files in MinGW don't list the other static libraries they depend on. We need to provide it through the pkg-config file.