### PR TITLE
Upload CI-built FLAC binaries as artifacts

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -132,3 +132,9 @@ jobs:
           path: |
             ./**/*.log
             ./**/out*.meta
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: flac-${{ github.run_id }}-${{ github.sha }}
+          path: flac

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -91,6 +91,7 @@ jobs:
           ./autogen.sh
           ./configure ${{ matrix.configure-opts }}
           make
+          make DESTDIR=$(pwd)/flac install
           make check
 
       - name: Prepare CMake build directory
@@ -114,7 +115,9 @@ jobs:
           CC: ${{ matrix.cc }}
           CXX: ${{ matrix.cxx }}
         working-directory: cmake-build
-        run: cmake --build . --config Release
+        run: |
+          cmake --build . --config Release
+          cmake --install . --prefix ../flac --config Release
 
       - name: CMake test
         if: startsWith(matrix.build-system,'cmake')
@@ -128,7 +131,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: flac-${{ github.sha }}-${{ github.run_id }}-logs
+          name: flac-${{ matrix.name }}-${{ github.sha }}-${{ github.run_id }}-logs
           path: |
             ./**/*.log
             ./**/out*.meta
@@ -136,5 +139,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: flac-${{ github.run_id }}-${{ github.sha }}
+          name: flac-${{ matrix.name }}-${{ github.sha }}
           path: flac

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Package build
         uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
         with:
           name: flac-win64-static-${{ github.sha}}
           path: flac

--- a/.github/workflows/options.yml
+++ b/.github/workflows/options.yml
@@ -42,13 +42,20 @@ jobs:
           ./autogen.sh
           ./configure --disable-thorough-tests ${{ matrix.configure-opts }}
           make
+          make DESTDIR=$(pwd)/flac install
           make check
 
       - name: Upload logs on failure
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: flac-${{ github.sha }}-${{ github.run_id }}-logs
+          name: flac-${{ matrix.name }}-${{ github.sha }}-${{ github.run_id }}-logs
           path: |
             ./**/*.log
             ./**/out*.meta
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: flac-${{ matrix.name }}-${{ github.sha }}
+          path: flac


### PR DESCRIPTION
1. Upload CI-built FLAC binaries as artifacts.

This can be useful for testing, tracking failures, or for those who want to use nightly builds.

2. Fix fail log artifact name conflict, which may cause the following error:
```
Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```