### PR TITLE
test: stop using which

### DIFF
--- a/test/test_compression.sh
+++ b/test/test_compression.sh
@@ -21,7 +21,7 @@
 
 PATH="$(pwd)/../src/flac:$PATH"
 
-printf "Using FLAC binary : %s\n" "$(which flac)"
+printf "Using FLAC binary : %s\n" "$(command -v flac)"
 
 date="$(date "+%Y%m%dT%H%M%S")"
 fname="comp${date}.flac"


### PR DESCRIPTION
`which` is an external command which isn't required by POSIX.

Debian and other distributions (like Gentoo!) are looking to drop it from their base set of packages.

Switch to `command -v` which is, however, POSIX. See https://lwn.net/Articles/874049/.