### PR TITLE
Restrict metaflac fuzzer to offered file

### DIFF
--- a/oss-fuzz/common.h
+++ b/oss-fuzz/common.h
@@ -1,2 +1,5 @@
 extern int alloc_check_threshold, alloc_check_counter, alloc_check_keep_failing;
 int alloc_check_threshold = INT32_MAX, alloc_check_counter = 0, alloc_check_keep_failing = 0;
+
+extern char* allowed_filename;
+char* allowed_filename = NULL;

--- a/oss-fuzz/tool_metaflac.c
+++ b/oss-fuzz/tool_metaflac.c
@@ -57,6 +57,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	share__opterr = 0;
 	share__optind = 0;
 
+	allowed_filename = NULL;
+
 
 	if(size < 2)
 		return 0;
@@ -87,6 +89,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	close(file_to_fuzz);
 
 	argv[numarg++] = filename;
+
+	allowed_filename = filename;
 
 	/* Create file to feed to stdin */
 	if(use_stdin) {


### PR DESCRIPTION
The metaflac fuzzer could be directed to use files on the system, leading to unreproducible crashes

Credit: Oss-fuzz
Issue: N/A (local run)