### PR TITLE
Potential fix for code scanning alert no. 8: Potential use after free

### DIFF
--- a/src/test_libFLAC/metadata_object.c
+++ b/src/test_libFLAC/metadata_object.c
@@ -474,13 +474,15 @@ static void cs_delete_(FLAC__StreamMetadata *block, uint32_t pos)
 
 static void pi_set_mime_type(FLAC__StreamMetadata *block, const char *s)
 {
+	char *new_mime_type = strdup(s);
+	FLAC__ASSERT(new_mime_type);
+
 	if(block->data.picture.mime_type) {
 		block->length -= strlen(block->data.picture.mime_type);
 		free(block->data.picture.mime_type);
 	}
-	block->data.picture.mime_type = strdup(s);
-	FLAC__ASSERT(block->data.picture.mime_type);
-	block->length += strlen(block->data.picture.mime_type);
+	block->data.picture.mime_type = new_mime_type;
+	block->length += strlen(new_mime_type);
 }
 
 static void pi_set_description(FLAC__StreamMetadata *block, const FLAC__byte *s)


### PR DESCRIPTION
Potential fix for Potential use after free

To fix safely without changing intended functionality, duplicate the new string before freeing the old one, then swap pointers. This removes alias-driven UAF risk (s == old mime_type) and avoids dereferencing possibly freed/invalid memory. Also, compute new length from the newly allocated copy and guard allocation similarly to existing style (assert).

In src/test_libFLAC/metadata_object.c, update pi_set_mime_type:

Add a local char *new_mime_type that stores strdup(s) first.
Assert new_mime_type.
Subtract old length and free old pointer only after successful duplicate.
Assign block->data.picture.mime_type = new_mime_type.
No new imports or dependencies are needed.
Add length using strlen(new_mime_type).
Suggested fixes powered by Copilot Autofix. Review carefully before merging.