### PR TITLE
Guard against uint32 overflow in byte-block skip/read limit checks

### DIFF
--- a/src/libFLAC/bitreader.c
+++ b/src/libFLAC/bitreader.c
@@ -621,7 +621,8 @@ FLAC__bool FLAC__bitreader_skip_byte_block_aligned_no_crc(FLAC__BitReader *br, u
 	FLAC__ASSERT(FLAC__bitreader_is_consumed_byte_aligned(br));
 
 	if(br->read_limit_set && br->read_limit < (uint32_t)-1){
-		if(br->read_limit < nvals*8){
+		if(nvals > UINT32_MAX / 8 ||
+		   br->read_limit < nvals*8){
 			br->read_limit = -1;
 			return false;
 		}
@@ -666,7 +667,8 @@ FLAC__bool FLAC__bitreader_read_byte_block_aligned_no_crc(FLAC__BitReader *br, F
 	FLAC__ASSERT(FLAC__bitreader_is_consumed_byte_aligned(br));
 
 	if(br->read_limit_set && br->read_limit < (uint32_t)-1){
-		if(br->read_limit < nvals*8){
+		if(nvals > UINT32_MAX / 8 ||
+		   br->read_limit < nvals*8){
 			br->read_limit = -1;
 			return false;
 		}


### PR DESCRIPTION
FLAC__bitreader_skip_byte_block_aligned_no_crc and
FLAC__bitreader_read_byte_block_aligned_no_crc both compute
nvals\*8 without overflow protection.  Values large enough to
overflow are unreachable through current callers (metadata block
length is at most 24 bits), but the overflow would silently disable
the limit enforcement.  Pre-check the multiplication against
UINT32_MAX/8 before computing nvals*8.