### PR TITLE
Disable fuzzer_tool_flac for i386

### DIFF
--- a/oss-fuzz/Makefile.am
+++ b/oss-fuzz/Makefile.am
@@ -35,7 +35,11 @@ EXTRA_DIST = \
 noinst_PROGRAMS =
 
 if USE_OSSFUZZERS
-noinst_PROGRAMS += fuzzer_encoder fuzzer_encoder_v2 fuzzer_decoder fuzzer_seek fuzzer_metadata fuzzer_reencoder fuzzer_tool_flac fuzzer_tool_metaflac
+noinst_PROGRAMS += fuzzer_encoder fuzzer_encoder_v2 fuzzer_decoder fuzzer_seek fuzzer_metadata fuzzer_reencoder fuzzer_tool_metaflac
+if FLaC__CPU_IA32
+else
+noinst_PROGRAMS += fuzzer_tool_flac
+endif
 endif
 
 fuzzer_encoder_SOURCES = encoder.cc

--- a/src/flac/encode.c
+++ b/src/flac/encode.c
@@ -1635,12 +1635,6 @@ static void static_metadata_clear(static_metadata_t *m)
 static FLAC__bool static_metadata_append(static_metadata_t *m, FLAC__StreamMetadata *d, FLAC__bool needs_delete)
 {
 	void *x;
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-#ifdef __i386__
-/* Work around i386 ASAN bug */
-	if(0 == d) return true;
-#endif
-#endif
 	if(0 == (x = safe_realloc_nofree_muladd2_(m->metadata, sizeof(*m->metadata), /*times (*/m->num_metadata, /*+*/1/*)*/)))
 		return false;
 	m->metadata = (FLAC__StreamMetadata**)x;
@@ -2919,13 +2913,6 @@ FLAC__bool fskip_ahead(FILE *f, FLAC__uint64 offset)
 {
 	static uint8_t dump[8192];
 	struct flac_stat_s stb;
-
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-#ifdef __i386__
-/* Work around i386 ASAN bug */
-	if(offset > (FLAC__uint64)(INT32_MAX)) return false;
-#endif
-#endif
 
 	if(flac_fstat(fileno(f), &stb) == 0 && (stb.st_mode & S_IFMT) == S_IFREG)
 	{


### PR DESCRIPTION
Revert commits ce91056 and 33b9a4a, disable tool_flac fuzzer for i386 ASAN because weird bugs (false positives) keep popping up