### PR TITLE
Don't just pass 0 for samples in Ogg/FLAC callback

### DIFF
--- a/include/FLAC/stream_encoder.h
+++ b/include/FLAC/stream_encoder.h
@@ -538,11 +538,16 @@ typedef FLAC__StreamEncoderReadStatus (*FLAC__StreamEncoderReadCallback)(const F
  *  callback is being called to write metadata.
  *
  * \note
- * Unlike when writing to native FLAC, when writing to Ogg FLAC the
- * write callback will be called twice when writing each audio
- * frame; once for the page header, and once for the page body.
- * When writing the page header, the \a samples argument to the
- * write callback will be \c 0.
+ * Unlike when writing to native FLAC, when writing to Ogg FLAC the write
+ * callback will be called at least twice when writing each audio frame; once
+ * for the page header and once for the page body, possibly repeating this
+ * pair of calls several times in a batch with the same value of
+ * \a current_frame.  When writing the page header, as well as in all but the
+ * first page body write of the batch, the \a samples argument to the write
+ * callback will be \c 0. The full number of samples of the batch will be
+ * passed in the first page body write. Furthermore, it is possible that a few
+ * of these samples are retained in an internal Ogg encoding buffer and not
+ * actually encoded until the next batch.
  *
  * \note In general, FLAC__StreamEncoder functions which change the
  * state should not be called on the \a encoder while in the callback.

--- a/src/libFLAC/include/private/ogg_encoder_aspect.h
+++ b/src/libFLAC/include/private/ogg_encoder_aspect.h
@@ -49,6 +49,7 @@ typedef struct FLAC__OggEncoderAspect {
 	FLAC__bool seen_magic; /* true if we've seen the fLaC magic in the write callback yet */
 	FLAC__bool is_first_packet;
 	FLAC__uint64 samples_written;
+	uint32_t samples_in_submit_buffer;
 } FLAC__OggEncoderAspect;
 
 void FLAC__ogg_encoder_aspect_set_serial_number(FLAC__OggEncoderAspect *aspect, long value);


### PR DESCRIPTION
This is a fix for issue #661 where I motivated it in a comment, but the comments in the code are actually probably enough to explain it.