### PR TITLE
Update flac.md: Reordering and updating options descriptions & more

### DIFF
--- a/man/flac.md
+++ b/man/flac.md
@@ -125,33 +125,27 @@ Some common **encoding** tasks using flac:
 :	Like above, except abc.wav is deleted if there were no errors.
 
 `flac --delete-input-file -w abc.wav`
-:	Like above, except abc.wav is deleted if there were no errors or warnings.
+:	Like above, except abc.wav is deleted if there were no errors and no warnings.
 
-`flac --best abc.wav`
-:	Encode abc.wav to abc.flac using the highest compression setting.
+`flac --best abc.wav` or `flac -8 abc.wav`
+:	Encode abc.wav to abc.flac using the highest compression preset.  
 
-`flac --verify abc.wav`
+`flac --verify abc.wav` or `flac -V abc.wav`
 :	Encode abc.wav to abc.flac and internally decode abc.flac to make sure it matches abc.wav.
 
 `flac -o my.flac abc.wav`
 :	Encode abc.wav to my.flac.
 
 `flac -T "TITLE=Bohemian Rhapsody" -T "ARTIST=Queen" abc.wav`
-:	Encode abc.wav and add some tags at the same time to abc.flac.
+:	Encode abc.wav and add some tags at the same time, to abc.flac.
 
-`flac *.wav`
-:	Encode all .wav files in the current directory.
+`flac abc.aiff foo.rf64 bar.w64`
+:	Encode abc.aiff to abc.flac, foo.rf64 to foo.flac and bar.w64 to bar.flac
 
-`flac abc.aiff`
-:	Encode abc.aiff to abc.flac.
+`flac *.wav *.aif`
+:	Encode all .wav files and all .aif files in the current directory.
 
-`flac abc.rf64`
-:	Encode abc.rf64 to abc.flac.
-
-`flac abc.w64`
-:	Encode abc.w64 to abc.flac.
-
-`flac abc.flac --force`
+`flac abc.flac --force` or `flac abc.flac -f`
 :	This one's a little tricky: notice that flac is in encode mode by
 	default (you have to specify -d to decode) so this command actually
 	recompresses abc.flac back to abc.flac. \--force is needed to make
@@ -159,30 +153,41 @@ Some common **encoding** tasks using flac:
 	would you want to do this? It allows you to recompress an existing
 	FLAC file with (usually) higher compression options or a newer
 	version of FLAC and preserve all the metadata like tags too.
+ 	Note: If the FLAC file does not end with .flac - say, it is abc.fla
+  	- then a new abc.flac will be created and the old kept, just like 
+   	for an uncompressed input file.
+
+`flac -8Vfo Track04.flac -T "ARTIST=Queen" -- -4.wav`
+:	Options in their short version - those invoked with single dash - 
+	can be concatenated until one that takes an argument: here -o and 
+ 	-T do, and so one of them requires its own dash. 
+	This command line takes the track -4.wav as input; its filename 
+ 	starts with a dash, so it needs the \-- to keep the encoder from
+  	taking the "4" as an option. All options must go before the --: 
+        It will overwrite any Track04.flac already present, encode with
+	highest compression preset, decode to verify that it matches, and 
+ 	a tag will be added. 
+
 
 Some common **decoding** tasks using flac:
 
-`flac -d abc.flac`
+`flac --decode abc.flac` or `flac -d abc.flac`
 :	Decode abc.flac to abc.wav. abc.flac is not deleted. NOTE: Without 
-	-d it means re-encode abc.flac to abc.flac (see above).
+	-d it would mean to re-encode abc.flac to abc.flac (see above) and 
+ 	would err out because abc.flac already exists.
 
-`flac -d --force-aiff-format abc.flac`  
-
-`flac -d -o abc.aiff abc.flac`
+`flac -d --force-aiff-format abc.flac` or `flac -d -o abc.aiff abc.flac`
 :	Two different ways of decoding abc.flac to abc.aiff (AIFF format).
-	abc.flac is not deleted.
+	abc.flac is not deleted. -d -o could be concatenated to -do.
+ 	The decoder can force other output formats, see the options below.
 
-`flac -d --force-rf64-format abc.flac`  
-
-`flac -d -o abc.rf64 abc.flac`
-:	Two different ways of decoding abc.flac to abc.rf64 (RF64 format).
-	abc.flac is not deleted.
-
-`flac -d --force-wave64-format abc.flac`  
-
-`flac -d -o abc.w64 abc.flac`
-:	Two different ways of decoding abc.flac to abc.w64 (Wave64 format).
-	abc.flac is not deleted.
+`flac -d --keep-foreign-metadata-if-present abc.flac`
+:	FLAC files can store non-audio chunks of input WAVE/AIFF/RF64/W64
+	files. If there are such chunks stored, the decoder will select
+ 	output format accordingly and restore both audio and non-audio.
+  	If there are no such chunks stored, it will decode to abc.wav.
+   	The related option \--keep-foreign-metadata will instead exit 
+    	with an error if no such non-audio chunks are found.
 
 `flac -d -F abc.flac`
 :	Decode abc.flac to abc.wav and don't abort if errors are found
@@ -192,18 +197,16 @@ Some common **decoding** tasks using flac:
 # OPTIONS
 
 A summary of options is included below. For a complete description, see
-the HTML documentation.
+the HTML documentation. Several of the options can be negated, see the 
+**Negative options** section below.
 
 ## GENERAL OPTIONS
 
 **-v, \--version**
-:	Show the flac version number
+:	Show the flac version number, and quit.
 
 **-h, \--help**
-:	Show basic usage and a list of all options
-
-**-H, \--explain**
-:	Show detailed explanation of usage and all options
+:	Show basic usage and a list of all options, and quit.
 
 **-d, \--decode**
 :	Decode (the default behavior is to encode)
@@ -220,45 +223,29 @@ the HTML documentation.
 **-c, \--stdout**
 :	Write output to stdout
 
-**-s, \--silent**
-:	Silent mode (do not write runtime encode/decode statistics to stderr)
-
-**\--totally-silent**
-: Do not print anything of any kind, including warnings or errors. The
-	exit code will be the only way to determine successful completion.
-
-**\--no-utf8-convert**
-:	Do not convert tags from local charset to UTF-8. This is useful for
-	scripts, and setting tags in situations where the locale is wrong.
-	This option must appear before any tag options!
-
-**-w, \--warnings-as-errors**
-:	Treat all warnings as errors (which cause flac to terminate with a
-	non-zero exit code).
-
 **-f, \--force**
 :	Force overwriting of output files. By default, flac warns that the
 	output file already exists and continues to the next file.
-
-**-o** *filename***, \--output-name=***filename*
-:	Force the output file name (usually flac just changes the extension).
-	May only be used when encoding a single file. May not be used in
-	conjunction with \--output-prefix.
-
-**\--output-prefix=***string*
-:	Prefix each output file name with the given string. This can be
-	useful for encoding or decoding files to a different directory. Make
-	sure if your string is a path name that it ends with a trailing \`/'
-	(slash).
 
 **\--delete-input-file**
 :	Automatically delete the input file after a successful encode or
 	decode. If there was an error (including a verify error) the input
 	file is left intact.
 
+**-o** _filename_, **\--output-name=** _filename_
+:	Force the output file name (usually flac just changes the extension).
+	May only be used when encoding a single file. May not be used in
+	conjunction with \--output-prefix.
+
+**\--output-prefix=** _string_
+:	Prefix each output file name with the given string. This can be
+	useful for encoding or decoding files to a different directory. Make
+	sure if your string is a path name that it ends with a trailing \`/'
+	(slash).
+
 **\--preserve-modtime**
-:	Output files have their timestamps/permissions set to match those of
-	their inputs (this is default). Use \--no-preserve-modtime to make
+:	(default!) Output files have their timestamps/permissions set to 
+	match those of their inputs. Use \--no-preserve-modtime to make
 	output files have the current time and default permissions.
 
 **\--keep-foreign-metadata**
@@ -268,20 +255,20 @@ the HTML documentation.
 	transcoded, e.g. WAVE chunks saved in a FLAC file cannot be restored
 	when decoding to AIFF. Input and output must be regular files (not
 	stdin or stdout). With this option, FLAC will pick the right output
-	format on decoding.
+	format on decoding. It will exit with error if no such chunks are found.
 
 **\--keep-foreign-metadata-if-present**
 :	Like \--keep-foreign-metadata, but without throwing an error if
-	foreign metadata cannot be found or restored, instead printing a 
+	foreign metadata cannot be found or restored.  Instead, prints a 
 	warning.
 
-**\--skip={***\#***\|***mm:ss.ss***}**
+**\--skip={**_\#_**\|**_mm:ss.ss_**}**
 :	Skip over the first number of samples of the input. This works for
 	both encoding and decoding, but not testing. The alternative form
 	mm:ss.ss can be used to specify minutes, seconds, and fractions of a
 	second.
 
-**\--until={***\#***\|\[***+***\|***-***\]***mm:ss.ss***}**
+**\--until={**_\#_**\|\[**_+_**\|**_-_**\]**_mm:ss.ss_**}**
 :	Stop at the given sample number for each input file. This works for
 	both encoding and decoding, but not testing. The given sample number
 	is not included in the decoded output. The alternative form mm:ss.ss
@@ -290,36 +277,32 @@ the HTML documentation.
 	relative to the \--skip point. If a \`-' (minus) sign is at the
 	beginning, the \--until point is relative to end of the audio.
 
-**\--ogg**
-:	When encoding, generate Ogg FLAC output instead of native FLAC. Ogg
-	FLAC streams are FLAC streams wrapped in an Ogg transport layer. The
-	resulting file should have an '.oga' extension and will still be
-	decodable by flac. When decoding, force the input to be treated as
-	Ogg FLAC. This is useful when piping input from stdin or when the
-	filename does not end in '.oga' or '.ogg'.
+**\--no-utf8-convert**
+:	Do not convert tags from local charset to UTF-8. This is useful for
+	scripts, and setting tags in situations where the locale is wrong.
+	This option must appear before any tag options!
 
-**\--serial-number=***\#*
-:	When used with \--ogg, specifies the serial number to use for the
-	first Ogg FLAC stream, which is then incremented for each additional
-	stream. When encoding and no serial number is given, flac uses a
-	random number for the first stream, then increments it for each
-	additional stream. When decoding and no number is given, flac uses
-	the serial number of the first page.
+**-s, \--silent**
+:	Silent mode (do not write runtime encode/decode statistics to stderr)
 
-## ANALYSIS OPTIONS
+**\--totally-silent**
+: Do not print anything of any kind, including warnings or errors. The
+	exit code will be the only way to determine successful completion.
 
-**\--residual-text**
-:	Includes the residual signal in the analysis file. This will make the
-	file very big, much larger than even the decoded file.
-
-**\--residual-gnuplot**
-:	Generates a gnuplot file for every subframe; each file will contain
-	the residual distribution of the subframe. This will create a lot of
-	files.
+**-w, \--warnings-as-errors**
+:	Treat all warnings as errors (which cause flac to terminate with a
+	non-zero exit code).
 
 ## DECODING OPTIONS
 
-**\--cue=\[***\#.#***\]\[-\[***\#.#***\]\]**
+**-F, \--decode-through-errors**
+:	By default flac stops decoding with an error and removes the
+	partially decoded file if it encounters a bitstream error. With -F,
+	errors are still printed but flac will continue decoding to
+	completion. Note that errors may cause the decoded audio to be
+	missing some samples or have silent sections.
+
+**\--cue=\[**_\#.#_**\]\[-\[**_\#.#_**\]\]**
 :	Set the beginning and ending cuepoints to decode. The optional first
 	\#.# is the track and index point at which decoding will start; the
 	default is the beginning of the stream. The optional second \#.# is
@@ -332,12 +315,8 @@ the HTML documentation.
 	\--skip and \--until. A CD track can always be cued by, for example,
 	\--cue=9.1-10.1 for track 9, even if the CD has no 10th track.
 
-**-F, \--decode-through-errors**
-:	By default flac stops decoding with an error and removes the
-	partially decoded file if it encounters a bitstream error. With -F,
-	errors are still printed but flac will continue decoding to
-	completion. Note that errors may cause the decoded audio to be
-	missing some samples or have silent sections.
+**--decode-chained-stream**
+: Decode all links in a chained Ogg stream, not just the first one.
 
 **\--apply-replaygain-which-is-not-lossless\[=\<specification\>\]**
 :	Applies ReplayGain values while decoding. **WARNING: THIS IS NOT
@@ -349,9 +328,78 @@ the HTML documentation.
 
 ## ENCODING OPTIONS
 
+Encoding will default to -5, -A "tukey(5e-1)" and one CPU thread.
+
 **-V, \--verify**
 :	Verify a correct encoding by decoding the output in parallel and
-	comparing to the original
+	comparing to the original.
+
+**-0, \--compression-level-0, \--fast**
+:	Fastest compression preset. Synonymous with `-l 0 -b 1152 -r 3 --no-mid-side`
+
+**-1, \--compression-level-1**
+:	Synonymous with `-l 0 -b 1152 -M -r 3`
+
+**-2, \--compression-level-2**
+:	Synonymous with `-l 0 -b 1152 -m -r 3`
+
+**-3, \--compression-level-3**
+:	Synonymous with `-l 6 -b 4096 -r 4 --no-mid-side`
+
+**-4, \--compression-level-4**
+:	Synonymous with `-l 8 -b 4096 -M -r 4`
+
+**-5, \--compression-level-5**
+:	Synonymous with `-l 8 -b 4096 -m -r 5`
+
+**-6, \--compression-level-6**
+:	Synonymous with `-l 8 -b 4096 -m -r 6 -A "subdivide_tukey(2)"`
+
+**-7, \--compression-level-7**
+:	Synonymous with `-l 12 -b 4096 -m -r 6 -A "subdivide_tukey(2)"`
+
+**-8, \--compression-level-8, \--best**
+:	Synonymous with `-l 12 -b 4096 -m -r 6 -A "subdivide_tukey(3)"`
+
+**-l** _\#_**, \--max-lpc-order=**_\#_  
+:	Specifies the maximum LPC order. This number must be \<= 32. For
+	subset streams, it must be \<=12 if the sample rate is \<=48kHz. If
+	0, the encoder will not attempt generic linear prediction, and use
+	only fixed predictors. Using fixed predictors is faster but usually
+	results in files being 5-10% larger.
+
+**-b** _\#_**, \--blocksize=**_\#_  
+:	Specify the blocksize in samples. The default is 1152 for -l 0,
+	else 4096. Blocksize must be between 16 and 65535 (inclusive). 
+ 	For subset streams it must be \<= 4608 if the samplerate is 
+  	\<= 48kHz, for subset streams with higher samplerates it must be \<=
+	16384.
+
+**-m, \--mid-side**
+:	Try mid-side coding for each frame (stereo input only, otherwise ignored)
+
+**-M, \--adaptive-mid-side**
+:	Adaptive mid-side coding for all frames (stereo input only, otherwise ignored)
+
+**-r \[**_\#_**,\]**_\#_**, \--rice-partition-order=\[**_\#_**,\]**_\#_  
+:	Set the \[min,\]max residual partition order (0..15).  For subset streams 
+	max must be \<=8.  min defaults to 0 if unspecified. Default is -r 5.
+
+**-A** _function_**, \--apodization=** _function_  
+:	Window audio data with given the apodization function(s). See section
+	**Apodization functions** for details.
+
+**-e, \--exhaustive-model-search**
+:	Do exhaustive model search (expensive!)
+
+**-q** _\#_**, \--qlp-coeff-precision=**_\#_  
+:	Precision of the quantized linear-predictor coefficients. This number must 
+	be in between 5 and 16, or 0 (default) =\> to encoder decide.  
+ 	Does nothing if using -l 0. 
+
+**-p, \--qlp-coeff-precision-search**
+:	Do exhaustive search of LP coefficient quantization (expensive!).
+	Overrides -q; does nothing if using -l 0
 
 **\--lax**
 :	Allow encoder to generate non-Subset files. The resulting FLAC file
@@ -360,14 +408,27 @@ the HTML documentation.
 	option in combination with custom encoding options meant for
 	archival.
 
-**-j** *\#***, \--threads=***\#*  
+**\--limit-min-bitrate**
+:	Ensure a certain minimum bitrate. This is sometimes needed for 
+	streaming. 
+
+**-j** _\#_**, \--threads=**_\#_  
 :	Try to set a maximum number of threads to use for encoding. If
 	multithreading was not enabled on compilation or when setting a
 	number of threads that is too high, this fails with a warning. The
-	value of 0 is currently equal to 1 thread (i.e. no multithreading)
-	but may mean something else in the future. Currently the maximum
-	supported number of threads is 128. Using a value higher than the
-	number of available CPU threads harms performance.
+	value of 0 means a default set by the encoder; currently that is 1 
+ 	thread (i.e. no multithreading), but that could change in the 
+  	future.  Currently, up to 128 threads are supported. Using a value 
+   	higher than the number of available CPU threads harms performance.
+
+**\--ignore-chunk-sizes**
+:	When encoding to flac, ignore the file size headers in WAV and AIFF
+	files to attempt to work around problems with over-sized or malformed
+	files. WAV and AIFF files both specifies length of audio data with
+ 	an unsigned 32-bit number, limiting audio to just over 4 gigabytes. 
+  	Files larger than this are malformed, but should be read correctly 
+   	using this option. However, it could interpret any data following
+    	the audio chunk, as audio.
 
 **\--replay-gain**
 :	Calculate ReplayGain values and store them as FLAC tags, similar to
@@ -383,13 +444,13 @@ the HTML documentation.
 	are processed. Note that this option cannot be used when encoding
 	to standard output (stdout).
 
-**\--cuesheet=***filename*  
+**\--cuesheet=**_filename_  
 :	Import the given cuesheet file and store it in a CUESHEET metadata
 	block. This option may only be used when encoding a single file. A
 	seekpoint will be added for each index point in the cuesheet to the
 	SEEKTABLE unless \--no-cued-seekpoints is specified.
 
-**\--picture={***FILENAME***\|***SPECIFICATION***}**
+**\--picture={**_FILENAME_**\|**_SPECIFICATION_**}**
 :	Import a picture and store it in a PICTURE metadata block. More than
 	one \--picture option can be specified. Either a filename for the
 	picture file or a more complete specification form can be used. The
@@ -398,16 +459,7 @@ the HTML documentation.
 	FILENAME is just shorthand for "\|\|\|\|FILENAME". For the format of
 	SPECIFICATION, see the section **picture specification**.
 
-**\--ignore-chunk-sizes**
-:	When encoding to flac, ignore the file size headers in WAV and AIFF
-	files to attempt to work around problems with over-sized or malformed
-	files. WAV and AIFF files both have an unsigned 32 bit numbers in
-	the file header which specifes the length of audio data. Since this
-	number is unsigned 32 bits, that limits the size of a valid file to
-	being just over 4 Gigabytes. Files larger than this are mal-formed,
-	but should be read correctly using this option.
-
-**-S {***\#***\|***X***\|***\#x***\|***\#s***}, \--seekpoint={***\#***\|***X***\|***\#x***\|***\#s***}**
+**-S {**_\#_**\|**_X_**\|**_\#x_**\|**_\#s_**}, \--seekpoint={**_\#_**\|**_X_**\|**_\#x_**\|**_\#s_**}**
 :	Include a point or points in a SEEKTABLE. Using \#, a seek point at
 	that sample number is added. Using X, a placeholder point is added at
 	the end of a the table. Using \#x, \# evenly spaced seek points will
@@ -423,162 +475,118 @@ the HTML documentation.
 	size is determinable before encoding starts) or a placeholder point
 	(if input size is not determinable).
 
-**-P** *\#***, \--padding=***\#*  
-:	Tell the encoder to write a PADDING metadata block of the given
-	length (in bytes) after the STREAMINFO block. This is useful if you
-	plan to tag the file later with an APPLICATION block; instead of
-	having to rewrite the entire file later just to insert your block,
-	you can write directly over the PADDING block. Note that the total
-	length of the PADDING block will be 4 bytes longer than the length
-	given because of the 4 metadata block header bytes. You can force no
-	PADDING block at all to be written with \--no-padding. The encoder
-	writes a PADDING block of 8192 bytes by default (or 65536 bytes if
-	the input audio stream is more that 20 minutes long).
+**-P** _\#_**, \--padding=**_\#_  
+:	(default: 8192 bytes, although 65536 for input audio above 20 minutes) 
+	Tell the encoder to write a PADDING metadata block of the given
+	length (in bytes) after the STREAMINFO block. This is useful for 
+ 	later tagging, where one can write over the PADDING block instead 
+  	of having to rewrite the entire file. Note that a block header 
+        of 4 bytes will come on top of the length specified.
 
-**-T** *FIELD=VALUE***, \--tag=***FIELD=VALUE*  
+**-T** "_FIELD=VALUE_"**, \--tag=**"_FIELD=VALUE_"  
 :	Add a FLAC tag. The comment must adhere to the Vorbis comment spec;
 	i.e. the FIELD must contain only legal characters, terminated by an
 	'equals' sign. Make sure to quote the comment if necessary. This
-	option may appear more than once to add several comments. NOTE: all
-	tags will be added to all encoded files.
+	option may appear more than once to add several comments. 
+ 	NOTE: all tags will be added to all encoded files.
 
-**\--tag-from-file=***FIELD=FILENAME*  
+**\--tag-from-file=**_FIELD=FILENAME_  
 :	Like \--tag, except FILENAME is a file whose contents will be read
 	verbatim to set the tag value. The contents will be converted to
 	UTF-8 from the local charset. This can be used to store a cuesheet
 	in a tag (e.g. \--tag-from-file="CUESHEET=image.cue"). Do not try to
 	store binary data in tag fields! Use APPLICATION blocks for that.
 
-**-b** *\#***, \--blocksize=***\#*  
-:	Specify the blocksize in samples. The default is 1152 for -l 0,
-	else 4096. For subset streams this must be \<= 4608 if the samplerate
-	\<= 48kHz, for subset streams with higher samplerates it must be \<=
-	16384.
-
-**-m, \--mid-side**
-:	Try mid-side coding for each frame (stereo input only)
-
-**-M, \--adaptive-mid-side**
-:	Adaptive mid-side coding for all frames (stereo input only)
-
-**-0..-8, \--compression-level-0..\--compression-level-8**
-:	Fastest compression..highest compression (default is -5). These are
-	synonyms for other options:
-
-**-0, \--compression-level-0**
-:	Synonymous with -l 0 -b 1152 -r 3 \--no-mid-side
-
-**-1, \--compression-level-1**
-:	Synonymous with -l 0 -b 1152 -M -r 3
-
-**-2, \--compression-level-2**
-:	Synonymous with -l 0 -b 1152 -m -r 3
-
-**-3, \--compression-level-3**
-:	Synonymous with -l 6 -b 4096 -r 4 \--no-mid-side
-
-**-4, \--compression-level-4**
-:	Synonymous with -l 8 -b 4096 -M -r 4
-
-**-5, \--compression-level-5**
-:	Synonymous with -l 8 -b 4096 -m -r 5
-
-**-6, \--compression-level-6**
-:	Synonymous with -l 8 -b 4096 -m -r 6 -A subdivide_tukey(2)
-
-**-7, \--compression-level-7**
-:	Synonymous with -l 12 -b 4096 -m -r 6 -A subdivide_tukey(2)
-
-**-8, \--compression-level-8**
-:	Synonymous with -l 12 -b 4096 -m -r 6 -A subdivide_tukey(3)
-
-**\--fast**
-:	Fastest compression. Currently synonymous with -0.
-
-**\--best**
-:	Highest compression. Currently synonymous with -8.
-
-**-e, \--exhaustive-model-search**
-:	Do exhaustive model search (expensive!)
-
-**-A** *function***, \--apodization=***function*  
-:	Window audio data with given the apodization function. See section
-	**Apodization functions** for details.
-
-**-l** *\#***, \--max-lpc-order=***\#*  
-:	Specifies the maximum LPC order. This number must be \<= 32. For
-	subset streams, it must be \<=12 if the sample rate is \<=48kHz. If
-	0, the encoder will not attempt generic linear prediction, and use
-	only fixed predictors. Using fixed predictors is faster but usually
-	results in files being 5-10% larger.
-
-**-p, \--qlp-coeff-precision-search**
-:	Do exhaustive search of LP coefficient quantization (expensive!).
-	Overrides -q; does nothing if using -l 0
-
-**-q** *\#***, \--qlp-coeff-precision=***\#*  
-:	Precision of the quantized linear-predictor coefficients, 0 =\> let
-	encoder decide (min is 5, default is 0)
-
-**-r \[***\#***,\]***\#***, \--rice-partition-order=\[***\#***,\]***\#*  
-:	Set the \[min,\]max residual partition order (0..15). min defaults to
-	0 if unspecified. Default is -r 5.
 
 ## FORMAT OPTIONS
 
-**\--endian={***big***\|***little***}**
-:	Set the byte order for samples
+Encoding defaults to FLAC and not OGG.  Decoding defaults to WAVE (more
+specifically WAVE_FORMAT_PCM for mono/stereo with 8/16 bits, and to 
+WAVE_FORMAT_EXTENSIBLE otherwise), except: will be overridden by chunks 
+found by \--keep-foreign-metadata-if-present or \--keep-foreign-metadata 
 
-**\--channels=***\#*
-:	Set number of channels.
+**\--ogg**
+:	When encoding, generate Ogg FLAC output instead of native FLAC. Ogg
+	FLAC streams are FLAC streams wrapped in an Ogg transport layer. The
+	resulting file should have an '.oga' extension and will still be
+	decodable by flac. When decoding, force the input to be treated as
+	Ogg FLAC. This is useful when piping input from stdin or when the
+	filename does not end in '.oga' or '.ogg'.
 
-**\--bps=***\#*
-:	Set bits per sample.
-
-**\--sample-rate=***\#*
-:	Set sample rate (in Hz).
-
-**\--sign={***signed***\|***unsigned***}**
-:	Set the sign of samples.
-
-**\--input-size=***\#*
-:	Specify the size of the raw input in bytes. If you are encoding raw
-	samples from stdin, you must set this option in order to be able to
-	use \--skip, \--until, \--cuesheet, or other options that need to
-	know the size of the input beforehand. If the size given is greater
-	than what is found in the input stream, the encoder will complain
-	about an unexpected end-of-file. If the size given is less, samples
-	will be truncated.
-
-**\--force-raw-format**
-:	Force input (when encoding) or output (when decoding) to be treated
-	as raw samples (even if filename ends in *.wav*).
+**\--serial-number=**_\#_
+:	When used with \--ogg, specifies the serial number to use for the
+	first Ogg FLAC stream, which is then incremented for each additional
+	stream. When encoding and no serial number is given, flac uses a
+	random number for the first stream, then increments it for each
+	additional stream. When decoding and no number is given, flac uses
+	the serial number of the first page.
 
 **\--force-aiff-format**  
 **\--force-rf64-format**  
 **\--force-wave64-format**
-:	Force the decoder to output AIFF/RF64/WAVE64 format respectively.
+:	For decoding: Override default output format and force output to 
+	AIFF/RF64/WAVE64, respectively.
 	This option is not needed if the output filename (as set by -o) 
-	ends with *.aif* or *.aiff*, *.rf64* and *.w64* respectively. Also,
-	this option has no effect when encoding since input is
-	auto-detected. When none of these options nor 
-	\--keep-foreign-metadata are given and no output filename is set,
-	the output format is WAV by default.
+	ends with *.aif* or *.aiff*, *.rf64* and *.w64* respectively. 
+ 	The encoder auto-detects format and ignores this option. 
 
 **\--force-legacy-wave-format**  
 **\--force-extensible-wave-format**
 :	Instruct the decoder to output a WAVE file with WAVE_FORMAT_PCM and
-	WAVE_FORMAT_EXTENSIBLE respectively. If none of these options nor
-	\--keep-foreign-metadata are given, FLAC outputs WAVE_FORMAT_PCM
-	for mono or stereo with a bit depth of 8 or 16 bits, and
-	WAVE_FORMAT_EXTENSIBLE for all other audio formats.
+	WAVE_FORMAT_EXTENSIBLE respectively, overriding default choice.
 
 **\--force-aiff-c-none-format**  
 **\--force-aiff-c-sowt-format**
 :	Instruct the decoder to output an AIFF-C file with format NONE and
 	sowt respectively.
 
+**\--force-raw-format**
+:	Force input (when encoding) or output (when decoding) to be treated
+	as raw samples (even if filename suggests otherwise).
+
+### raw format options
+
+When encoding from or decoding to raw PCM, format must be specified.
+
+**\--sign={**_signed_**\|**_unsigned_**}**
+:	Specify the sign of samples.
+
+**\--endian={**_big_**\|**_little_**}**
+:	Specify the byte order for samples
+
+**\--channels=**_\#_
+:	(Input only) specify number of channels.  For output, the channels 
+	of the FLAC file will be written interleaved. 
+
+**\--bps=**_\#_
+:	(Input only) specify bits per sample (per channel: 16 for CDDA.)
+
+**\--sample-rate=**_\#_
+:	(Input only) specify sample rate (in Hz).
+
+**\--input-size=**_\#_
+:	(Input only) specify the size of the raw input in bytes.  This is only
+	compulsory when encoding from stdin and using options that need to 
+ 	know the input size beforehand (like, \--skip, \--until, \--cuesheet )
+	The encoder will truncate at the specified size if the input stream is
+ 	bigger.  If the input stream is smaller, it will complain about an 
+  	unexpected end-of-file. 
+
+## ANALYSIS OPTIONS
+
+**\--residual-text**
+:	Includes the residual signal in the analysis file. This will make the
+	file very big, much larger than even the decoded file.
+
+**\--residual-gnuplot**
+:	Generates a gnuplot file for every subframe; each file will contain
+	the residual distribution of the subframe. This will create a lot of
+	files. gnuplot must be installed separately. 
+
+
 ## NEGATIVE OPTIONS
+
+The following will negate an option previously given:
 
 **\--no-adaptive-mid-side**  
 **\--no-cued-seekpoints**  
@@ -601,11 +609,9 @@ the HTML documentation.
 **\--no-verify**  
 **\--no-warnings-as-errors**
 
-These flags can be used to invert the sense of the corresponding normal
-option.
 
 ## ReplayGain application specification
-The option \--apply-replaygain-which-is-not-lossless\[=\<specification\>\]**
+The option \--apply-replaygain-which-is-not-lossless\[=\<specification\>\]
 applies ReplayGain values while decoding. **WARNING: THIS IS NOT
 LOSSLESS. DECODED AUDIO WILL NOT BE IDENTICAL TO THE ORIGINAL WITH THIS
 OPTION.** This option is useful for example in transcoding media servers,

--- a/man/flac.md
+++ b/man/flac.md
@@ -799,7 +799,7 @@ e.g. tukey(0.5) or tukey(0,5) depending on your system.
 that is cosine-tapered; *P*=0 corresponds to "rectangle" and *P*=1 to "hann". 
 
 - partial_tukey(*N*) and punchout_tukey(*N*) are largely obsoleted by the 
-more time-effective subdivide_tukey(*N*), see next item. They generate n 
+more time-effective subdivide_tukey(*N*), see next item. They generate *N* 
 functions each spanning a part of each block. Optional arguments are an 
 overlap *OV* (\<1, may be negative), for example partial_tukey(2/2e-1); 
 and then a taper parameter *P*, for example partial_tukey(2/2e-1/5e-1).

--- a/man/flac.md
+++ b/man/flac.md
@@ -41,6 +41,7 @@ the convention is that FLAC files have the extension ".flac"
 
 Before going into the full command-line description, a few other things
 help to sort it out:
+
 1.	flac encodes by default, so you must use -d to decode
 2.	Encoding options -0 .. -8 (or \--fast and \--best) that control the
 	compression level actually are just synonyms for different groups of

--- a/man/flac.md
+++ b/man/flac.md
@@ -41,17 +41,19 @@ the convention is that FLAC files have the extension ".flac"
 
 Before going into the full command-line description, a few other things
 help to sort it out:
-1. flac encodes by default, so you must use -d to decode
-2. the options -0 .. -8 (or \--fast and \--best) that control the
-   compression level actually are just synonyms for different groups of
-   specific encoding options (described later) and you can get the same
-   effect by using the same options. When specific options are specified
-   they take priority over the compression level no matter the order
-3. flac behaves similarly to gzip in the way it handles input and output
-   files
-4. the order in which options are specified is generally not important
+1.	flac encodes by default, so you must use -d to decode
+2.	Encoding options -0 .. -8 (or \--fast and \--best) that control the
+	compression level actually are just synonyms for different groups of
+	specific encoding options (described later).  
+3.	The order in which options are specified is generally not important 
+	except when they contradict each other, then the latter takes 
+	precedence except that compression presets are overridden by any
+	option given before or after. For example, -0M, -M0, -M2 and -2M are 
+	all the same as -1, and -l 12 -6 the same as -7.
+4.	flac behaves similarly to gzip in the way it handles input and output 
+	files
 
-Skip to the examples below for examples of some common tasks.
+Skip to the EXAMPLES section below for examples of some typical tasks.
 
 flac will be invoked one of four ways, depending on whether you are
 encoding, decoding, testing, or analyzing. Encoding is the default
@@ -116,7 +118,9 @@ the FLAC website.
 
 # EXAMPLES
 
-Some common **encoding** tasks using flac:
+Some typical encoding and decoding tasks using flac:
+
+## Encoding examples
 
 `flac abc.wav`
 :	Encode abc.wav to abc.flac using the default compression setting. abc.wav is not deleted.
@@ -145,25 +149,25 @@ Some common **encoding** tasks using flac:
  	.aif+one character) in the current directory.
 
 `flac abc.flac --force` or `flac abc.flac -f`
-:	This one's a little tricky: because flac defaults to encode mode 
-	(you have to specify -d to decode), this command actually recompresses 
-	abc.flac back to abc.flac. To prevent against accidental overwrites, 
-	flac requires \--force or shortform -f to force overwriting. It will 
-	then write a temporary file, which afterwards replaces the old 
-	abc.flac (provided flac has write access to that file). 
-	Why would you want to do this? It allows you to recompress an existing
-	FLAC file with (usually) higher compression options or a newer
-	version of FLAC and preserve all the metadata like tags too.
+:	Recompresses, keeping metadata like tags. The syntax is a little 
+	tricky: this is an *encoding* command (which is the default: you need 
+	to specify -d for decoded output), and will thus want to output the 
+	file abc.flac - which already exists. flac will require the \--force 
+	or shortform -f option to overwrite an existing file. Recompression 
+	will first write a temporary file, which afterwards replaces the old 
+	abc.flac (provided flac has write access to that file).
+	The above example uses default settings. More often, recompression is
+	combined with a different - usually higher - compression option.
  	Note: If the FLAC file does not end with .flac - say, it is abc.fla
-	- then a new abc.flac will be created and the old kept, just like 
-	for an uncompressed input file.
+	- the -f is not needed: A new abc.flac will be created and the old 
+	kept, just like for an uncompressed input file.
 
 `flac --tag-from-file="ALBUM=albumtitle.txt" -T "ARTIST=Queen" *.wav`
 :	Encode every .wav file in the directory and add some tags. Every 
 	file will get the same set of tags.
-	Warning: Will wipe all existing tags, when when the input file is 
-	(Ogg) FLAC - not just those listed. Use the metaflac utility to tag
-	FLAC files.
+	Warning: Will wipe all existing tags, when the input file is (Ogg) 
+	FLAC - not just those tags listed in the option. Use the metaflac 
+	utility to tag FLAC files.
 
 `flac --keep-foreign-metadata-if-present abc.wav`
 :	FLAC files can store non-audio chunks of input WAVE/AIFF/RF64/W64
@@ -174,19 +178,27 @@ Some common **encoding** tasks using flac:
 	the content into its own tags (vorbis comments). To transfer such
 	tags from a source file, use tagging software which supports them.
 
-`flac -8Vfo Track04.flac -T "ARTIST=Queen" -- -4.wav`
-:	Options in their short version - those invoked with single dash - 
-	can be concatenated until one that takes an argument: here -o and 
- 	-T do, and so one of them requires its own dash. 
-	This command line takes the track -4.wav as input; its filename 
- 	starts with a dash, so it needs the \-- to keep the encoder from
-	taking the "4" as an option. All options must go before the --:
-	It will overwrite any Track04.flac already present, encode with
-	highest compression preset, decode to verify that it matches, and 
-	a tag will be added. 
+`flac -Vj2 -m3fo Track07.flac  -- -7.wav`
+:	flac employs the commonplace convention that options in a short 
+	version - invoked with single dash - can be shortened together until 
+	one that takes an argument. Here -j and -o do, and after the "2" a 
+	whitespace is needed to start new options with single/double dash. 
+	The -m option does not, and the following "3" is the -3 compression
+	setting. The options could equally well have been written out as 
+	-V -j 2 -m -3 -f -o Track04.flac , or as -fo Track04.flac -3mVj2.  
+	flac also employs the convention that `-- ` (with whitespace!)  
+	signifies end of options, treating everything to follow as filename.
+	That is needed when an input filenames could otherwise be read as an
+	option, and "-7" is one such.
+	In total, this line takes the input file -7.wav as input; -o will 
+	give output filename as Track07.flac, and the -f will overwrite if 
+	the file Track04.flac is already present. The encoder will select 
+	encoding preset -3 modified with the -m switch, and use two CPU 
+	threads. Afterwards, the -V will make it decode the flac file and 
+	compare the audio to the input, to ensure they are indeed equal. 
 
 
-Some common **decoding** tasks using flac:
+## Decoding examples
 
 `flac --decode abc.flac` or `flac -d abc.flac`
 :	Decode abc.flac to abc.wav. abc.flac is not deleted. If abc.wav is
@@ -215,16 +227,23 @@ Some common **decoding** tasks using flac:
 	with an error if no such non-audio chunks are found.
 
 `flac -d -F abc.flac`
-:	Decode abc.flac to abc.wav and don't abort if errors are found
-	(useful for recovering as much as possible from corrupted files).
-
+:	Decode abc.flac to abc.wav and don't abort if errors are found.
+	This is potentially useful for recovering as much as possible from 
+	a corrupted file.
+	Note: Be careful about trying to "repair" files this way. Often it
+	will only conceal an error, and not play any subjectively "better"
+	than the corrupted file. It is a good idea to at least keep it,
+	and possibly try several decoders, including the one that generated 
+	the file, and hear if one has less detrimental audible errors than 
+	another. Make sure output volume is limited, as corrupted audio can
+	generate loud noises.
 
 
 # OPTIONS
 
-A summary of options is included below. For a complete description, see
-the HTML documentation. Several of the options can be negated, see the 
-**Negative options** section below.
+A summary of options is included below. Several of the options can be 
+negated, see the **Negative options** section below. 
+
 
 ## GENERAL OPTIONS
 
@@ -289,11 +308,12 @@ the HTML documentation. Several of the options can be negated, see the
 	warning.
 
 **\--skip**={\#\|*MM:SS*}
-:	Skip over the first number of samples of the input. To skip over
-	a given time, specify instead minutes and seconds. Fractions of a
+:	Skip the first number of samples of the input. To skip over a given
+	initial time, specify instead minutes and seconds: there must then 
+	be at least one digit on each side of the colon sign. Fractions of a 
 	second can be specified, with locale-dependent decimal point, e.g.
-	\--skip=2:34,567 if your decimal point is a comma. 
-	The option is applied to each input file. 
+	\--skip=123:9,867 if your decimal point is a comma. 
+	A \--skip option is applied to each input file if more are given. 
 	This option cannot be used with -t. When used with -a, the analysis
 	file will enumerate frames from starting point.
 	
@@ -376,10 +396,10 @@ Encoding will default to -5, -A "tukey(5e-1)" and one CPU thread.
 :	Currently synonymous with `-l 6 -b 4096 -r 4 --no-mid-side`
 
 **-4**, **\--compression-level-4**
-:	Synonymous with `-l 8 -b 4096 -M -r 4`
+:	Currently synonymous with `-l 8 -b 4096 -M -r 4`
 
 **-5**, **\--compression-level-5**
-:	Synonymous with `-l 8 -b 4096 -m -r 5`
+:	Currently synonymous with `-l 8 -b 4096 -m -r 5`
 
 **-6**, **\--compression-level-6**
 :	Currently synonymous with `-l 8 -b 4096 -m -r 6 -A "subdivide_tukey(2)"`
@@ -487,10 +507,10 @@ Encoding will default to -5, -A "tukey(5e-1)" and one CPU thread.
 :	Import a picture and store it in a PICTURE metadata block. More than
 	one \--picture option can be specified. Either a filename for the
 	picture file or a more complete specification form can be used. The
-	SPECIFICATION is a string whose parts are separated by \| (pipe)
+	*SPECIFICATION* is a string whose parts are separated by \| (pipe)
 	characters. Some parts may be left empty to invoke default values.
-	FILENAME is just shorthand for "\|\|\|\|FILENAME". For the format of
-	SPECIFICATION, see the section **Picture specification**.
+	Specifying only *FILENAME* is just shorthand for "\|\|\|\|FILENAME". 
+	See the section **Picture specification** for *SPECIFICATION* format.
 
 **-S** {\#\|X\|\#x\|\#s}, **\--seekpoint**={\#\|X\|\#x\|\#s}
 :	Specifies point(s) to include in SEEKTABLE, to override the encoder's
@@ -650,12 +670,9 @@ LOSSLESS. DECODED AUDIO WILL NOT BE IDENTICAL TO THE ORIGINAL WITH THIS
 OPTION.** This option is useful for example in transcoding media servers,
 where the client does not support ReplayGain.
 	
-The equals sign and \<specification\> is optional. If omitted, the
-default specification is 0aLn1.
-
 The \<specification\> is a shorthand notation for describing how to	apply
-ReplayGain. All components are optional but order is important. '\[\]'
-means 'optional'. '\|' means 'or'. '{}' means required. The format is: 
+ReplayGain. All elements are optional - defaulting to 0aLn1 - but order 
+is important.  The format is: 
 	
 \[\<preamp\>\]\[a\|t\]\[l\|L\]\[n{0\|1\|2\|3}\]
 
@@ -689,9 +706,9 @@ continue with a warning, and no ReplayGain is applied to that stream.
 
 ## Picture specification
 This described the specification used for the **\--picture** option.
-\[TYPE\]\|\[MIME-TYPE\]\|\[DESCRIPTION\]\|\[WIDTHxHEIGHTxDEPTH\[/COLORS\]\]\|FILE
+\[*TYPE*\]\|\[*MIME-TYPE*\]\|\[*DESCRIPTION*\]\|\[*WIDTHxHEIGHTxDEPTH*\[/*COLORS*\]\]\|*FILE*
 
-TYPE is optional; it is a number from one of:
+*TYPE* is optional; it is a number from one of:
 
 0. Other
 1. 32x32 pixels 'file icon' (PNG only)
@@ -718,25 +735,26 @@ TYPE is optional; it is a number from one of:
 The default is 3 (front cover). There may only be one picture each of
 type 1 and 2 in a file.
 
-MIME-TYPE is optional; if left blank, it will be detected from the file.
+*MIME-TYPE* is optional; if left blank, it will be detected from the file.
 For best compatibility with players, use pictures with MIME type
 image/jpeg or image/png. The MIME type can also be \--\> to mean that
 FILE is actually a URL to an image, though this use is discouraged.
 
-DESCRIPTION is optional; the default is an empty string.
+*DESCRIPTION* is optional; the default is an empty string.
 
 The next part specifies the resolution and color information. If the
-MIME-TYPE is image/jpeg, image/png, or image/gif, you can usually leave
+*MIME-TYPE* is image/jpeg, image/png, or image/gif, you can usually leave
 this empty and they can be detected from the file. Otherwise, you must
 specify the width in pixels, height in pixels, and color depth in
 bits-per-pixel. If the image has indexed colors you should also specify
 the number of colors used. When manually specified, it is not checked
 against the file for accuracy.
 
-FILE is the path to the picture file to be imported, or the URL if MIME
+*FILE* is the path to the picture file to be imported, or the URL if MIME
 type is \--\>
 
-Specification examples: "\|image/jpeg\|\|\|../cover.jpg" will embed the 
+**Specification examples:** 
+"\|image/jpeg\|\|\|../cover.jpg" will embed the 
 JPEG file at ../cover.jpg, defaulting to type 3 (front cover) and an 
 empty description. The resolution and color info will be retrieved 
 from the file itself. 
@@ -749,26 +767,26 @@ stored in the PICTURE metadata block.
 ## Apodization functions
 To improve LPC analysis, the audio data is windowed. An **-A** option 
 applies the specified apodization function(s) instead of the default 
-(which is tukey(5e-1), though different for presets -6 to -8.)
+(which is "tukey(5e-1)", though different for presets -6 to -8.)
 Specifying one more function effectively means, for each subframe, to 
 try another weighting of the data and see if it happens to result in a 
 smaller encoded subframe. Specifying several functions is time-expensive, 
 at typically diminishing compression gains. 
 
 The subdivide_tukey(*N*) functions (see below) used in presets -6 to -8 
-were developed to recycle calculations for speed, compared to using 
-a number of independent functions. Even then, a high number like *N*\>4 
-or 5, will often (though results vary with signal) become less 
-efficient than other options considered expensive, like the slower -p.
+were developed to recycle calculations for speed, compared to using a 
+number of independent functions. Even then, a high number like *N*\>4 
+or 5, will often become less efficient than other options considered 
+expensive, like the slower -p, though results vary with signal.
 
 Up to 32 functions can be given as comma-separated list and/or individual 
-**-A** options. Any mis-specified function is silently ignored. Depending 
-on shell, it may be necessary to escape parentheses. Currently the 
-following functions are implemented: bartlett, bartlett_hann, blackman, 
-blackman_harris_4term_92db, connes, flattop, gauss(*STDDEV*), hamming, 
-hann, kaiser_bessel, nuttall, rectangle, triangle, tukey(*P*), 
-partial_tukey(*N*\[/*OV*\[/*P*\]\]), punchout_tukey(*N*\[/*OV*\[/*P*\]\]), 
-subdivide_tukey(*N*\[/*P*\]), welch.
+**-A** options. Any mis-specified function is silently ignored. Quoting 
+a function which takes options (and has parentheses) may be necessary, 
+depending on shell. Currently the following functions are implemented: 
+bartlett, bartlett_hann, blackman, blackman_harris_4term_92db, connes, 
+flattop, gauss(*STDDEV*), hamming, hann, kaiser_bessel, nuttall, 
+rectangle, triangle, tukey(*P*), partial_tukey(*N*\[/*OV*\[/*P*\]\]), 
+punchout_tukey(*N*\[/*OV*\[/*P*\]\]), subdivide_tukey(*N*\[/*P*\]), welch.
 
 For parameters *P*, *STDDEV* and *OV*, scientific notation is supported, e.g. 
 tukey(5e-1). Otherwise, the decimal point must agree with the locale, 

--- a/man/flac.md
+++ b/man/flac.md
@@ -185,8 +185,8 @@ Some typical encoding and decoding tasks using flac:
 	whitespace is needed to start new options with single/double dash. 
 	The -m option does not, and the following "3" is the -3 compression
 	setting. The options could equally well have been written out as 
-	-V -j 2 -m -3 -f -o Track04.flac , or as -fo Track04.flac -3mVj2.  
-	flac also employs the convention that `-- ` (with whitespace!)  
+	-V -j 2 -m -3 -f -o Track04.flac , or as -fo Track04.flac -3mVj2. 
+	flac also employs the convention that `-- ` (with whitespace!) 
 	signifies end of options, treating everything to follow as filename.
 	That is needed when an input filenames could otherwise be read as an
 	option, and "-7" is one such.


### PR DESCRIPTION
I am not sure about the organization of the initial part of the document, to be honest. For example the way it promises examples before options, but before the examples sections it gives examples (on using stdin and redirects).

Anyway, here are the most significant changes made: 
- Some in the examples. Less confident about what should be there. 
- Options are reorganized to match the flac -h order 
- I used _underscores_ for italics, avoiding some formatting issue that arose from triple asterisks 
- Some " " inserted - you will all too easily need them when using -T - but I dared not use too many of them. 

... and some more text tweaks.