### PR TITLE
Remove debug messages

### DIFF
--- a/src/libFLAC/cpu.c
+++ b/src/libFLAC/cpu.c
@@ -45,14 +45,6 @@
 #include <cpuid.h> /* for __get_cpuid() and __get_cpuid_max() */
 #endif
 
-#ifndef NDEBUG
-#include <stdio.h>
-#define dfprintf flac_fprintf
-#else
-/* This is bad practice, it should be a static void empty function */
-#define dfprintf(file, format, ...)
-#endif
-
 #if defined(HAVE_SYS_AUXV_H)
 #include <sys/auxv.h>
 #endif
@@ -190,35 +182,11 @@ x86_cpu_info (FLAC__CPUInfo *info)
 		info->x86.bmi2  = (flags_ebx & FLAC__CPUINFO_X86_CPUID_BMI2   ) ? true : false;
 	}
 
-#if defined FLAC__CPU_IA32
-	dfprintf(stderr, "CPU info (IA-32):\n");
-#else
-	dfprintf(stderr, "CPU info (x86-64):\n");
-#endif
-	dfprintf(stderr, "  CMOV ....... %c\n", info->x86.cmov    ? 'Y' : 'n');
-	dfprintf(stderr, "  MMX ........ %c\n", info->x86.mmx     ? 'Y' : 'n');
-	dfprintf(stderr, "  SSE ........ %c\n", info->x86.sse     ? 'Y' : 'n');
-	dfprintf(stderr, "  SSE2 ....... %c\n", info->x86.sse2    ? 'Y' : 'n');
-	dfprintf(stderr, "  SSE3 ....... %c\n", info->x86.sse3    ? 'Y' : 'n');
-	dfprintf(stderr, "  SSSE3 ...... %c\n", info->x86.ssse3   ? 'Y' : 'n');
-	dfprintf(stderr, "  SSE41 ...... %c\n", info->x86.sse41   ? 'Y' : 'n');
-	dfprintf(stderr, "  SSE42 ...... %c\n", info->x86.sse42   ? 'Y' : 'n');
-
-	if (FLAC__AVX_SUPPORTED) {
-		dfprintf(stderr, "  AVX ........ %c\n", info->x86.avx     ? 'Y' : 'n');
-		dfprintf(stderr, "  FMA ........ %c\n", info->x86.fma     ? 'Y' : 'n');
-		dfprintf(stderr, "  AVX2 ....... %c\n", info->x86.avx2    ? 'Y' : 'n');
-		dfprintf(stderr, "  BMI2 ....... %c\n", info->x86.bmi2    ? 'Y' : 'n');
-	}
-
 	/*
 	 * now have to check for OS support of AVX instructions
 	 */
 	if (FLAC__AVX_SUPPORTED && info->x86.avx && x86_osxsave && (cpu_xgetbv_x86() & 0x6) == 0x6) {
 		os_avx = true;
-	}
-	if (os_avx) {
-		dfprintf(stderr, "  AVX OS sup . %c\n", info->x86.avx ? 'Y' : 'n');
 	}
 	if (!os_avx) {
 		/* no OS AVX support */

--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -4994,9 +4994,6 @@ FLAC__bool set_partitioned_rice_(
 			rice_parameter = FLAC__bitmath_ilog2_wide(((mean - 1)*partition_samples_fixed_point_divisor)>>18) + 1;
 
 		if(rice_parameter >= rice_parameter_limit) {
-#ifndef NDEBUG
-			flac_fprintf(stderr, "clipping rice_parameter (%u -> %u) @6\n", rice_parameter, rice_parameter_limit - 1);
-#endif
 			rice_parameter = rice_parameter_limit - 1;
 		}
 
@@ -5009,9 +5006,6 @@ FLAC__bool set_partitioned_rice_(
 				min_rice_parameter = rice_parameter - rice_parameter_search_dist;
 			max_rice_parameter = rice_parameter + rice_parameter_search_dist;
 			if(max_rice_parameter >= rice_parameter_limit) {
-#ifndef NDEBUG
-				flac_fprintf(stderr, "clipping rice_parameter (%u -> %u) @7\n", max_rice_parameter, rice_parameter_limit - 1);
-#endif
 				max_rice_parameter = rice_parameter_limit - 1;
 			}
 		}


### PR DESCRIPTION
When compiled with NDEBUG defined, the test suite output was extremely noisy. As both these debug messages have served me no use the last few years, it is time to remove them.