### PR TITLE
Fix discards const from pointer target

### DIFF
--- a/src/flac/main.c
+++ b/src/flac/main.c
@@ -1132,7 +1132,7 @@ int parse_option(int short_option, const char *long_option, const char *option_a
 			case 'r':
 				{
 					uint32_t i;
-					char * p;
+					const char * p;
 					FLAC__ASSERT(0 != option_argument);
 					p = strchr(option_argument, ',');
 					if(0 == p) {

--- a/src/flac/utils.c
+++ b/src/flac/utils.c
@@ -475,7 +475,7 @@ FLAC__bool flac__utils_get_channel_mask_tag(const FLAC__StreamMetadata *object, 
 {
 	int offset;
 	uint32_t val;
-	char *p;
+	const char *p;
 	FLAC__ASSERT(object);
 	FLAC__ASSERT(object->type == FLAC__METADATA_TYPE_VORBIS_COMMENT);
 	if(0 > (offset = FLAC__metadata_object_vorbiscomment_find_entry_from(object, /*offset=*/0, CHANNEL_MASK_TAG)))

--- a/src/share/getopt/getopt.c
+++ b/src/share/getopt/getopt.c
@@ -778,7 +778,7 @@ share___getopt_internal (
 
   {
     char c = *nextchar++;
-    char *temp = my_index (optstring, c);
+    const char *temp = my_index (optstring, c);
 
     /* Increment `share__optind' when we start to process its last character.  */
     if (*nextchar == '\0')


### PR DESCRIPTION
- Fixes #880

Since glibc-2.43 and ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

char * pointer returns are only being used for comparisons so declare then as const, which matches the input variables.

```c
Fixes:
    ../../../src/share/getopt/getopt.c: In function 'share___getopt_internal':
    ../../../src/share/getopt/getopt.c:781:18: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
      781 |     char *temp = my_index (optstring, c);
          |                  ^~~~~~~~
    ../../../src/flac/utils.c: In function 'flac__utils_get_channel_mask_tag':
    ../../../src/flac/utils.c:485:20: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
      485 |         if(0 == (p = strchr((const char *)object->data.vorbis_comment.comments[offset].entry, '='))) /* should never happen, but just in case */
          |                    ^
    ../../../src/flac/main.c: In function 'parse_option':
    ../../../src/flac/main.c:1137:43: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
     1137 |                                         p = strchr(option_argument, ',');
          |                                           ^
``` 