### PR TITLE
decode: add early FLAC signature check to prevent input file overwrite

### DIFF
--- a/src/flac/decode.c
+++ b/src/flac/decode.c
@@ -141,6 +141,23 @@ static void print_stats(const DecoderSession *decoder_session);
  */
 int flac__decode_file(const char *infilename, const char *outfilename, FLAC__bool analysis_mode, analysis_options aopts, decode_options_t options)
 {
+	FILE *infile = flac_fopen(infilename, "rb");
+	if(!infile) {
+		flac__utils_printf(stderr, 1, "ERROR: cannot open input file '%s'\n", infilename);
+		return 1;
+	}
+
+	unsigned char sig[4];
+	size_t bytes_read = fread(sig, 1, 4, infile);
+	fclose(infile);
+
+	if(bytes_read != 4 || !(sig[0] == 0xFF && (sig[1] & 0xFC) == 0xF8)) {
+		flac__utils_printf(stderr, 1,
+						   "ERROR: '%s' is not a valid FLAC file.\n",
+						   infilename);
+		return 1;
+	}
+
 	DecoderSession decoder_session;
 
 	FLAC__ASSERT(


### PR DESCRIPTION
Fixes #763

When accidentally running `flac -d -f file.wav`, the input file could be overwritten because the output file was opened before format validation.

This change adds an early check for the FLAC signature (`0xFFF8`) before opening any output file. If the file is not a valid FLAC, decoding aborts immediately and no files are modified.

This makes `flac` safer for users who accidentally swap `-d` and `-e`.

## Changes
- Added early signature check in `flac__decode_file()`
- If file doesn't start with `FF F8`, decoding aborts with error
- Output file is never opened if input is not a valid FLAC

## Example
Before:
```bash
flac -d -f 1.wav
# 1.wav could be overwritten
```

After:
```bash
flac -d -f 1.wav
# ERROR: '1.wav' is not a valid FLAC file.
# 1.wav remains unchanged
```