### PR TITLE
API documentation: replace modules.html by topics.html

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -296,7 +296,7 @@ if test "x$enable_doxygen_docs" != xfalse ; then
 fi
 AM_CONDITIONAL(FLaC__HAS_DOXYGEN, test -n "$DOXYGEN")
 
-if test ! -n "$DOXYGEN" && test -f "$srcdir/doc/FLAC.tag" && test -f "$srcdir/doc/api/modules.html" ; then
+if test ! -n "$DOXYGEN" && test -f "$srcdir/doc/FLAC.tag" && test -f "$srcdir/doc/api/topics.html" ; then
 	HAS_PREBUILT_DOXYGEN=yes
 fi
 AM_CONDITIONAL(FLaC__HAS_PREBUILT_DOXYGEN, test "x$HAS_PREBUILT_DOXYGEN" = xyes)

--- a/include/FLAC/all.h
+++ b/include/FLAC/all.h
@@ -102,7 +102,7 @@
  * \section getting_started Getting Started
  *
  * A good starting point for learning the API is to browse through
- * the <A HREF="modules.html">modules</A>.  Modules are logical
+ * the <A HREF="topics.html">modules</A>.  Modules are logical
  * groupings of related functions or classes, which correspond roughly
  * to header files or sections of header files.  Each module includes a
  * detailed description of the general usage of its functions or


### PR DESCRIPTION
This fixes the issue reported on
https://lists.xiph.org/pipermail/flac-dev/2025-February/006696.html

Newer Doxygen versions call what was previously api/modules.html api/topics.html instead.

Suggested-by: Christian Weisgerber <naddy@mips.inka.de>