### PR TITLE
Fix metaflac version output on Windows

### DIFF
--- a/src/metaflac/operations.c
+++ b/src/metaflac/operations.c
@@ -104,7 +104,7 @@ FLAC__bool do_operations(const CommandLineOptions *options)
 
 void show_version(void)
 {
-	printf("metaflac %s\n", FLAC__VERSION_STRING);
+	flac_printf("metaflac %s\n", FLAC__VERSION_STRING);
 }
 
 FLAC__bool do_major_operation(const CommandLineOptions *options)


### PR DESCRIPTION
Fixes #810

Replace one last call to printf() with flac_printf() that was missed on commit dda3e77ea227108a255293076f7c0c22e750a2ee

Thanks @ktmf01 for [indicating](https://github.com/xiph/flac/issues/810#issuecomment-2667821164) the fix