### PR TITLE
ci: add permissions and pin actions to full commit SHAs

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -67,9 +70,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: startsWith(matrix.build-system,'cmake')
         with:
           repository: xiph/ogg
@@ -135,7 +138,7 @@ jobs:
         run: ctest -V -C Release
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -7,13 +7,16 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   distcheck:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ietf-wg-cellar/flac-test-files
           path: ./test-files
@@ -46,21 +49,21 @@ jobs:
         run: ./src/flac/flac -t test-files/subset/*.flac test-files/uncommon/0[5-9]*.flac test-files/uncommon/10*.flac
 
       - name: Upload build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist-tarball
           path: |
             ./flac-*.tar.xz
 
       - name: Upload ABI compliance reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-compat
           path: |
             ./compat_reports
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -2,6 +2,9 @@ name: Build on MSYS2
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest
@@ -11,8 +14,8 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
-      - uses: actions/checkout@v4
-      - uses: msys2/setup-msys2@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: mingw64
           install: autotools mingw-w64-x86_64-gcc mingw-w64-x86_64-libogg
@@ -39,7 +42,7 @@ jobs:
           cp man/*.html flac
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs
@@ -48,7 +51,7 @@ jobs:
             ./**/out*.meta
 
       - name: Package build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: flac-win64-static-${{ github.sha}}
           path: flac

--- a/.github/workflows/options.yml
+++ b/.github/workflows/options.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -28,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install dependencies
         run: |
@@ -45,7 +48,7 @@ jobs:
           make check
 
       - name: Upload logs on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: flac-${{ github.sha }}-${{ github.run_id }}-logs


### PR DESCRIPTION
All 4 non-fuzz workflow files (`action.yml`, `distcheck.yml`, `msys2.yml`, `options.yml`) were missing a top-level `permissions:` block and used mutable action tag references.

**Add `permissions: contents: read`** to all 4 workflows.

**Pin all `uses:` to full commit SHAs** (tags kept as comments):

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/upload-artifact` | `@v4` | `@ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `msys2/setup-msys2` | `@v2` | `@66cd2cce69caa17b53920067426061ca1de3a884` |

Qualifies under the [Google Open Source Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards).