### PR TITLE
Add missing overflow check to safe_calloc_

### DIFF
--- a/include/share/alloc.h
+++ b/include/share/alloc.h
@@ -121,6 +121,8 @@ static inline void *safe_calloc_(size_t nmemb, size_t size)
 #endif
 	if(!nmemb || !size)
 		return malloc(1); /* malloc(0) is undefined; FLAC src convention is to always allocate */
+	if(nmemb > SIZE_MAX / size)
+		return 0;
 	return calloc(nmemb, size);
 }
 


### PR DESCRIPTION
Unlike the other safe_* allocation wrappers in this file,
safe_calloc_ did not check whether nmemb * size would overflow
before calling calloc().  All existing call sites pass tightly
bounded arguments, so this is defense-in-depth against future
misuse.