### PR TITLE
cmake: Include "-pthread" in the pkg-config file if using pthreads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ if(MINGW AND (WITH_FORTIFY_SOURCE OR WITH_STACK_PROTECTOR))
     link_libraries("ssp.a")
     # static libraries don't carry over other static libraries in mingw
     # we need to export it in the pkg-config
-    set(FLAC_STATIC_LIBS "-lssp")
+    set(FLAC_STATIC_LIBS "${FLAC_STATIC_LIBS} -lssp")
   endif()
 elseif(NOT MSVC)
   set(HAVE_LIBSSP 1)
@@ -212,6 +212,7 @@ if(ENABLE_MULTITHREADING)
     find_package(Threads)
     if(CMAKE_USE_PTHREADS_INIT)
         set(HAVE_PTHREAD 1)
+        set(FLAC_STATIC_LIBS "${FLAC_STATIC_LIBS} -pthread")
     endif()
 endif()
 


### PR DESCRIPTION
This makes sure that users of the library pass the right linker flags if linking libflac statically, with a mingw toolchain that doesn't automatically link in pthreads.