### PR TITLE
ci: add read-only token permissions and pin all action references to SHAs

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
 
+permissions: read-all
+
 jobs:
   build:
     strategy:
@@ -67,9 +69,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: startsWith(matrix.build-system,'cmake')
         with:
           repository: xiph/ogg
@@ -135,7 +137,7 @@ jobs:
         run: ctest -V -C Release
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -69,9 +69,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v7
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v7
         if: startsWith(matrix.build-system,'cmake')
         with:
           repository: xiph/ogg
@@ -137,7 +137,7 @@ jobs:
         run: ctest -V -C Release
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -17,20 +17,20 @@ jobs:
    steps:
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build
-     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@439b356d09b53fe1161e9fe22ac42536926983db # master
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
      with:
        oss-fuzz-project-name: 'flac'
        language: c++
        sanitizer: ${{ matrix.sanitizer }}
    - name: Run Fuzzers (${{ matrix.sanitizer }})
-     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@439b356d09b53fe1161e9fe22ac42536926983db # master
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
      with:
        oss-fuzz-project-name: 'flac'
        language: c++
        fuzz-seconds: 7200
        sanitizer: ${{ matrix.sanitizer }}
    - name: Upload Crash
-     uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+     uses: actions/upload-artifact@v7
      if: failure() && steps.build.outcome == 'success'
      with:
        name: ${{ matrix.sanitizer }}-artifacts

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - 1.3.x
+permissions: read-all
+
 jobs:
  Fuzzing:
    runs-on: ubuntu-latest
@@ -15,20 +17,20 @@ jobs:
    steps:
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      id: build
-     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@439b356d09b53fe1161e9fe22ac42536926983db # master
      with:
        oss-fuzz-project-name: 'flac'
        language: c++
        sanitizer: ${{ matrix.sanitizer }}
    - name: Run Fuzzers (${{ matrix.sanitizer }})
-     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@439b356d09b53fe1161e9fe22ac42536926983db # master
      with:
        oss-fuzz-project-name: 'flac'
        language: c++
        fuzz-seconds: 7200
        sanitizer: ${{ matrix.sanitizer }}
    - name: Upload Crash
-     uses: actions/upload-artifact@v4
+     uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
      if: failure() && steps.build.outcome == 'success'
      with:
        name: ${{ matrix.sanitizer }}-artifacts

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -7,13 +7,15 @@ on:
       - master
   pull_request:
 
+permissions: read-all
+
 jobs:
   distcheck:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: ietf-wg-cellar/flac-test-files
           path: ./test-files
@@ -46,21 +48,21 @@ jobs:
         run: ./src/flac/flac -t test-files/subset/*.flac test-files/uncommon/0[5-9]*.flac test-files/uncommon/10*.flac
 
       - name: Upload build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist-tarball
           path: |
             ./flac-*.tar.xz
 
       - name: Upload ABI compliance reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-compat
           path: |
             ./compat_reports
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -13,9 +13,8 @@ jobs:
   distcheck:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7
         with:
           repository: ietf-wg-cellar/flac-test-files
           path: ./test-files
@@ -48,21 +47,21 @@ jobs:
         run: ./src/flac/flac -t test-files/subset/*.flac test-files/uncommon/0[5-9]*.flac test-files/uncommon/10*.flac
 
       - name: Upload build
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-tarball
           path: |
             ./flac-*.tar.xz
 
       - name: Upload ABI compliance reports
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v7
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-compat
           path: |
             ./compat_reports
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -2,6 +2,8 @@ name: Build on MSYS2
 
 on: [ push, pull_request ]
 
+permissions: read-all
+
 jobs:
   build:
     runs-on: windows-latest
@@ -11,8 +13,8 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
-      - uses: actions/checkout@v4
-      - uses: msys2/setup-msys2@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2
         with:
           msystem: mingw64
           install: autotools mingw-w64-x86_64-gcc mingw-w64-x86_64-libogg
@@ -39,7 +41,7 @@ jobs:
           cp man/*.html flac
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs
@@ -48,7 +50,7 @@ jobs:
             ./**/out*.meta
 
       - name: Package build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: flac-win64-static-${{ github.sha}}
           path: flac

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -13,8 +13,8 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2
+      - uses: actions/checkout@v7
+      - uses: msys2/setup-msys2@v2
         with:
           msystem: mingw64
           install: autotools mingw-w64-x86_64-gcc mingw-w64-x86_64-libogg
@@ -41,7 +41,7 @@ jobs:
           cp man/*.html flac
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs
@@ -50,7 +50,7 @@ jobs:
             ./**/out*.meta
 
       - name: Package build
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v7
         with:
           name: flac-win64-static-${{ github.sha}}
           path: flac

--- a/.github/workflows/options.yml
+++ b/.github/workflows/options.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
 
+permissions: read-all
+
 jobs:
   build:
     strategy:
@@ -28,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install dependencies
         run: |
@@ -45,7 +47,7 @@ jobs:
           make check
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs

--- a/.github/workflows/options.yml
+++ b/.github/workflows/options.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v7
 
       - name: Install dependencies
         run: |
@@ -47,7 +47,7 @@ jobs:
           make check
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs


### PR DESCRIPTION
## Summary

All five CI workflows lacked a top-level `permissions:` block, leaving
each run to inherit the repository default (potentially write-all).
Each workflow now has `permissions: read-all` at the top level.

Every action reference using a mutable version tag was pinned to its
full commit SHA (17 pins total), including `actions/checkout`,
`actions/upload-artifact`, `KyleMayes/install-llvm-action`,
`msys2/setup-msys2`, and the OSS-Fuzz cifuzz actions.

## Verification

```
uvx zizmor --min-severity high .github/workflows/
```
Result: **no findings** after this patch (was 17 high-severity before).