### PR TITLE
Fix units mismatch in picture metadata limit checks

### DIFF
--- a/src/libFLAC/stream_decoder.c
+++ b/src/libFLAC/stream_decoder.c
@@ -2230,7 +2230,7 @@ FLAC__bool read_metadata_picture_(FLAC__StreamDecoder *decoder, FLAC__StreamMeta
 	/* read MIME type */
 	if(!FLAC__bitreader_read_raw_uint32(decoder->private_->input, &x, FLAC__STREAM_METADATA_PICTURE_MIME_TYPE_LENGTH_LEN))
 		return false; /* read_callback_ sets the state for us */
-	if(FLAC__bitreader_limit_remaining(decoder->private_->input) < x){
+	if(FLAC__bitreader_limit_remaining(decoder->private_->input) < (FLAC__uint64)x * 8){
 		FLAC__bitreader_limit_invalidate(decoder->private_->input);
 		return false;
 	}
@@ -2247,7 +2247,7 @@ FLAC__bool read_metadata_picture_(FLAC__StreamDecoder *decoder, FLAC__StreamMeta
 	/* read description */
 	if(!FLAC__bitreader_read_raw_uint32(decoder->private_->input, &x, FLAC__STREAM_METADATA_PICTURE_DESCRIPTION_LENGTH_LEN))
 		return false; /* read_callback_ sets the state for us */
-	if(FLAC__bitreader_limit_remaining(decoder->private_->input) < x){
+	if(FLAC__bitreader_limit_remaining(decoder->private_->input) < (FLAC__uint64)x * 8){
 		FLAC__bitreader_limit_invalidate(decoder->private_->input);
 		return false;
 	}
@@ -2280,7 +2280,7 @@ FLAC__bool read_metadata_picture_(FLAC__StreamDecoder *decoder, FLAC__StreamMeta
 	/* read data */
 	if(!FLAC__bitreader_read_raw_uint32(decoder->private_->input, &(obj->data_length), FLAC__STREAM_METADATA_PICTURE_DATA_LENGTH_LEN))
 		return false; /* read_callback_ sets the state for us */
-	if(FLAC__bitreader_limit_remaining(decoder->private_->input) < obj->data_length){
+	if(FLAC__bitreader_limit_remaining(decoder->private_->input) < (FLAC__uint64)obj->data_length * 8){
 		FLAC__bitreader_limit_invalidate(decoder->private_->input);
 		return false;
 	}


### PR DESCRIPTION
FLAC__bitreader_limit_remaining() returns bits, but the picture
metadata parser was comparing it directly against byte lengths for
MIME type, description, and picture data fields. This meant fields
with lengths between (limit/8, limit] could bypass the check.

The actual read would still be caught by the downstream
FLAC__bitreader_read_byte_block_aligned_no_crc which correctly
converts bytes to bits before comparing, so this is not exploitable,
but it is a correctness bug.