### PR TITLE
Only call tell callback when necessary

### DIFF
--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -3036,13 +3036,14 @@ FLAC__StreamEncoderWriteStatus write_frame_(FLAC__StreamEncoder *encoder, const 
 	 * Watch for the STREAMINFO block and first SEEKTABLE block to go by and store their offsets.
 	 */
 	if(samples == 0) {
+		FLAC__MetadataType type = (buffer[0] & 0x7f);
+
 		/* FLAC__STREAM_ENCODER_TELL_STATUS_UNSUPPORTED just means we didn't get the offset; no error */
 		if(encoder->private_->tell_callback && encoder->private_->tell_callback(encoder, &output_position, encoder->private_->client_data) == FLAC__STREAM_ENCODER_TELL_STATUS_ERROR) {
 			encoder->protected_->state = FLAC__STREAM_ENCODER_CLIENT_ERROR;
 			return FLAC__STREAM_ENCODER_WRITE_STATUS_FATAL_ERROR;
 		}
 
-		FLAC__MetadataType type = (buffer[0] & 0x7f);
 		if(type == FLAC__METADATA_TYPE_STREAMINFO)
 			encoder->protected_->streaminfo_offset = output_position;
 		else if(type == FLAC__METADATA_TYPE_SEEKTABLE && encoder->protected_->seektable_offset == 0)

--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -3032,16 +3032,16 @@ FLAC__StreamEncoderWriteStatus write_frame_(FLAC__StreamEncoder *encoder, const 
 	(void)is_last_block;
 #endif
 
-	/* FLAC__STREAM_ENCODER_TELL_STATUS_UNSUPPORTED just means we didn't get the offset; no error */
-	if(encoder->private_->tell_callback && encoder->private_->tell_callback(encoder, &output_position, encoder->private_->client_data) == FLAC__STREAM_ENCODER_TELL_STATUS_ERROR) {
-		encoder->protected_->state = FLAC__STREAM_ENCODER_CLIENT_ERROR;
-		return FLAC__STREAM_ENCODER_WRITE_STATUS_FATAL_ERROR;
-	}
-
 	/*
 	 * Watch for the STREAMINFO block and first SEEKTABLE block to go by and store their offsets.
 	 */
 	if(samples == 0) {
+		/* FLAC__STREAM_ENCODER_TELL_STATUS_UNSUPPORTED just means we didn't get the offset; no error */
+		if(encoder->private_->tell_callback && encoder->private_->tell_callback(encoder, &output_position, encoder->private_->client_data) == FLAC__STREAM_ENCODER_TELL_STATUS_ERROR) {
+			encoder->protected_->state = FLAC__STREAM_ENCODER_CLIENT_ERROR;
+			return FLAC__STREAM_ENCODER_WRITE_STATUS_FATAL_ERROR;
+		}
+
 		FLAC__MetadataType type = (buffer[0] & 0x7f);
 		if(type == FLAC__METADATA_TYPE_STREAMINFO)
 			encoder->protected_->streaminfo_offset = output_position;
@@ -3066,6 +3066,12 @@ FLAC__StreamEncoderWriteStatus write_frame_(FLAC__StreamEncoder *encoder, const 
 				break;
 			}
 			else if(test_sample >= frame_first_sample) {
+				/* FLAC__STREAM_ENCODER_TELL_STATUS_UNSUPPORTED just means we didn't get the offset; no error */
+				if(output_position == 0 && encoder->private_->tell_callback && encoder->private_->tell_callback(encoder, &output_position, encoder->private_->client_data) == FLAC__STREAM_ENCODER_TELL_STATUS_ERROR) {
+					encoder->protected_->state = FLAC__STREAM_ENCODER_CLIENT_ERROR;
+					return FLAC__STREAM_ENCODER_WRITE_STATUS_FATAL_ERROR;
+				}
+
 				encoder->private_->seek_table->points[i].sample_number = frame_first_sample;
 				encoder->private_->seek_table->points[i].stream_offset = output_position - encoder->protected_->audio_offset;
 				encoder->private_->seek_table->points[i].frame_samples = blocksize;


### PR DESCRIPTION
This slightly speeds up the encoder by reducing the number of syscalls, but can result in a 30% speedup in extreme cases, mostly when using extremely small blocksizes.