### PR TITLE
Fix heap overflow under out-of-memory conditions ...

### DIFF
--- a/src/libFLAC/ogg_decoder_aspect.c
+++ b/src/libFLAC/ogg_decoder_aspect.c
@@ -146,15 +146,15 @@ static FLAC__OggDecoderAspectReadStatus process_page_(FLAC__OggDecoderAspect *as
 
 static FLAC__bool check_size_of_link_allocation_(FLAC__OggDecoderAspect *aspect)
 {
-	/* reallocate in chunks of 4 */
+	/* double on reallocating */
 	if(aspect->current_linknumber >= aspect->number_of_links_allocated || aspect->current_linknumber_advance_read >= aspect->number_of_links_allocated) {
 		FLAC__OggDecoderAspect_LinkDetails * tmpptr = NULL;
-		if(NULL == (tmpptr = safe_realloc_nofree_mul_2op_(aspect->linkdetails,4+aspect->number_of_links_allocated,sizeof(FLAC__OggDecoderAspect_LinkDetails)))) {
+		if(NULL == (tmpptr = safe_realloc_nofree_mul_2op_(aspect->linkdetails,2*aspect->number_of_links_allocated,sizeof(FLAC__OggDecoderAspect_LinkDetails)))) {
 			return false;
 		}
 		aspect->linkdetails = tmpptr;
-		memset(aspect->linkdetails + aspect->number_of_links_allocated, 0, 4 * sizeof(FLAC__OggDecoderAspect_LinkDetails));
-		aspect->number_of_links_allocated += 4;
+		memset(aspect->linkdetails + aspect->number_of_links_allocated, 0, aspect->number_of_links_allocated * sizeof(FLAC__OggDecoderAspect_LinkDetails));
+		aspect->number_of_links_allocated *= 2;
 	}
 	return true;
 }
@@ -453,6 +453,11 @@ FLAC__OggDecoderAspectReadStatus FLAC__ogg_decoder_aspect_skip_link(FLAC__OggDec
 {
 	if(seek_callback == NULL || tell_callback == NULL || length_callback == NULL)
 		return FLAC__OGG_DECODER_ASPECT_READ_STATUS_CALLBACKS_NONFUNCTIONAL;
+
+	/* This extra check is here, because allocation failures while reading cannot always be
+	 * properly passed down the chain with the current API. So, instead, check again */
+	if(!check_size_of_link_allocation_(aspect))
+		return FLAC__OGG_DECODER_ASPECT_READ_STATUS_MEMORY_ALLOCATION_ERROR;
 
 	if(aspect->current_linknumber < aspect->number_of_links_indexed) {
 		if(aspect->linkdetails[aspect->current_linknumber].is_last) {


### PR DESCRIPTION
... and use realloc of linkdetails more efficiently. This should reduce the number of fuzzer timeouts for fuzzer_seek

Credit: Oss-Fuzz
Issue: https://issues.oss-fuzz.com/issues/379254072