### PR TITLE
Add support for zeroing least-significant bits in encoder settings

### DIFF
--- a/include/FLAC++/encoder.h
+++ b/include/FLAC++/encoder.h
@@ -148,6 +148,7 @@ namespace FLAC {
 			virtual bool set_metadata(::FLAC__StreamMetadata **metadata, uint32_t num_blocks);    ///< See FLAC__stream_encoder_set_metadata()
 			virtual bool set_metadata(FLAC::Metadata::Prototype **metadata, uint32_t num_blocks); ///< See FLAC__stream_encoder_set_metadata()
 			virtual bool set_limit_min_bitrate(bool value);                 ///< See FLAC__stream_encoder_set_limit_min_bitrate()
+			virtual bool set_zero_lsbs(uint32_t value);                     ///< See FLAC__stream_encoder_set_zero_lsbs()
 			virtual uint32_t set_num_threads(uint32_t value);                       ///< See FLAC__stream_encoder_set_num_threads()
 
 			/* get_state() is not virtual since we want subclasses to be able to return their own state */
@@ -172,6 +173,7 @@ namespace FLAC {
 			virtual uint32_t get_rice_parameter_search_dist() const;   ///< See FLAC__stream_encoder_get_rice_parameter_search_dist()
 			virtual FLAC__uint64 get_total_samples_estimate() const;   ///< See FLAC__stream_encoder_get_total_samples_estimate()
 			virtual bool     get_limit_min_bitrate() const;            ///< See FLAC__stream_encoder_get_limit_min_bitrate()
+			virtual uint32_t get_zero_lsbs() const;                    ///< See FLAC__stream_encoder_get_zero_lsbs()
 			virtual uint32_t get_num_threads() const;                  ///< See FLAC__stream_encoder_get_num_threads()
 
 			virtual ::FLAC__StreamEncoderInitStatus init();            ///< See FLAC__stream_encoder_init_stream()

--- a/include/FLAC/stream_encoder.h
+++ b/include/FLAC/stream_encoder.h
@@ -1288,6 +1288,20 @@ FLAC_API FLAC__bool FLAC__stream_encoder_set_metadata(FLAC__StreamEncoder *encod
  */
 FLAC_API FLAC__bool FLAC__stream_encoder_set_limit_min_bitrate(FLAC__StreamEncoder *encoder, FLAC__bool value);
 
+/** Set the number of least-significant bits to zero out in each sample
+ *  before encoding. This can improve compression at the cost of precision.
+ *  The value must be less than the bits-per-sample of the input.
+ *
+ * \default \c 0 (no bits zeroed)
+ * \param  encoder  An encoder instance to set.
+ * \param  value    Number of LSBs to zero, must be less than bits-per-sample.
+ * \assert
+ *    \code encoder != NULL \endcode
+ * \retval FLAC__bool
+ *    \c false if the encoder is already initialized, else \c true.
+ */
+FLAC_API FLAC__bool FLAC__stream_encoder_set_zero_lsbs(FLAC__StreamEncoder *encoder, uint32_t value);
+
 /** Get the current encoder state.
  *
  * \param  encoder  An encoder instance to query.
@@ -1534,6 +1548,16 @@ FLAC_API FLAC__uint64 FLAC__stream_encoder_get_total_samples_estimate(const FLAC
  *    See FLAC__stream_encoder_set_limit_min_bitrate().
  */
 FLAC_API FLAC__bool FLAC__stream_encoder_get_limit_min_bitrate(const FLAC__StreamEncoder *encoder);
+
+/** Get the number of least-significant bits being zeroed out.
+ *
+ * \param  encoder  An encoder instance to query.
+ * \assert
+ *    \code encoder != NULL \endcode
+ * \retval uint32_t
+ *    See FLAC__stream_encoder_set_zero_lsbs().
+ */
+FLAC_API uint32_t FLAC__stream_encoder_get_zero_lsbs(const FLAC__StreamEncoder *encoder);
 
 /** Initialize the encoder instance to encode native FLAC streams.
  *

--- a/src/flac/encode.c
+++ b/src/flac/encode.c
@@ -2090,6 +2090,9 @@ FLAC__bool EncoderSession_init_encoder(EncoderSession *e, encode_options_t optio
 			case CST_RICE_PARAMETER_SEARCH_DIST:
 				FLAC__stream_encoder_set_rice_parameter_search_dist(e->encoder, options.compression_settings[ic].value.t_unsigned);
 				break;
+			case CST_ZERO_LSBS:
+				FLAC__stream_encoder_set_zero_lsbs(e->encoder, options.compression_settings[ic].value.t_unsigned);
+				break;
 		}
 	}
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
@@ -2099,6 +2102,7 @@ FLAC__bool EncoderSession_init_encoder(EncoderSession *e, encode_options_t optio
 	FLAC__stream_encoder_set_total_samples_estimate(e->encoder, e->total_samples_to_encode);
 	FLAC__stream_encoder_set_metadata(e->encoder, (num_metadata > 0)? metadata : 0, num_metadata);
 	FLAC__stream_encoder_set_limit_min_bitrate(e->encoder, options.limit_min_bitrate);
+	FLAC__stream_encoder_set_zero_lsbs(e->encoder, options.zero_lsbs);
 
 	FLAC__stream_encoder_disable_constant_subframes(e->encoder, options.debug.disable_constant_subframes);
 	FLAC__stream_encoder_disable_fixed_subframes(e->encoder, options.debug.disable_fixed_subframes);

--- a/src/flac/encode.h
+++ b/src/flac/encode.h
@@ -44,7 +44,8 @@ typedef enum {
 	CST_DO_EXHAUSTIVE_MODEL_SEARCH,
 	CST_MIN_RESIDUAL_PARTITION_ORDER,
 	CST_MAX_RESIDUAL_PARTITION_ORDER,
-	CST_RICE_PARAMETER_SEARCH_DIST
+	CST_RICE_PARAMETER_SEARCH_DIST,
+	CST_ZERO_LSBS
 } compression_setting_type_t;
 
 typedef struct {
@@ -83,6 +84,7 @@ typedef struct {
 	FLAC__bool ignore_chunk_sizes;
 	FLAC__bool error_on_compression_fail;
 	FLAC__bool limit_min_bitrate;
+	uint32_t zero_lsbs;
 	FLAC__bool relaxed_foreign_metadata_handling;
 
 	FLAC__StreamMetadata *vorbis_comment;

--- a/src/flac/main.c
+++ b/src/flac/main.c
@@ -182,6 +182,7 @@ static struct share__option long_options_[] = {
 	{ "input-size"                , share__required_argument, 0, 0 },
 	{ "error-on-compression-fail" , share__no_argument, 0, 0 },
 	{ "limit-min-bitrate"         , share__no_argument, 0, 0 },
+	{ "zero-lsbs"                 , share__required_argument, 0, 0 },
 
 	/*
 	 * analysis options
@@ -287,6 +288,7 @@ static struct {
 	FLAC__bool channel_map_none; /* --channel-map=none specified, eventually will expand to take actual channel map */
 	FLAC__bool error_on_compression_fail;
 	FLAC__bool limit_min_bitrate;
+	uint32_t zero_lsbs;
 
 	uint32_t num_files;
 	char **filenames;
@@ -655,6 +657,7 @@ FLAC__bool init_options(void)
 	option_values.channel_map_none = false;
 	option_values.error_on_compression_fail = false;
 	option_values.limit_min_bitrate = false;
+	option_values.zero_lsbs = 0;
 
 	option_values.num_files = 0;
 	option_values.filenames = 0;
@@ -898,6 +901,17 @@ int parse_option(int short_option, const char *long_option, const char *option_a
 		}
 		else if(0 == strcmp(long_option, "limit-min-bitrate")) {
 			option_values.limit_min_bitrate = true;
+		}
+		else if(0 == strcmp(long_option, "zero-lsbs")) {
+			FLAC__ASSERT(0 != option_argument);
+			{
+				uint32_t i;
+				i = atoi(option_argument);
+				if(i > 31)
+					return usage_error("ERROR: invalid value for --zero-lsbs '%s', must be >= 0 and <= 31\n", option_argument);
+				option_values.zero_lsbs = i;
+				add_compression_setting_uint32_t(CST_ZERO_LSBS, i);
+			}
 		}
 		/*
 		 * negatives
@@ -1385,6 +1399,9 @@ void show_help(void)
 	printf("  -p, --qlp-coeff-precision-search   Exhaustively search LP coeff quantization\n");
 	printf("      --lax                          Allow encoder to generate non-Subset files\n");
 	printf("      --limit-min-bitrate            Limit minimum bitrate (for streaming)\n");
+	printf("      --zero-lsbs=#                  Zero out # least-significant bits per\n");
+	printf("                                     sample (improves compression, loses\n");
+	printf("                                     precision, must be < bits-per-sample)\n");
 	printf("  -j, --threads=#                    Set number of encoding threads\n");
 	printf("      --ignore-chunk-sizes           Ignore data chunk sizes in WAVE/AIFF files\n");
 	printf("      --replay-gain                  Calculate ReplayGain & store in FLAC tags\n");
@@ -1711,6 +1728,7 @@ int encode_file(const char *infilename, FLAC__bool is_first_file, FLAC__bool is_
 	encode_options.debug.do_md5 = option_values.debug.do_md5;
 	encode_options.error_on_compression_fail = option_values.error_on_compression_fail;
 	encode_options.limit_min_bitrate = option_values.limit_min_bitrate;
+	encode_options.zero_lsbs = option_values.zero_lsbs;
 	encode_options.relaxed_foreign_metadata_handling = option_values.keep_foreign_metadata_if_present;
 
 	/* if infilename and outfilename point to the same file, we need to write to a temporary file */

--- a/src/libFLAC++/stream_encoder.cpp
+++ b/src/libFLAC++/stream_encoder.cpp
@@ -217,6 +217,12 @@ namespace FLAC {
 			return static_cast<bool>(::FLAC__stream_encoder_set_limit_min_bitrate(encoder_, value));
 		}
 
+		bool Stream::set_zero_lsbs(uint32_t value)
+		{
+			FLAC__ASSERT(is_valid());
+			return static_cast<bool>(::FLAC__stream_encoder_set_zero_lsbs(encoder_, value));
+		}
+
 		uint32_t Stream::set_num_threads(uint32_t value)
 		{
 			FLAC__ASSERT(is_valid());
@@ -347,6 +353,12 @@ namespace FLAC {
 		{
 			FLAC__ASSERT(is_valid());
 			return static_cast<bool>(::FLAC__stream_encoder_get_limit_min_bitrate(encoder_));
+		}
+
+		uint32_t Stream::get_zero_lsbs() const
+		{
+			FLAC__ASSERT(is_valid());
+			return ::FLAC__stream_encoder_get_zero_lsbs(encoder_);
 		}
 
 		uint32_t Stream::get_num_threads() const

--- a/src/libFLAC/include/protected/stream_encoder.h
+++ b/src/libFLAC/include/protected/stream_encoder.h
@@ -113,6 +113,7 @@ typedef struct FLAC__StreamEncoderProtected {
 	uint32_t rice_parameter_search_dist;
 	FLAC__uint64 total_samples_estimate;
 	FLAC__bool limit_min_bitrate;
+	uint32_t zero_lsbs;
 	FLAC__StreamMetadata **metadata;
 	uint32_t num_metadata_blocks;
 	uint32_t num_threads;

--- a/src/libFLAC/stream_encoder.c
+++ b/src/libFLAC/stream_encoder.c
@@ -742,6 +742,9 @@ static FLAC__StreamEncoderInitStatus init_stream_internal_(
 	if(encoder->protected_->bits_per_sample < FLAC__MIN_BITS_PER_SAMPLE || encoder->protected_->bits_per_sample > FLAC__MAX_BITS_PER_SAMPLE)
 		return FLAC__STREAM_ENCODER_INIT_STATUS_INVALID_BITS_PER_SAMPLE;
 
+	if(encoder->protected_->zero_lsbs >= encoder->protected_->bits_per_sample)
+		return FLAC__STREAM_ENCODER_INIT_STATUS_INVALID_BITS_PER_SAMPLE;
+
 	if(!FLAC__format_sample_rate_is_valid(encoder->protected_->sample_rate))
 		return FLAC__STREAM_ENCODER_INIT_STATUS_INVALID_SAMPLE_RATE;
 
@@ -2242,6 +2245,17 @@ FLAC_API FLAC__bool FLAC__stream_encoder_set_limit_min_bitrate(FLAC__StreamEncod
 	return true;
 }
 
+FLAC_API FLAC__bool FLAC__stream_encoder_set_zero_lsbs(FLAC__StreamEncoder *encoder, uint32_t value)
+{
+	FLAC__ASSERT(0 != encoder);
+	FLAC__ASSERT(0 != encoder->private_);
+	FLAC__ASSERT(0 != encoder->protected_);
+	if(encoder->protected_->state != FLAC__STREAM_ENCODER_UNINITIALIZED)
+		return false;
+	encoder->protected_->zero_lsbs = value;
+	return true;
+}
+
 /*
  * These four functions are not static, but not publicly exposed in
  * include/FLAC/ either.  They are used by the test suite and in fuzzing
@@ -2510,6 +2524,14 @@ FLAC_API FLAC__bool FLAC__stream_encoder_get_limit_min_bitrate(const FLAC__Strea
 	return encoder->protected_->limit_min_bitrate;
 }
 
+FLAC_API uint32_t FLAC__stream_encoder_get_zero_lsbs(const FLAC__StreamEncoder *encoder)
+{
+	FLAC__ASSERT(0 != encoder);
+	FLAC__ASSERT(0 != encoder->private_);
+	FLAC__ASSERT(0 != encoder->protected_);
+	return encoder->protected_->zero_lsbs;
+}
+
 FLAC_API FLAC__bool FLAC__stream_encoder_process(FLAC__StreamEncoder *encoder, const FLAC__int32 * const buffer[], uint32_t samples)
 {
 	uint32_t i, j = 0, k = 0, channel;
@@ -2542,6 +2564,17 @@ FLAC_API FLAC__bool FLAC__stream_encoder_process(FLAC__StreamEncoder *encoder, c
 			}
 			memcpy(&encoder->private_->threadtask[0]->integer_signal[channel][encoder->private_->current_sample_number], &buffer[channel][j], sizeof(buffer[channel][0]) * n);
 		}
+
+		/* Zero out LSBs if requested */
+		if(encoder->protected_->zero_lsbs > 0) {
+			const FLAC__int32 mask = ~((FLAC__int32)((1u << encoder->protected_->zero_lsbs) - 1));
+			for(channel = 0; channel < channels; channel++) {
+				for(i = encoder->private_->current_sample_number; i < encoder->private_->current_sample_number + n; i++) {
+					encoder->private_->threadtask[0]->integer_signal[channel][i] &= mask;
+				}
+			}
+		}
+
 		j += n;
 		encoder->private_->current_sample_number += n;
 
@@ -2588,6 +2621,13 @@ FLAC_API FLAC__bool FLAC__stream_encoder_process_interleaved(FLAC__StreamEncoder
 					return false;
 				}
 				encoder->private_->threadtask[0]->integer_signal[channel][i] = buffer[k++];
+			}
+			/* Zero out LSBs if requested */
+			if(encoder->protected_->zero_lsbs > 0) {
+				const FLAC__int32 mask = ~((FLAC__int32)((1u << encoder->protected_->zero_lsbs) - 1));
+				for(channel = 0; channel < channels; channel++) {
+					encoder->private_->threadtask[0]->integer_signal[channel][i] &= mask;
+				}
 			}
 		}
 		encoder->private_->current_sample_number = i;
@@ -2645,6 +2685,7 @@ void set_defaults_(FLAC__StreamEncoder *encoder)
 	encoder->protected_->rice_parameter_search_dist = 0;
 	encoder->protected_->total_samples_estimate = 0;
 	encoder->protected_->limit_min_bitrate = false;
+	encoder->protected_->zero_lsbs = 0;
 	encoder->protected_->metadata = 0;
 	encoder->protected_->num_metadata_blocks = 0;
 	encoder->protected_->num_threads = 1;


### PR DESCRIPTION
Adds CLI/API option to zero N LSBs per sample before encoding.