### PR TITLE
Some fixes to WAV reader

### DIFF
--- a/src/flac/encode.c
+++ b/src/flac/encode.c
@@ -370,6 +370,11 @@ static FLAC__bool get_sample_info_wave(EncoderSession *e, encode_options_t optio
 				return false;
 			bps = (uint32_t)x;
 
+			if((bps == 0) || (bps > 32)) {
+				flac__utils_printf(stderr, 1, "%s: ERROR: invalid WAVE file bits-per-sample=%u\n", e->inbasefilename, bps);
+				return false;
+			}
+
 			e->info.is_unsigned_samples = (bps <= 8);
 
 			if(wFormatTag == 1) {
@@ -409,9 +414,20 @@ static FLAC__bool get_sample_info_wave(EncoderSession *e, encode_options_t optio
 					flac__utils_printf(stderr, 1, "%s: ERROR: invalid WAVEFORMATEXTENSIBLE chunk with cbSize %u\n", e->inbasefilename, (uint32_t)x);
 					return false;
 				}
+				/* bps is supposed to be in whole number of bytes, while valid-bps provides the real value */
+				if((bps % 8) != 0) {
+					flac__utils_printf(stderr, 1, "%s: WARNING: WAVE file bits-per-sample=%u, expected %u\n", e->inbasefilename, bps, ((bps + 7) / 8) * 8);
+					if(e->treat_warnings_as_errors) {
+						return false;
+					}
+				}
 				/* valid bps */
 				if(!read_uint16(e->fin, /*big_endian=*/false, &x, e->inbasefilename))
 					return false;
+				if(x == 0) {
+					flac__utils_printf(stderr, 1, "%s: ERROR: invalid WAVEFORMATEXTENSIBLE chunk with wValidBitsPerSample (%u)\n", e->inbasefilename, (uint32_t)x, bps);
+					return false;
+				}
 				if((uint32_t)x > bps) {
 					flac__utils_printf(stderr, 1, "%s: ERROR: invalid WAVEFORMATEXTENSIBLE chunk with wValidBitsPerSample (%u) > wBitsPerSample (%u)\n", e->inbasefilename, (uint32_t)x, bps);
 					return false;
@@ -426,17 +442,49 @@ static FLAC__bool get_sample_info_wave(EncoderSession *e, encode_options_t optio
 					if(e->treat_warnings_as_errors)
 						return false;
 				}
-				/* first part of GUID */
-				if(!read_uint16(e->fin, /*big_endian=*/false, &x, e->inbasefilename))
-					return false;
-				if(x != 1) {
-					flac__utils_printf(stderr, 1, "%s: ERROR: unsupported WAVEFORMATEXTENSIBLE chunk with non-PCM format %u\n", e->inbasefilename, (uint32_t)x);
-					return false;
+
+				{
+					/* read entire GUID */
+					uint32_t guid_part1 = 0;
+					uint16_t guid_part2 = 0;
+					uint16_t guid_part3 = 0;
+					uint8_t guid_part4[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+					if(!read_uint32(e->fin, /*big_endian=*/false, &guid_part1, e->inbasefilename)) {
+						return false;
+					}
+					if(!read_uint16(e->fin, /*big_endian=*/false, &guid_part2, e->inbasefilename)) {
+						return false;
+					}
+					if(!read_uint16(e->fin, /*big_endian=*/false, &guid_part3, e->inbasefilename)) {
+						return false;
+					}
+					if(!read_bytes(e->fin, &guid_part4[0], sizeof(guid_part4), /*eof_ok=*/false, e->inbasefilename)) {
+						return false;
+					}
+					//  { 0x1, 0x0, 0x10, {0x80,0x00,0x00,0xaa,0x00,0x38,0x9b,0x71} }
+					if((guid_part1 != 0x1) || (guid_part2 != 0x0) || (guid_part3 != 0x10) ||
+					   (memcmp(&guid_part4[0], "\x80\x00\x00\xaa\x00\x38\x9b\x71", 8) != 0)) {
+						flac__utils_printf(stderr, 1, "%s: ERROR: unsupported WAVEFORMATEXTENSIBLE chunk with GUID {%.8x-%.4x-%.4x-%.2x%.2x-%.2x%.2x%.2x%.2x%.2x%.2x}\n",
+										   e->inbasefilename,
+										   guid_part1,
+										   guid_part2,
+										   guid_part3,
+										   guid_part4[0],
+										   guid_part4[1],
+										   guid_part4[2],
+										   guid_part4[3],
+										   guid_part4[4],
+										   guid_part4[5],
+										   guid_part4[6],
+										   guid_part4[7]);
+						return false;
+					}
 				}
-				data_bytes -= 26;
+
+				data_bytes -= 40;
 			}
 
-			e->info.bytes_per_wide_sample = channels * (bps / 8);
+			e->info.bytes_per_wide_sample = channels * ((bps + 7) / 8);
 
 			/* skip any extra data in the fmt chunk */
 			if(!fskip_ahead(e->fin, data_bytes)) {
@@ -953,16 +1001,28 @@ int flac__encode_file(FILE *infile, FLAC__off_t infilesize, const char *infilena
 
 		switch(options.format) {
 			case FORMAT_RAW:
-				if(infilesize < 0)
+				if(infilesize < 0) {
 					total_samples_in_input = 0;
-				else
+				}
+				else {
+					if(encoder_session.info.bytes_per_wide_sample == 0) {
+						flac__utils_printf(stderr, 1, "%s: ERROR: unsupported bytes-per-wide-sample %u\n", encoder_session.inbasefilename, encoder_session.info.bytes_per_wide_sample);
+						return EncoderSession_finish_error(&encoder_session);
+					}
 					total_samples_in_input = (FLAC__uint64)infilesize / encoder_session.info.bytes_per_wide_sample;
+				}
 				break;
+
 			case FORMAT_WAVE:
 			case FORMAT_WAVE64:
 			case FORMAT_RF64:
 			case FORMAT_AIFF:
 			case FORMAT_AIFF_C:
+				if(encoder_session.info.bytes_per_wide_sample == 0) {
+					flac__utils_printf(stderr, 1, "%s: ERROR: unsupported bytes-per-wide-sample %u\n", encoder_session.inbasefilename, encoder_session.info.bytes_per_wide_sample);
+					return EncoderSession_finish_error(&encoder_session);
+				}
+
 				/* truncation in the division removes any padding byte that was counted in encoder_session.fmt.iff.data_bytes */
 				total_samples_in_input = encoder_session.fmt.iff.data_bytes / encoder_session.info.bytes_per_wide_sample;
 
@@ -985,10 +1045,12 @@ int flac__encode_file(FILE *infile, FLAC__off_t infilesize, const char *infilena
 					}
 				}
 				break;
+
 			case FORMAT_FLAC:
 			case FORMAT_OGGFLAC:
 				total_samples_in_input = encoder_session.fmt.flac.client_data.metadata_blocks[0]->data.stream_info.total_samples;
 				break;
+
 			default:
 				FLAC__ASSERT(0);
 				/* double protection */

--- a/src/test_streams/main.c
+++ b/src/test_streams/main.c
@@ -826,11 +826,16 @@ foo:
 	return false;
 }
 
-/* flavor is: 0:WAVE, 1:RF64, 2:WAVE64 */
-static FLAC__bool generate_wav(const char *filename, unsigned sample_rate, unsigned channels, unsigned bps, unsigned samples, FLAC__bool strict, int flavor)
-{
-	const FLAC__bool waveformatextensible = strict && (channels > 2 || (bps != 8 && bps != 16));
+enum WaveFormatExtensibleType {
+	WAVEFORMATEXTENSIBLE_AUTO, /* enabled only if (channels > 2 || (bps != 8 && bps != 16)) */
+	WAVEFORMATEXTENSIBLE_DISABLE,
+	WAVEFORMATEXTENSIBLE_FORCE,
+};
 
+/* flavor is: 0:WAVE, 1:RF64, 2:WAVE64 */
+static FLAC__bool generate_wav(const char *filename, unsigned sample_rate, unsigned channels, unsigned bps, FLAC__bool fmt_use_exact_bps, unsigned samples, enum WaveFormatExtensibleType waveformatextensible_type, int flavor)
+{
+	FLAC__bool waveformatextensible = false;
 	const unsigned bytes_per_sample = (bps+7)/8;
 	const unsigned shift = (bps%8)? 8 - (bps%8) : 0;
 	/* this rig is not going over 4G so we're ok with 32-bit sizes here */
@@ -843,6 +848,18 @@ static FLAC__bool generate_wav(const char *filename, unsigned sample_rate, unsig
 	double theta1, theta2;
 	FILE *f;
 	unsigned i, j;
+
+	switch(waveformatextensible_type) {
+		case WAVEFORMATEXTENSIBLE_AUTO:
+			waveformatextensible = (channels > 2 || (bps != 8 && bps != 16));
+			break;
+		case WAVEFORMATEXTENSIBLE_DISABLE:
+			waveformatextensible = false;
+			break;
+		case WAVEFORMATEXTENSIBLE_FORCE:
+			waveformatextensible = true;
+			break;
+	}
 
 	if(0 == (f = fopen(filename, "wb")))
 		return false;
@@ -924,7 +941,7 @@ static FLAC__bool generate_wav(const char *filename, unsigned sample_rate, unsig
 		goto foo;
 	if(!write_little_endian_uint16(f, (FLAC__uint16)(channels * bytes_per_sample))) /* block align */
 		goto foo;
-	if(!write_little_endian_uint16(f, (FLAC__uint16)(bps+shift)))
+	if(!write_little_endian_uint16(f, (FLAC__uint16)(bps + (fmt_use_exact_bps ? 0 : shift))))
 		goto foo;
 	if(waveformatextensible) {
 		if(!write_little_endian_uint16(f, (FLAC__uint16)22)) /* cbSize */
@@ -1518,15 +1535,15 @@ int main(int argc, char *argv[])
 					return 1;
 
 				flac_snprintf(fn, sizeof (fn), "rt-%u-%u-%u.wav", channels, bits_per_sample, nsamples[samples]);
-				if(!generate_wav(fn, 44100, channels, bits_per_sample, nsamples[samples], /*strict=*/true, /*flavor=*/0))
+				if(!generate_wav(fn, 44100, channels, bits_per_sample, /*fmt_use_exact_bps=*/false, nsamples[samples], WAVEFORMATEXTENSIBLE_AUTO, /*flavor=*/0))
 					return 1;
 
 				flac_snprintf(fn, sizeof (fn), "rt-%u-%u-%u.rf64", channels, bits_per_sample, nsamples[samples]);
-				if(!generate_wav(fn, 44100, channels, bits_per_sample, nsamples[samples], /*strict=*/true, /*flavor=*/1))
+				if(!generate_wav(fn, 44100, channels, bits_per_sample, /*fmt_use_exact_bps=*/false, nsamples[samples], WAVEFORMATEXTENSIBLE_AUTO, /*flavor=*/1))
 					return 1;
 
 				flac_snprintf(fn, sizeof (fn), "rt-%u-%u-%u.w64", channels, bits_per_sample, nsamples[samples]);
-				if(!generate_wav(fn, 44100, channels, bits_per_sample, nsamples[samples], /*strict=*/true, /*flavor=*/2))
+				if(!generate_wav(fn, 44100, channels, bits_per_sample, /*fmt_use_exact_bps=*/false, nsamples[samples], WAVEFORMATEXTENSIBLE_AUTO, /*flavor=*/2))
 					return 1;
 
 				if(bits_per_sample % 8 == 0) {
@@ -1537,6 +1554,54 @@ int main(int argc, char *argv[])
 					if(!generate_unsigned_raw(fn, channels, bits_per_sample/8, nsamples[samples]))
 						return 1;
 				}
+			}
+		}
+	}
+
+	/* Test with non-standard bits per sample */
+	for(channels = 1; channels <= 8; channels *= 2) {
+		unsigned bits_per_sample;
+		for(bits_per_sample = 1; bits_per_sample <= 32; bits_per_sample += 1) {
+			const unsigned nsamples = 5;
+			static const enum WaveFormatExtensibleType wave_format_extensible_types[2] = { WAVEFORMATEXTENSIBLE_DISABLE,
+																						   WAVEFORMATEXTENSIBLE_FORCE };
+			const unsigned bits_per_sample_rounded_up = ((bits_per_sample + 7) / 8) * 8;
+			unsigned type;
+			char fn[64];
+			for(type = 0; type < sizeof(wave_format_extensible_types) / sizeof(wave_format_extensible_types[0]); type++) {
+				const char *suffix = "";
+
+				if((bits_per_sample < 4) || ((bits_per_sample % 8) != 0)) {
+					/* bps is supposed to be in whole number of bytes, while valid-bps provides the real value */
+					suffix = "fail";
+				}
+
+				flac_snprintf(fn, sizeof(fn), "bps%s-%u-%u-%u-%u.wav", suffix, channels, bits_per_sample, bits_per_sample, wave_format_extensible_types[type]);
+				if(!generate_wav(fn, 44100, channels, bits_per_sample, /*fmt_use_exact_bps=*/true, nsamples, wave_format_extensible_types[type], /*flavor=*/0))
+					return 1;
+
+				flac_snprintf(fn, sizeof(fn), "bps%s-%u-%u-%u-%u.rf64", suffix, channels, bits_per_sample, bits_per_sample, wave_format_extensible_types[type]);
+				if(!generate_wav(fn, 44100, channels, bits_per_sample, /*fmt_use_exact_bps=*/true, nsamples, wave_format_extensible_types[type], /*flavor=*/1))
+					return 1;
+
+				flac_snprintf(fn, sizeof(fn), "bps%s-%u-%u-%u-%u.w64", suffix, channels, bits_per_sample, bits_per_sample, wave_format_extensible_types[type]);
+				if(!generate_wav(fn, 44100, channels, bits_per_sample, /*fmt_use_exact_bps=*/true, nsamples, wave_format_extensible_types[type], /*flavor=*/2))
+					return 1;
+			}
+
+			if((bits_per_sample >= 4) && ((bits_per_sample % 8) != 0)) {
+				/* generate valid files also for all bits per sample */
+				flac_snprintf(fn, sizeof(fn), "bps-%u-%u-%u-%u.wav", channels, bits_per_sample_rounded_up, bits_per_sample, WAVEFORMATEXTENSIBLE_FORCE);
+				if(!generate_wav(fn, 44100, channels, bits_per_sample, /*fmt_use_exact_bps=*/false, nsamples, WAVEFORMATEXTENSIBLE_FORCE, /*flavor=*/0))
+					return 1;
+
+				flac_snprintf(fn, sizeof(fn), "bps-%u-%u-%u-%u.rf64", channels, bits_per_sample_rounded_up, bits_per_sample, WAVEFORMATEXTENSIBLE_FORCE);
+				if(!generate_wav(fn, 44100, channels, bits_per_sample, /*fmt_use_exact_bps=*/false, nsamples, WAVEFORMATEXTENSIBLE_FORCE, /*flavor=*/1))
+					return 1;
+
+				flac_snprintf(fn, sizeof(fn), "bps-%u%u-%u-%u.w64", channels, bits_per_sample_rounded_up, bits_per_sample, WAVEFORMATEXTENSIBLE_FORCE);
+				if(!generate_wav(fn, 44100, channels, bits_per_sample, /*fmt_use_exact_bps=*/false, nsamples, WAVEFORMATEXTENSIBLE_FORCE, /*flavor=*/2))
+					return 1;
 			}
 		}
 	}

--- a/test/test_flac.sh
+++ b/test/test_flac.sh
@@ -342,6 +342,52 @@ rt_test_ogg_flac ()
 	rm -f rt.wav rt.oga rt2.oga
 }
 
+bps_test ()
+{
+	f="$1"
+	ext="$2"
+	extra="$3"
+	echo $ECHO_N "bps test ($f) encode... " $ECHO_C
+	run_flac --force --verify --channel-map=none --no-padding --lax -o bps.flac $extra $f || die "ERROR"
+	echo $ECHO_N "decode... " $ECHO_C
+	run_flac --force --decode --channel-map=none -o "bps$ext" $extra bps.flac || die "ERROR"
+	# Note: Comparison of decoded files doesn't work since they will likely differ due to WAVE_FORMAT_EXTENSIBLE,
+	# only with foreign metadata can they be decoded back identically.
+	# Instead we encode again to .flac and compare the encoded files.
+	echo $ECHO_N "encode again... " $ECHO_C
+	run_flac --force --verify --channel-map=none --no-padding --lax -o bps2.flac $extra "bps$ext"|| die "ERROR"
+	echo $ECHO_N "compare... " $ECHO_C
+	cmp bps.flac bps2.flac || die "ERROR: file mismatch"
+	echo "OK"
+	rm -f bps.flac bps2.flac "bps$ext"
+}
+
+bps_keep_foreign_metadata_test ()
+{
+	f="$1"
+	ext="$2"
+	extra="$3"
+	echo $ECHO_N "bps keep foreign metadata test ($f) encode... " $ECHO_C
+	run_flac --keep-foreign-metadata --force --verify --channel-map=none --no-padding --lax -o bps.flac $extra $f || die "ERROR"
+	echo $ECHO_N "decode... " $ECHO_C
+	run_flac --keep-foreign-metadata --force --decode --channel-map=none -o "bps$ext" $extra bps.flac || die "ERROR"
+	echo $ECHO_N "compare... " $ECHO_C
+	cmp $f "bps$ext" || die "ERROR: file mismatch"
+	echo "OK"
+	rm -f bps.flac "bps$ext"
+}
+
+bps_expected_fail_test ()
+{
+	f="$1"
+	ext="$2"
+	extra="$3"
+	echo $ECHO_N "bps expected fail test ($f) encode... " $ECHO_C
+	run_flac --force --verify --channel-map=none --no-padding --lax -o bps.flac $extra $f && die "ERROR: expected to fail but didn't"
+	echo "OK"
+	rm -f bps.flac "bps$ext"
+}
+
 for f in rt-*.raw ; do
 	rt_test_raw $f
 done
@@ -371,6 +417,33 @@ if [ $has_ogg = yes ] ; then
 		rt_test_ogg_flac $f
 	done
 fi
+
+# Test with non-standard bits per sample
+for f in bps-*.wav ; do
+	bps_test $f ".wav"
+	bps_keep_foreign_metadata_test $f ".wav"
+done
+for f in bps-*.w64 ; do
+	bps_test $f ".w64"
+	# WAVE64 differs from WAV how it handles WAVE_FORMAT_EXTENSIBLE
+	#bps_keep_foreign_metadata_test $f ".w64"
+done
+for f in bps-*.rf64 ; do
+	bps_test $f ".rf64"
+	# RF64 differs from WAV how it handles WAVE_FORMAT_EXTENSIBLE
+	#bps_keep_foreign_metadata_test $f ".rf64"
+done
+
+# Test with unsupported bits per sample
+for f in bpsfail-*.wav ; do
+	bps_expected_fail_test $f ".wav"
+done
+for f in bpsfail-*.w64 ; do
+	bps_expected_fail_test $f ".w64"
+done
+for f in bpsfail-*.rf64 ; do
+	bps_expected_fail_test $f ".rf64"
+done
 
 ############################################################################
 # test --skip and --until


### PR DESCRIPTION
* Checks that bps is a multiple of 8, and >0 and <= 32.
* Checks that valid-bps is not 0
* Validates entire WAV GUID, not just the first part
* bytes_per_wide_sample is calculated with a rounded up bps value
* explicit check if bytes_per_wide_sample is 0

Fixes #873
Fixes #917